### PR TITLE
feat(stencil) expose stencil.Args, stencil.Arg calls w/ no name

### DIFF
--- a/pkg/functions/stencil.go
+++ b/pkg/functions/stencil.go
@@ -53,11 +53,23 @@ func (s *Stencil) ApplyTemplate(name string) (string, error) {
 	return buf.String(), err
 }
 
-// Arg returns an argument from the ServiceManifest
+// Arg returns an argument from the ServiceManifest.
+// Note: Only the top-level arguments are supported.
 //
 //   {{- stencil.Arg "name" }}
 func (s *Stencil) Arg(name string) interface{} {
+	if name == "" {
+		return s.Args()
+	}
+
 	return s.m.Arguments[name]
+}
+
+// Args returns the arguments from the ServiceManifest.
+//
+//   {{- (stencil.Args).name }}
+func (s *Stencil) Args() interface{} {
+	return s.m.Arguments
 }
 
 // InstallFile changes the current active rendered file and writes


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Adds a new `stencil.Args` function that enables accessing the raw arguments map instead of going through `stencil.Arg`. I don't feel there's any real value to dot notation besides gating the accessor for arguments which I also don't find useful.

Intended use:

```tpl
{{- (stencil.Args).dependencies.required }}
```


<!--- Block(jiraPrefix) --->
**JIRA ID**: [DTSS-0]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
