### PR TITLE
feat(codegen): support templates injecting data cross-modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getoutreach/stencil
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.2
@@ -21,6 +21,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gotest.tools/v3 v3.1.0
 )
+
+require github.com/imdario/mergo v0.3.12
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2 // indirect
@@ -50,7 +52,6 @@ require (
 	github.com/honeycombio/beeline-go v1.4.1 // indirect
 	github.com/honeycombio/libhoney-go v1.15.8 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,9 +72,7 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
-github.com/bradleyfalzon/ghinstallation/v2 v2.0.4/go.mod h1:B40qPqJxWE0jDZgOR1JmaMy+4AY1eBP+IByOvqyAKp0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -105,7 +103,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
-github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.1.0 h1:3RNcEpBg4IhIChZdFRSdlQt1QjCp1sMAPIrOnm7Yf8g=
 github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7hqDjlFjiygg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -167,7 +164,6 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
@@ -205,7 +201,6 @@ github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
-github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -247,10 +242,8 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-github.com/google/go-github/v41 v41.0.0/go.mod h1:XgmCA5H323A9rtgExdTcnDkcqp6S30AVACCBDOonIxg=
 github.com/google/go-github/v43 v43.0.0 h1:y+GL7LIsAIF2NZlJ46ZoC/D1W1ivZasT0lnWHMYPZ+U=
 github.com/google/go-github/v43 v43.0.0/go.mod h1:ZkTvvmCXBvsfPpTHXnH/d2hP9Y0cTbvN9kr5xqyXOIc=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
@@ -519,7 +512,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
-github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -552,7 +544,6 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zalando/go-keyring v0.1.1 h1:w2V9lcx/Uj4l+dzAf1m9s+DJ1O8ROkEHnynonHjTcYE=
 github.com/zalando/go-keyring v0.1.1/go.mod h1:OIC+OZ28XbmwFxU/Rp9V7eKzZjamBJwRzC8UFJH9+L8=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
@@ -619,7 +610,6 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -658,7 +648,6 @@ golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5o
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210913180222-943fd674d43e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -735,7 +724,6 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -802,7 +790,6 @@ golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/codegen/stencil_test.go
+++ b/internal/codegen/stencil_test.go
@@ -100,7 +100,7 @@ func ExampleStencil_PostRun() {
 	f.Close()
 
 	nullLog := logrus.New()
-	logrus.SetOutput(io.Discard)
+	nullLog.SetOutput(io.Discard)
 
 	st := NewStencil(&configuration.ServiceManifest{
 		Name:      "test",

--- a/internal/codegen/stencil_test.go
+++ b/internal/codegen/stencil_test.go
@@ -59,7 +59,7 @@ func TestBasicE2ERender(t *testing.T) {
 	})
 }
 
-func TestModuleToModuleBlockRender(t *testing.T) {
+func TestModuleHookRender(t *testing.T) {
 	m1fs := memfs.New()
 	m2fs := memfs.New()
 	ctx := context.Background()
@@ -67,12 +67,12 @@ func TestModuleToModuleBlockRender(t *testing.T) {
 	// create a stub template
 	f, err := m1fs.Create("test-template.tpl")
 	assert.NilError(t, err, "failed to create stub template")
-	f.Write([]byte(`{{ file.Skip "virtual file" }}{{ stencil.AddToModuleBlock "testing2" "coolthing" (list "a") }}`))
+	f.Write([]byte(`{{ file.Skip "virtual file" }}{{ stencil.AddToModuleHook "testing2" "coolthing" (list "a") }}`))
 	f.Close()
 
 	f, err = m2fs.Create("test-template.tpl")
 	assert.NilError(t, err, "failed to create stub template")
-	f.Write([]byte(`{{ index (stencil.GetModuleBlock "coolthing") 0 }}`))
+	f.Write([]byte(`{{ index (stencil.GetModuleHook "coolthing") 0 }}`))
 	f.Close()
 
 	st := NewStencil(&configuration.ServiceManifest{

--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -24,14 +24,14 @@ type TplStencil struct {
 	t *Template
 }
 
-// GetModuleBlock returns a module block in the scope of this
+// GetModuleHook returns a module block in the scope of this
 // module
-func (s *TplStencil) GetModuleBlock(name string) interface{} {
+func (s *TplStencil) GetModuleHook(name string) interface{} {
 	return s.s.sharedData[path.Join(s.t.Module.Name, name)]
 }
 
-// AddToModuleBlock adds to a block in another module
-func (s *TplStencil) AddToModuleBlock(module, name string, data interface{}) (string, error) {
+// AddToModuleHook adds to a hook in another module
+func (s *TplStencil) AddToModuleHook(module, name string, data interface{}) (string, error) {
 	// Only modify on first pass
 	if !s.s.isFirstPass {
 		return "", nil

--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -61,7 +61,6 @@ func (s *TplStencil) AddToModuleHook(module, name string, data interface{}) (str
 
 // Arg returns the value of an argument in the service's
 // manifest.
-// Note: Only the top-level arguments are supported.
 //
 //   {{- stencil.Arg "name" }}
 func (s *TplStencil) Arg(pth string) (interface{}, error) {

--- a/internal/dotnotation/dotnotation.go
+++ b/internal/dotnotation/dotnotation.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+// Description: This file implements a dotnotation parser for
+// accessing a map[string]interface{}
+
+// Package dotnotation implements a dotnotation (hello.world) for
+// accessing fields within a map[string]interface{}
+package dotnotation
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+func Get(data map[string]interface{}, key string) (interface{}, error) {
+	return get(data, key)
+}
+
+// get is a recursize function to get a field from a map[string]interface{}
+// this is done by splitting the key on "." and using the first part of the
+// split, if there is anymore parts of the key then get() is called with
+// the non processed part
+func get(data map[string]interface{}, key string) (interface{}, error) {
+	spl := strings.Split(key, ".")
+
+	partialKey := spl[0]
+	subDataInf, ok := data[partialKey]
+	if !ok {
+		return nil, fmt.Errorf("unknown key %q", partialKey)
+	}
+
+	// check if we have more "keys"
+	if len(spl) > 1 {
+		subData, ok := subDataInf.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("unsupported type %q on key %q", reflect.ValueOf(subDataInf).Type(), partialKey)
+		}
+
+		return get(subData, strings.Join(spl[1:], "."))
+	}
+
+	// otherwise return the data
+	return subDataInf, nil
+}

--- a/internal/dotnotation/dotnotation.go
+++ b/internal/dotnotation/dotnotation.go
@@ -12,7 +12,7 @@ import (
 	"reflect"
 	"strings"
 )
-
+// Get looks up an entry in data by parsing the "key" into deeply nested keys, traversing it by "dots" in the key name.
 func Get(data map[string]interface{}, key string) (interface{}, error) {
 	return get(data, key)
 }

--- a/internal/dotnotation/dotnotation_test.go
+++ b/internal/dotnotation/dotnotation_test.go
@@ -1,0 +1,88 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+// Description: This file implements a dotnotation parser for
+// accessing a map[string]interface{}
+
+// Package dotnotation implements a dotnotation (hello.world) for
+// accessing fields within a map[string]interface{}
+package dotnotation
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	type args struct {
+		data map[string]interface{}
+		key  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			name: "should handle basic depths",
+			args: args{
+				key: "hello.world",
+				data: map[string]interface{}{
+					"hello": map[string]interface{}{
+						"world": "hello, world!",
+					},
+				},
+			},
+			want:    "hello, world!",
+			wantErr: false,
+		},
+		{
+			name: "should fail on invalid keys",
+			args: args{
+				key:  "hello.world",
+				data: map[string]interface{}{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Get(tt.args.data, tt.args.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_get(t *testing.T) {
+	type args struct {
+		data map[string]interface{}
+		key  string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    interface{}
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := get(tt.args.data, tt.args.key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("get() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -10,8 +10,6 @@ import (
 	"os/exec"
 	"regexp"
 
-	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/pkg/errors"
 )
 
@@ -32,32 +30,11 @@ var (
 // GetDefaultBranch determines the default/HEAD branch for a given git
 // repository.
 func GetDefaultBranch(ctx context.Context, path string) (string, error) {
-	r, err := git.PlainOpen(path)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to open directory as a repository")
-	}
-
-	_, err = r.Remote("origin")
-	if err != nil {
-		// loop through the local branchs
-		candidates := []string{"main", "master"}
-		for _, branch := range candidates {
-			_, err := r.Reference(plumbing.NewBranchReferenceName(branch), true)
-			if err == nil {
-				return branch, nil
-			}
-		}
-
-		// we couldn't find one
-		return "", ErrNoHeadBranch
-	}
-
-	// we found an origin reference, figure out the HEAD
-	cmd := exec.CommandContext(ctx, "git", "remote", "show", "origin")
+	cmd := exec.CommandContext(ctx, "git", "remote", "show", "origin", "-n")
 	cmd.Dir = path
 	out, err := cmd.Output()
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to get head branch from remote origin")
+		return "", errors.Wrap(err, "failed to get head branch from remote origin")
 	}
 
 	matches := headPattern.FindStringSubmatch(string(out))

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -118,24 +118,6 @@ type TemplateRepositoryManifest struct {
 
 	// Arguments are a declaration of arguments to the template generator
 	Arguments map[string]Argument
-
-	// ModuleBlocks contains all of the module to module blocks that
-	// this module provides to other modules
-	ModuleBlocks struct {
-		// Provides is a list of module blocks that this module provides
-		// as an injection point for other templates
-		Provides []*ModuleBlock `yaml:"provides"`
-	} `yaml:"moduleBlocks"`
-}
-
-// ModuleBlock is a module block that modules can provide or inject into
-type ModuleBlock struct {
-	// Name is the name of a module block. This is unique to a module.
-	Name string `yaml:"name"`
-
-	// Type defines the type, in Go, that this
-	// block should be.
-	Type string `yaml:"type"`
 }
 
 // PostRunCommandSpec is the spec of a command to be ran and its

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -118,6 +118,24 @@ type TemplateRepositoryManifest struct {
 
 	// Arguments are a declaration of arguments to the template generator
 	Arguments map[string]Argument
+
+	// ModuleBlocks contains all of the module to module blocks that
+	// this module provides to other modules
+	ModuleBlocks struct {
+		// Provides is a list of module blocks that this module provides
+		// as an injection point for other templates
+		Provides []*ModuleBlock `yaml:"provides"`
+	} `yaml:"moduleBlocks"`
+}
+
+// ModuleBlock is a module block that modules can provide or inject into
+type ModuleBlock struct {
+	// Name is the name of a module block. This is unique to a module.
+	Name string `yaml:"name"`
+
+	// Type defines the type, in Go, that this
+	// block should be.
+	Type string `yaml:"type"`
 }
 
 // PostRunCommandSpec is the spec of a command to be ran and its


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR introduces the concept of "module hooks" which are cross-module blocks that modules can write to. These enable modules to programmatically insert contents into another module in a predictable way.

There are currently restrictions on the type of data that is allowed to be passed, they must be slices or maps. This helps ensure that multiple modules are able to write to the same hook without the possibility of being overwritten. If the same hook is written more than once, the data is merged together via mergo.

<!--- Block(jiraPrefix) --->
## Jira ID

[DTSS-1379]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->


[DTSS-1379]: https://outreach-io.atlassian.net/browse/DTSS-1379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ