### PR TITLE
fix(stencil): use templates/ as the base directory if present

### DIFF
--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -180,13 +180,17 @@ func (s *Stencil) getTemplates(ctx context.Context, log logrus.FieldLogger) ([]*
 
 		// default to templates/, but if it's not present fallback to
 		// the root w/ a warning
-		baseDir := "templates"
-		if inf, err := fs.Stat(baseDir); err != nil || !inf.IsDir() {
-			baseDir = ""
+		if inf, err := fs.Stat("templates"); err != nil || !inf.IsDir() {
 			log.Warnf("Module %q has templates outside of templates/ directory, this is not recommended and is deprecated", m.Name)
+		} else {
+			var err error
+			fs, err = fs.Chroot("templates")
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to chroot module filesystem to templates/")
+			}
 		}
 
-		err = util.Walk(fs, baseDir, func(path string, inf os.FileInfo, err error) error {
+		err = util.Walk(fs, "", func(path string, inf os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}

--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -181,7 +181,7 @@ func (s *Stencil) getTemplates(ctx context.Context, log logrus.FieldLogger) ([]*
 		// default to templates/, but if it's not present fallback to
 		// the root w/ a warning
 		baseDir := "templates"
-		if inf, err := fs.Stat("templates"); err != nil || !inf.IsDir() {
+		if inf, err := fs.Stat(baseDir); err != nil || !inf.IsDir() {
 			baseDir = ""
 			log.Warn("Module %q has templates outside of templates/ directory, this is not recommended and is deprecated", m.Name)
 		}

--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -182,6 +182,8 @@ func (s *Stencil) getTemplates(ctx context.Context, log logrus.FieldLogger) ([]*
 		// use templates/ if present
 		if inf, err := fs.Stat("templates"); err == nil && inf.IsDir() {
 			baseDir = "templates"
+		} else {
+			log.Warn("Module %q has templates outside of templates/ directory, this is not recommended and is deprecated", m.Name)
 		}
 
 		err = util.Walk(fs, baseDir, func(path string, inf os.FileInfo, err error) error {

--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -177,12 +177,12 @@ func (s *Stencil) getTemplates(ctx context.Context, log logrus.FieldLogger) ([]*
 		}
 
 		log.Debugf("Discovering templates from module %q", m.Name)
-		baseDir := ""
 
-		// use templates/ if present
-		if inf, err := fs.Stat("templates"); err == nil && inf.IsDir() {
-			baseDir = "templates"
-		} else {
+		// default to templates/, but if it's not present fallback to
+		// the root w/ a warning
+		baseDir := "templates"
+		if inf, err := fs.Stat("templates"); err != nil || !inf.IsDir() {
+			baseDir = ""
 			log.Warn("Module %q has templates outside of templates/ directory, this is not recommended and is deprecated", m.Name)
 		}
 

--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -177,7 +177,14 @@ func (s *Stencil) getTemplates(ctx context.Context, log logrus.FieldLogger) ([]*
 		}
 
 		log.Debugf("Discovering templates from module %q", m.Name)
-		err = util.Walk(fs, "", func(path string, inf os.FileInfo, err error) error {
+		baseDir := ""
+
+		// use templates/ if present
+		if inf, err := fs.Stat("templates"); err == nil && inf.IsDir() {
+			baseDir = "templates"
+		}
+
+		err = util.Walk(fs, baseDir, func(path string, inf os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}

--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -183,7 +183,7 @@ func (s *Stencil) getTemplates(ctx context.Context, log logrus.FieldLogger) ([]*
 		baseDir := "templates"
 		if inf, err := fs.Stat(baseDir); err != nil || !inf.IsDir() {
 			baseDir = ""
-			log.Warn("Module %q has templates outside of templates/ directory, this is not recommended and is deprecated", m.Name)
+			log.Warnf("Module %q has templates outside of templates/ directory, this is not recommended and is deprecated", m.Name)
 		}
 
 		err = util.Walk(fs, baseDir, func(path string, inf os.FileInfo, err error) error {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Keeping templates in the root has been... a big mistake, so, instead, we'll place them in `templates/` and keep the behavior but treating that as a "chroot".


<!--- Block(jiraPrefix) --->
## Jira ID

[DTSS-0]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
