### PR TITLE
fix(stencil): properly handle yaml map type

### DIFF
--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -80,8 +80,13 @@ func (s *TplStencil) Arg(pth string) (interface{}, error) {
 		return "", fmt.Errorf("module %q doesn't list argument %q as an argument in it's manifest", s.t.Module.Name, pth)
 	}
 
+	mapInf := make(map[interface{}]interface{})
+	for k, v := range s.s.m.Arguments {
+		mapInf[k] = v
+	}
+
 	// if not set then we return a default value based on the denoted type
-	v, err := dotnotation.Get(s.s.m.Arguments, pth)
+	v, err := dotnotation.Get(mapInf, pth)
 	if err != nil {
 		switch mf.Arguments[pth].Type {
 		case "list":

--- a/internal/dotnotation/dotnotation.go
+++ b/internal/dotnotation/dotnotation.go
@@ -14,15 +14,15 @@ import (
 )
 
 // Get looks up an entry in data by parsing the "key" into deeply nested keys, traversing it by "dots" in the key name.
-func Get(data map[string]interface{}, key string) (interface{}, error) {
+func Get(data map[interface{}]interface{}, key string) (interface{}, error) {
 	return get(data, key)
 }
 
-// get is a recursize function to get a field from a map[string]interface{}
+// get is a recursize function to get a field from a map[interface{}]interface{}
 // this is done by splitting the key on "." and using the first part of the
 // split, if there is anymore parts of the key then get() is called with
 // the non processed part
-func get(data map[string]interface{}, key string) (interface{}, error) {
+func get(data map[interface{}]interface{}, key string) (interface{}, error) {
 	spl := strings.Split(key, ".")
 
 	partialKey := spl[0]
@@ -33,7 +33,7 @@ func get(data map[string]interface{}, key string) (interface{}, error) {
 
 	// check if we have more "keys"
 	if len(spl) > 1 {
-		subData, ok := subDataInf.(map[string]interface{})
+		subData, ok := subDataInf.(map[interface{}]interface{})
 		if !ok {
 			return nil, fmt.Errorf("unsupported type %q on key %q", reflect.ValueOf(subDataInf).Type(), partialKey)
 		}

--- a/internal/dotnotation/dotnotation_test.go
+++ b/internal/dotnotation/dotnotation_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestGet(t *testing.T) {
 	type args struct {
-		data map[string]interface{}
+		data map[interface{}]interface{}
 		key  string
 	}
 	tests := []struct {
@@ -27,8 +27,8 @@ func TestGet(t *testing.T) {
 			name: "should handle basic depths",
 			args: args{
 				key: "hello.world",
-				data: map[string]interface{}{
-					"hello": map[string]interface{}{
+				data: map[interface{}]interface{}{
+					"hello": map[interface{}]interface{}{
 						"world": "hello, world!",
 					},
 				},
@@ -40,7 +40,7 @@ func TestGet(t *testing.T) {
 			name: "should fail on invalid keys",
 			args: args{
 				key:  "hello.world",
-				data: map[string]interface{}{},
+				data: map[interface{}]interface{}{},
 			},
 			want:    nil,
 			wantErr: true,
@@ -62,7 +62,7 @@ func TestGet(t *testing.T) {
 
 func Test_get(t *testing.T) {
 	type args struct {
-		data map[string]interface{}
+		data map[interface{}]interface{}
 		key  string
 	}
 	tests := []struct {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Yaml returns `map[interface{}]interface{}` for maps, so we need to handle that in `dotnotation`.


<!--- Block(jiraPrefix) --->
## Jira ID

[XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
