### PR TITLE
feat(create): add create and create templaterepository commands

### DIFF
--- a/cmd/stencil/create.go
+++ b/cmd/stencil/create.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+// Description: This file contains code for the create command
+
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+// NewCreateCommand returns a new urfave/cli.Command for the
+// create command
+func NewCreateCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "create",
+		Description: "Commands to create template repositories, or stencil powered repositories",
+		Subcommands: []*cli.Command{
+			NewCreateTemplateRepositoryCommand(),
+		},
+	}
+}

--- a/cmd/stencil/create_templaterepository.go
+++ b/cmd/stencil/create_templaterepository.go
@@ -1,0 +1,73 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+// Description: This file contains code for the create templaterepository command
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/getoutreach/stencil/pkg/configuration"
+	"github.com/urfave/cli/v2"
+	"gopkg.in/yaml.v3"
+)
+
+// NewCreateTemplateRepositoryCommand returns a new urfave/cli.Command for the
+// create templaterepository command
+func NewCreateTemplateRepositoryCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "templaterepository",
+		Description: "Creates a templaterepository with the provided name in the current directory",
+		ArgsUsage:   "create templaterepository <name>",
+		Action: func(c *cli.Context) error {
+			var manifestFileName = "manifest.yaml"
+
+			// ensure we have a name
+			if c.NArg() != 1 {
+				return errors.New("must provide a name for the templaterepository")
+			}
+
+			allowedFiles := []string{".", "..", ".git"}
+			files, err := os.ReadDir(".")
+			if err != nil {
+				return err
+			}
+
+			// ensure we don't have any files in the current directory, except for
+			// the allowed files
+			for _, file := range files {
+				found := false
+				for _, af := range allowedFiles {
+					if file.Name() == af {
+						found = true
+						continue
+					}
+				}
+				if !found {
+					return errors.New("must be in a directory with no files")
+				}
+			}
+
+			tm := &configuration.TemplateRepositoryManifest{
+				Name: c.Args().Get(0),
+			}
+
+			if _, err := os.Stat(manifestFileName); err == nil {
+				return fmt.Errorf("%s already exists", manifestFileName)
+			}
+
+			f, err := os.Create(manifestFileName)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			enc := yaml.NewEncoder(f)
+			defer enc.Close()
+
+			return enc.Encode(tm)
+		},
+	}
+}

--- a/cmd/stencil/stencil.go
+++ b/cmd/stencil/stencil.go
@@ -77,6 +77,7 @@ func main() {
 	app.Commands = []*cli.Command{
 		///Block(commands)
 		NewDescribeCmd(),
+		NewCreateCommand(),
 		///EndBlock(commands)
 	}
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds a `create templaterepository` command that enables users to quickly create a template repository


<!--- Block(jiraPrefix) --->
## Jira ID

[XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
