### PR TITLE
feat: add negotiation support for go-extensions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-golang 1.16.5
+golang 1.17
 terraform 0.13.5
 ###Block(toolver)
 nodejs 14.15.1

--- a/bootstrap.lock
+++ b/bootstrap.lock
@@ -3,4 +3,4 @@
 version: v7.16.1
 generated: 2021-08-03T22:43:38Z
 versions:
-  devbase: v1.15.0
+  devbase: v1.21.2

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.2.15 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/blang/semver/v4 v4.0.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/getoutreach/gobox v1.11.0
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-github/v34 v34.0.0
+	github.com/hashicorp/go-hclog v0.14.1
 	github.com/hashicorp/go-plugin v1.4.3
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.6
+	github.com/google/go-github/v34 v34.0.0
+	github.com/hashicorp/go-plugin v1.4.3
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12
 	github.com/klauspost/compress v1.11.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,7 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqL
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpmbhCOZJ293Lz68O7PYrF2EzeiFMwCLk=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
@@ -312,9 +313,13 @@ github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoP
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.14.1 h1:nQcJDQwIAGnmoUWp8ubocEX40cCml/17YkF6csQLReU=
+github.com/hashicorp/go-hclog v0.14.1/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-plugin v1.4.3 h1:DXmvivbWD5qdiBts9TpBC7BYL1Aia5sxbRgQB+v6UZM=
+github.com/hashicorp/go-plugin v1.4.3/go.mod h1:5fGEH17QVwTTcR0zV7yhDPLLmFX9YSZ38b18Udy6vYQ=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
@@ -329,6 +334,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
+github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174 h1:WlZsjVhE8Af9IcZDGgJGQpNflI3+MJSBhsgT5PCtzBQ=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/honeycombio/beeline-go v1.0.0 h1:SYozvIelFC/U6WWhKtemvByqSs1ViG7yn1IP6r+w2No=
@@ -382,6 +389,8 @@ github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
+github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jmoiron/sqlx v1.3.1/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
@@ -462,6 +471,7 @@ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
+github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
@@ -485,6 +495,8 @@ github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFW
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
@@ -507,6 +519,7 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
+github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -753,6 +766,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.0 h1:UG21uOlmZabA4fW5i7ZX6bjw1xELEGg/ZLgZq9auk/Q=
 golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -837,6 +851,7 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -974,6 +989,7 @@ google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
@@ -1003,7 +1019,9 @@ google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEY
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200825200019-8632dd797987 h1:PDIOdWxZ8eRizhKa1AAvY53xsvLB1cWorMjslvY3VA8=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.0/go.mod h1:chYK+tFQF0nDUGJgXMSgLCQk3phJEuONr2DCgLDdAQM=
@@ -1021,6 +1039,7 @@ google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKa
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.36.1 h1:cmUfbeGKnz9+2DD/UYsMQXeqbHZqZDs4eQwW0sFOpBY=
 google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -34,6 +34,7 @@ import (
 	"github.com/getoutreach/gobox/pkg/cfg"
 	"github.com/getoutreach/stencil/internal/vfs"
 	"github.com/getoutreach/stencil/pkg/configuration"
+	"github.com/getoutreach/stencil/pkg/extensions"
 	"github.com/getoutreach/stencil/pkg/functions"
 	"github.com/getoutreach/stencil/pkg/processors"
 	"github.com/pkg/errors"
@@ -66,6 +67,7 @@ type Builder struct {
 	GitRepoFs billy.Filesystem
 
 	Processors *processors.Table
+	extensions *extensions.Host
 
 	log logrus.FieldLogger
 
@@ -82,6 +84,7 @@ func NewBuilder(repo, dir string, s *configuration.ServiceManifest, sshKeyPath s
 		Dir:        dir,
 		Manifest:   s,
 		Processors: processors.New(),
+		extensions: extensions.NewHost(),
 
 		sshKeyPath:  sshKeyPath,
 		accessToken: accessToken,
@@ -102,8 +105,8 @@ func (b *Builder) Run(ctx context.Context, log logrus.FieldLogger) ([]string, er
 	}
 
 	b.log.Info("Fetching dependencies")
-	fetcher := NewFetcher(b.log, b.Manifest, b.sshKeyPath, b.accessToken)
-	fs, manifests, err := fetcher.CreateVFS()
+	fetcher := NewFetcher(b.log, b.Manifest, b.sshKeyPath, b.accessToken, b.extensions)
+	fs, manifests, err := fetcher.CreateVFS(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create vfs")
 	}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -46,6 +46,20 @@ type ServiceManifest struct {
 	Arguments map[string]interface{} `yaml:"arguments"`
 }
 
+// TemplateRepositoryType specifies what type of a template
+// repository a repository is.
+type TemplateRepositoryType string
+
+const (
+	// TemplateRepositoryTypeExt denotes a repository as being
+	// an extension repository.
+	TemplateRepositoryTypeExt TemplateRepositoryType = "extension"
+
+	// TemplateRepositoryTypeStd denotes a repository as being a
+	// standard template repository. This is the default
+	TemplateRepositoryTypeStd TemplateRepositoryType = "standard"
+)
+
 // TemplateRepository is a repository of template files.
 type TemplateRepository struct {
 	// URL is the fully qualified URL that is able to access the templates
@@ -65,6 +79,9 @@ type TemplateRepositoryManifest struct {
 
 	// Modules are template repositories that this manifest requires
 	Modules []*TemplateRepository `yaml:"modules"`
+
+	// Type is the type of repository this is
+	Type TemplateRepositoryType `yaml:"type"`
 
 	// PostRunCommand is a command to be ran after rendering and post-processors
 	// have been ran on the project

--- a/pkg/extensions/apiv1/client.go
+++ b/pkg/extensions/apiv1/client.go
@@ -1,0 +1,38 @@
+package apiv1
+
+import (
+	"os"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-plugin"
+)
+
+// NewHandshake returns a plugin.HandshakeConfig for
+// this extension api version.
+func NewHandshake() plugin.HandshakeConfig {
+	return plugin.HandshakeConfig{
+		ProtocolVersion:  Version,
+		MagicCookieKey:   CookieKey,
+		MagicCookieValue: CookieValue,
+	}
+}
+
+// NewExtensionImplementation implements a new extension
+// and starts serving it.
+func NewExtensionImplementation(impl Implementation) error {
+	logger := hclog.New(&hclog.LoggerOptions{
+		Level:      hclog.Trace,
+		Output:     os.Stderr,
+		JSONFormat: true,
+	})
+
+	plugin.Serve(&plugin.ServeConfig{
+		Logger:          logger,
+		HandshakeConfig: NewHandshake(),
+		Plugins: map[string]plugin.Plugin{
+			Name: &ExtensionPlugin{Impl: impl},
+		},
+	})
+
+	return nil
+}

--- a/pkg/extensions/apiv1/client.go
+++ b/pkg/extensions/apiv1/client.go
@@ -23,7 +23,7 @@ func NewExtensionImplementation(impl Implementation) error {
 	logger := hclog.New(&hclog.LoggerOptions{
 		Level:      hclog.Trace,
 		Output:     os.Stderr,
-		JSONFormat: true,
+		JSONFormat: false,
 	})
 
 	plugin.Serve(&plugin.ServeConfig{

--- a/pkg/extensions/apiv1/extensions.go
+++ b/pkg/extensions/apiv1/extensions.go
@@ -1,0 +1,74 @@
+// Package apiv1 implements the extension API for stencil
+package apiv1
+
+import (
+	"github.com/getoutreach/stencil/pkg/functions"
+)
+
+const (
+	// Version that this extension API implements
+	Version = 1
+
+	// CookieKey is a basic UX feature for ensuring that
+	// we execute a valid stencil plugin. This is exported
+	// for ease of consumption by extensions.
+	CookieKey = "STENCIL_PLUGIN"
+
+	// CookieValue is the expected value for our CookieKey to
+	// return.
+	CookieValue = "はじめまして"
+)
+
+// TemplateFunction is a request to create a new template function.
+type TemplateFunction struct {
+	// Name of the template function, will be registered as:
+	//  extensions.<extensionLowerName>.<name>
+	Name string
+
+	// NumArguments are the number of arguments, arbitrarily, that this
+	// function expects.
+	NumArguments int
+}
+
+// TemplateFunctionExec executes a template function
+type TemplateFunctionExec struct {
+	// Name is the name of this go-template function. It will be prefixed with the
+	// following format: extensions.<name>.<templateName>
+	Name string
+
+	// File is the file metadata provided by stencil
+	// See: https://github.com/getoutreach/stencil/blob/df20471857be9f8cc60bc538fa54e227c449fe8c/pkg/functions/rendered_template.go#L8
+	File *functions.RenderedTemplate
+
+	// Stencil is the stencil object provided by stencil
+	// See: https://github.com/getoutreach/stencil/blob/df20471857be9f8cc60bc538fa54e227c449fe8c/pkg/functions/stencil.go#L20
+	Stencil *functions.Stencil
+
+	// Arguments are the arbitrary arguments that were passed to this function
+	Arguments []interface{}
+}
+
+// Config is configuration returned by an extension
+// to the extension host.
+type Config struct {
+	// Name is the name of this extension, used for template
+	// function naming
+	Name string
+}
+
+// Implementation is the extension api that is implemented
+// by all extensions.
+type Implementation interface {
+	// GetConfig returns the configuration of this extension.
+	GetConfig() (*Config, error)
+
+	// GetTemplateFunctions returns all go-template functions this ext
+	// implements, when a function is called, it's transparently passed over to
+	// the actual extension and called there instead, it's output being
+	// returned.
+	GetTemplateFunctions() ([]*TemplateFunction, error)
+
+	// ExecuteTemplateFunction executes a provided template function
+	// and returns it's response.
+	ExecuteTemplateFunction(t *TemplateFunctionExec) ([]interface{}, error)
+}

--- a/pkg/extensions/apiv1/extensions.go
+++ b/pkg/extensions/apiv1/extensions.go
@@ -11,6 +11,9 @@ const (
 	// Version that this extension API implements
 	Version = 1
 
+	// Name is the plugin name that is served by go-plugin
+	Name = "extension"
+
 	// CookieKey is a basic UX feature for ensuring that
 	// we execute a valid stencil plugin. This is exported
 	// for ease of consumption by extensions.

--- a/pkg/extensions/apiv1/extensions.go
+++ b/pkg/extensions/apiv1/extensions.go
@@ -2,6 +2,8 @@
 package apiv1
 
 import (
+	"reflect"
+
 	"github.com/getoutreach/stencil/pkg/functions"
 )
 
@@ -25,9 +27,8 @@ type TemplateFunction struct {
 	//  extensions.<extensionLowerName>.<name>
 	Name string
 
-	// NumArguments are the number of arguments, arbitrarily, that this
-	// function expects.
-	NumArguments int
+	// Arguments are the arguments that this function expects
+	Arguments []reflect.Type
 }
 
 // TemplateFunctionExec executes a template function

--- a/pkg/extensions/apiv1/extensions.go
+++ b/pkg/extensions/apiv1/extensions.go
@@ -1,12 +1,6 @@
 // Package apiv1 implements the extension API for stencil
 package apiv1
 
-import (
-	"reflect"
-
-	"github.com/getoutreach/stencil/pkg/functions"
-)
-
 const (
 	// Version that this extension API implements
 	Version = 1
@@ -30,8 +24,14 @@ type TemplateFunction struct {
 	//  extensions.<extensionLowerName>.<name>
 	Name string
 
-	// Arguments are the arguments that this function expects
-	Arguments []reflect.Type
+	// ArgumentTypes are the argument types that this function
+	// expects. They should be serializable via gob.
+	ArgumentTypes []interface{}
+
+	// ReturnType is the return type for this function, note that
+	// the signature is always (type, error) and that error is already
+	// included in the function signature.
+	ReturnType interface{}
 }
 
 // TemplateFunctionExec executes a template function
@@ -39,14 +39,6 @@ type TemplateFunctionExec struct {
 	// Name is the name of this go-template function. It will be prefixed with the
 	// following format: extensions.<name>.<templateName>
 	Name string
-
-	// File is the file metadata provided by stencil
-	// See: https://github.com/getoutreach/stencil/blob/df20471857be9f8cc60bc538fa54e227c449fe8c/pkg/functions/rendered_template.go#L8
-	File *functions.RenderedTemplate
-
-	// Stencil is the stencil object provided by stencil
-	// See: https://github.com/getoutreach/stencil/blob/df20471857be9f8cc60bc538fa54e227c449fe8c/pkg/functions/stencil.go#L20
-	Stencil *functions.Stencil
 
 	// Arguments are the arbitrary arguments that were passed to this function
 	Arguments []interface{}
@@ -74,5 +66,5 @@ type Implementation interface {
 
 	// ExecuteTemplateFunction executes a provided template function
 	// and returns it's response.
-	ExecuteTemplateFunction(t *TemplateFunctionExec) ([]interface{}, error)
+	ExecuteTemplateFunction(t *TemplateFunctionExec) (interface{}, error)
 }

--- a/pkg/extensions/apiv1/plugin.go
+++ b/pkg/extensions/apiv1/plugin.go
@@ -44,6 +44,7 @@ func (s *ExtensionPluginServer) GetTemplateFunctions(args interface{}, resp *[]*
 	return err
 }
 
+//nolint:gocritic // Why: This is how go-plugin does it. :shrug:
 func (s *ExtensionPluginServer) ExecuteTemplateFunction(t *TemplateFunctionExec, resp *interface{}) error {
 	v, err := s.Impl.ExecuteTemplateFunction(t)
 	*resp = v

--- a/pkg/extensions/apiv1/plugin.go
+++ b/pkg/extensions/apiv1/plugin.go
@@ -6,6 +6,9 @@ import (
 	"github.com/hashicorp/go-plugin"
 )
 
+// compile time assertion we implement the interface
+var _ Implementation = &ExtensionPluginClient{}
+
 // ExtensionPluginClient implements a client that communicates over RPC
 type ExtensionPluginClient struct{ client *rpc.Client }
 
@@ -23,7 +26,7 @@ func (g *ExtensionPluginClient) GetTemplateFunctions() ([]*TemplateFunction, err
 
 func (g *ExtensionPluginClient) ExecuteTemplateFunction(t *TemplateFunctionExec) (interface{}, error) {
 	var resp interface{}
-	err := g.client.Call("Plugin.ExecuteTemplateFunction", new(interface{}), &resp)
+	err := g.client.Call("Plugin.ExecuteTemplateFunction", t, &resp)
 	return resp, err
 }
 

--- a/pkg/extensions/apiv1/plugin.go
+++ b/pkg/extensions/apiv1/plugin.go
@@ -1,0 +1,65 @@
+package apiv1
+
+import (
+	"net/rpc"
+
+	"github.com/hashicorp/go-plugin"
+)
+
+// ExtensionPluginClient implements a client that communicates over RPC
+type ExtensionPluginClient struct{ client *rpc.Client }
+
+func (g *ExtensionPluginClient) GetConfig() (*Config, error) {
+	var resp *Config
+	err := g.client.Call("Plugin.GetConfig", new(interface{}), &resp)
+	return resp, err
+}
+
+func (g *ExtensionPluginClient) GetTemplateFunctions() ([]*TemplateFunction, error) {
+	var resp []*TemplateFunction
+	err := g.client.Call("Plugin.GetTemplateFunctions", new(interface{}), &resp)
+	return resp, err
+}
+
+func (g *ExtensionPluginClient) ExecuteTemplateFunction(t *TemplateFunctionExec) (interface{}, error) {
+	var resp interface{}
+	err := g.client.Call("Plugin.ExecuteTemplateFunction", new(interface{}), &resp)
+	return resp, err
+}
+
+// ExtensionPluginServer implements a rpc compliant server
+type ExtensionPluginServer struct {
+	Impl Implementation
+}
+
+func (s *ExtensionPluginServer) GetConfig(args interface{}, resp **Config) error {
+	v, err := s.Impl.GetConfig()
+	*resp = v
+	return err
+}
+
+func (s *ExtensionPluginServer) GetTemplateFunctions(args interface{}, resp *[]*TemplateFunction) error {
+	v, err := s.Impl.GetTemplateFunctions()
+	*resp = v
+	return err
+}
+
+func (s *ExtensionPluginServer) ExecuteTemplateFunction(t *TemplateFunctionExec, resp *interface{}) error {
+	v, err := s.Impl.ExecuteTemplateFunction(t)
+	*resp = v
+	return err
+}
+
+// ExtensionPlugin is the high level plugin used by go-plugin
+// it stores both the server and client implementation
+type ExtensionPlugin struct {
+	Impl Implementation
+}
+
+func (p *ExtensionPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+	return &ExtensionPluginServer{Impl: p.Impl}, nil
+}
+
+func (*ExtensionPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+	return &ExtensionPluginClient{client: c}, nil
+}

--- a/pkg/extensions/caller.go
+++ b/pkg/extensions/caller.go
@@ -1,0 +1,62 @@
+package extensions
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// ExtensionCaller calls extension functions
+type ExtensionCaller struct {
+	funcMap map[string]map[string]reflect.Value
+}
+
+// Call returns a function based on its path, e.g. test.callFunction
+func (ec *ExtensionCaller) Call(args ...reflect.Value) (reflect.Value, error) {
+	if len(args) == 0 {
+		return reflect.ValueOf(nil), fmt.Errorf("expected at least 1 arg")
+	}
+
+	extPath := args[0]
+	if extPath.Type().Kind() != reflect.String {
+		return reflect.ValueOf(nil), fmt.Errorf("expected first arg to be type string, got %s", extPath.Type().String())
+	}
+	keys := strings.Split(extPath.Interface().(string), ".")
+	if len(keys) != 2 {
+		return reflect.ValueOf(nil), fmt.Errorf("invalid extension provided to extension function")
+	}
+
+	extName := keys[0]
+	extFn := keys[1]
+
+	if _, ok := ec.funcMap[extName]; !ok {
+		return reflect.ValueOf(nil), fmt.Errorf("unknown extension '%s'", extName)
+	}
+
+	if _, ok := ec.funcMap[extName][extFn]; !ok {
+		return reflect.ValueOf(nil), fmt.Errorf("extension '%s' doesn't provide function '%s'", extName, extFn)
+	}
+
+	resp := ec.funcMap[extName][extFn].Call(args[1:])
+	switch len(resp) {
+	case 0:
+		return reflect.ValueOf(nil), nil
+	case 1:
+		return resp[0], nil
+	case 2:
+		// we need to check that the err pararm returned implements an error interface
+		ok := resp[1].Type().Implements(reflect.TypeOf((*error)(nil)).Elem())
+		if !ok {
+			return reflect.ValueOf(nil), fmt.Errorf("expected extension to return error as second param, got %v", reflect.TypeOf(resp[1]).String())
+		}
+
+		// if it's nil, just return the response
+		if resp[1].IsNil() {
+			return resp[0], nil
+		}
+
+		return resp[0], resp[1].Interface().(error)
+	}
+
+	return reflect.ValueOf(nil), fmt.Errorf("extension returned wrong number of args")
+}

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -1,0 +1,158 @@
+// Package extensions consumes extensions in stencil
+package extensions
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/getoutreach/gobox/pkg/updater"
+	"github.com/getoutreach/stencil/pkg/extensions/apiv1"
+	"github.com/getoutreach/stencil/pkg/extensions/github"
+	"github.com/hashicorp/go-plugin"
+	"github.com/pkg/errors"
+	giturls "github.com/whilp/git-urls"
+
+	gogithub "github.com/google/go-github/v34/github"
+)
+
+// Host implements an extension host that handles
+// registering extensions and executing them.
+type Host struct {
+	extensions map[string]apiv1.Implementation
+}
+
+// NewHost creates a new extension host
+func NewHost() *Host {
+	return &Host{
+		extensions: make(map[string]apiv1.Implementation),
+	}
+}
+
+// RegisterExtension registers a ext from a given source
+// and compiles/downloads it. A client is then created
+// that is able to communicate with the ext.
+func (h *Host) RegisterExtension(ctx context.Context, source, name, version string) error {
+	// 1. download the ext from a repository
+	// 2. (optional) support local paths (how?)
+	// 3. run the ext by creating a connection to it
+	u, err := giturls.Parse(source)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse extension URL")
+	}
+
+	var extPath string
+	if u.Scheme == "file" {
+		extPath, err = h.buildFromLocal(ctx, u.Path, name)
+	} else {
+		extPath, err = h.downloadFromRemote(ctx, source, name, version)
+	}
+	if err != nil {
+		return errors.Wrap(err, "failed to setup extension")
+	}
+
+	// create a connection to the extension
+	client := plugin.NewClient(&plugin.ClientConfig{
+		HandshakeConfig: plugin.HandshakeConfig{
+			ProtocolVersion:  apiv1.Version,
+			MagicCookieKey:   apiv1.CookieKey,
+			MagicCookieValue: apiv1.CookieValue,
+		},
+		Plugins: map[string]plugin.Plugin{
+			"extension": &apiv1.ExtensionPlugin{},
+		},
+		Cmd: exec.CommandContext(ctx, extPath),
+	})
+
+	rpcClient, err := client.Client()
+	if err != nil {
+		return errors.Wrap(err, "failed to create connection to extension")
+	}
+
+	raw, err := rpcClient.Dispense("extension")
+	if err != nil {
+		return errors.Wrap(err, "failed to setup extension connection over extension")
+	}
+
+	ext, ok := raw.(apiv1.Implementation)
+	if !ok {
+		return fmt.Errorf("failed to create apiv1.Implementation from type %s", reflect.TypeOf(raw).String())
+	}
+
+	conf, err := ext.GetConfig()
+	if err != nil {
+		return errors.Wrap(err, "failed to get config from extension")
+	}
+	h.extensions[strings.ToLower(conf.Name)] = ext
+
+	return nil
+}
+
+// getExtensionPath returns the path to an extension binary
+func (h *Host) getExtensionPath(version string, name string) string {
+	homeDir, _ := os.UserHomeDir()
+	path := filepath.Join(homeDir, ".outreach", ".config", "stencil", "extensions", name, "@v", version, name)
+	os.MkdirAll(path, 0755)
+	return path
+}
+
+// buildFromLocal copies a local extension to it's stable path
+func (h *Host) buildFromLocal(ctx context.Context, filePath, name string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to open extension")
+	}
+
+	dlPath := h.getExtensionPath("local", name)
+	nf, err := os.Create(dlPath)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to open extension path")
+	}
+
+	_, err = io.Copy(nf, f)
+	return dlPath, errors.Wrap(err, "failed to copy local extension to storage path")
+}
+
+// downloadFromRemote downloads a release from github and extracts it to disk
+func (h *Host) downloadFromRemote(ctx context.Context, source, name, version string) (string, error) {
+	token, err := github.GetGHToken()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get github token")
+	}
+
+	gh := updater.NewGithubUpdater(ctx, token, "", "")
+	err = gh.Check(ctx)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to validate github client worked")
+	}
+
+	var rel *gogithub.RepositoryRelease
+	if version == "" {
+		rel, err = gh.GetLatestVersion(ctx, "v0.0.0", false)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to find latest extension version")
+		}
+		version = rel.GetTagName()
+	} else {
+		return "", fmt.Errorf("setting versions is not currently supported")
+	}
+
+	bin, cleanup, err := gh.DownloadRelease(ctx, rel, name, name)
+	if cleanup != nil {
+		cleanup()
+	}
+	if err != nil {
+		return "", errors.Wrap(err, "failed to download extension")
+	}
+
+	dlPath := h.getExtensionPath(version, name)
+	return dlPath, errors.Wrap(
+		os.Rename(bin, dlPath),
+		"failed to move downloaded extension",
+	)
+}

--- a/pkg/extensions/github/github.go
+++ b/pkg/extensions/github/github.go
@@ -1,0 +1,76 @@
+// Package github implements helpers accessing github
+// via the gh cli
+package github
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+
+	"github.com/getoutreach/gobox/pkg/cfg"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+var ghInstallInstructions = map[string]string{
+	"windows": "Please run via WSL2",
+	"linux":   "Download at https://github.com/cli/cli/releases",
+	"darwin":  "Install via brew: brew install gh",
+}
+
+// GetGHToken gets a token from gh, or informs the user how to setup
+// a github token via gh, or install gh if not found
+func GetGHToken() (cfg.SecretData, error) {
+	ghPath, err := exec.LookPath("gh")
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to find gh: %s", ghInstallInstructions[runtime.GOOS])
+	} else if ghPath == "" {
+		return "", fmt.Errorf("failed to find gh: %s", ghInstallInstructions[runtime.GOOS])
+	}
+
+	cmd := exec.Command("gh", "auth", "status")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to ensure we had a valid Github token: %s", out)
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get user home directory")
+	}
+
+	ghAuthPath := filepath.Join(homeDir, ".config", "gh", "hosts.yml")
+	f, err := os.Open(ghAuthPath)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read gh auth configuration, try running 'gh auth login'")
+	}
+
+	var conf map[string]interface{}
+	err = yaml.NewDecoder(f).Decode(&conf)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse gh auth configuration")
+	}
+
+	if _, ok := conf["github.conf"]; !ok {
+		return "", fmt.Errorf("failed to find host 'github.com' in gh auth config, try running 'gh auth login'")
+	}
+
+	conf, ok := conf["github.com"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("expected map[string]interface{} for github.com host, got %v", reflect.TypeOf(conf["github.com"]).String())
+	}
+	tokenInf, ok := conf["oauth_token"]
+	if !ok {
+		return "", fmt.Errorf("failed to find oauth_token in gh auth config, try running 'gh auth login'")
+	}
+
+	token, ok := tokenInf.(string)
+	if !ok {
+		return "", fmt.Errorf("expected string for oauth_token, got %s", reflect.TypeOf(token).String())
+	}
+
+	return cfg.SecretData(token), nil
+}

--- a/service.yaml
+++ b/service.yaml
@@ -1,6 +1,6 @@
 name: stencil
 versions:
-  go: 1.16.5
+  go: 1.17
 
 # Support bootstrap
 library: true


### PR DESCRIPTION
<!-- !!!! README !!!! Please fill this out. -->
<!-- 
  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
**What this PR does / why we need it**: This PR adds support for basic go extensions to stencil. An extension is made via go-plugin. A basic example of a plugin looks like so:

```go
type TestPlugin struct{}

func (tp *TestPlugin) GetConfig() (*apiv1.Config, error) {
	return &apiv1.Config{
		Name: "test",
	}, nil
}

func (tp *TestPlugin) ExecuteTemplateFunction(t *apiv1.TemplateFunctionExec) (interface{}, error) {
	return hello()
}

func (tp *TestPlugin) GetTemplateFunctions() ([]*apiv1.TemplateFunction, error) {
	return []*apiv1.TemplateFunction{
		{
			Name:          "hello",
			ArgumentTypes: []interface{}{""},
			ReturnType:    "",
		},
	}, nil
}

func hello() (interface{}, error) {
	return "hello from a plugin!", nil
}

func main() {
	err := apiv1.NewExtensionImplementation(&TestPlugin{})
	if err != nil {
		logrus.WithError(err).Fatal("failed to start extension")
	}
}

```

When run via stencil, with a module manifest like so:

```yaml
name: test-plugin
type: extension
```

the extension will be executed by stencil and automatically exposed to templates. Templates can call a plugin via the `extensions.Call` function. For example, to call that test function would be done like so from a template:

```tpl
{{- extensions.Call "test.hello" }}

# results in: hello from a plugin!
```

This is done by dynamically generating a function via `reflect.MakeFunc` by communicating with the plugin in the extensions package in this PR based on the `GetTemplateFunctions` RPC. When this function is called via `extensions.Call` in the template, a go-plugin is transparently called over RPC and the response is returned. We're limited to only types that gob supports, but in general, this is pretty powerful.


<!--- Block(jiraPrefix) --->
**JIRA ID**: [DTSS-765]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
**Notes for your reviewer**:

<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[DTSS-765]: https://outreach-io.atlassian.net/browse/DTSS-765