### PR TITLE
fix(tpl/stencil): return []interface{}{} instead of []string for list default

### DIFF
--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -90,7 +90,7 @@ func (s *TplStencil) Arg(pth string) (interface{}, error) {
 	if err != nil {
 		switch mf.Arguments[pth].Type {
 		case "list":
-			v = []string{}
+			v = []interface{}{}
 		case "boolean":
 			v = false
 		case "string":


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Minor optimization to not assume the list type when returning a default value


<!--- Block(jiraPrefix) --->
## Jira ID

[XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
