### PR TITLE
fix(git): query remote for HEAD branch

### DIFF
--- a/internal/codegen/values_test.go
+++ b/internal/codegen/values_test.go
@@ -42,8 +42,8 @@ func TestValues(t *testing.T) {
 	assert.NilError(t, err, "expected worktree.Commit() not to fail")
 
 	err = wrk.Checkout(&gogit.CheckoutOptions{
-		Create: true,
-		Branch: plumbing.NewBranchReferenceName("main"),
+		//Create: true,
+		Branch: plumbing.NewBranchReferenceName("master"),
 	})
 	assert.NilError(t, err, "expected worktree.Checkout() not to fail")
 
@@ -56,7 +56,7 @@ func TestValues(t *testing.T) {
 	vals := NewValues(context.Background(), sm)
 	assert.DeepEqual(t, &Values{
 		Git: &git{
-			Ref:           plumbing.NewBranchReferenceName("main").String(),
+			Ref:           plumbing.NewBranchReferenceName("master").String(),
 			Commit:        cmt.String(),
 			Dirty:         false,
 			DefaultBranch: "main",

--- a/internal/codegen/values_test.go
+++ b/internal/codegen/values_test.go
@@ -42,8 +42,8 @@ func TestValues(t *testing.T) {
 	assert.NilError(t, err, "expected worktree.Commit() not to fail")
 
 	err = wrk.Checkout(&gogit.CheckoutOptions{
-		//Create: true,
-		Branch: plumbing.NewBranchReferenceName("master"),
+		Create: true,
+		Branch: plumbing.NewBranchReferenceName("main"),
 	})
 	assert.NilError(t, err, "expected worktree.Checkout() not to fail")
 
@@ -56,7 +56,7 @@ func TestValues(t *testing.T) {
 	vals := NewValues(context.Background(), sm)
 	assert.DeepEqual(t, &Values{
 		Git: &git{
-			Ref:           plumbing.NewBranchReferenceName("master").String(),
+			Ref:           plumbing.NewBranchReferenceName("main").String(),
 			Commit:        cmt.String(),
 			Dirty:         false,
 			DefaultBranch: "main",

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -30,7 +30,7 @@ var (
 // GetDefaultBranch determines the default/HEAD branch for a given git
 // repository.
 func GetDefaultBranch(ctx context.Context, path string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", "remote", "show", "origin", "-n")
+	cmd := exec.CommandContext(ctx, "git", "remote", "show", "origin")
 	cmd.Dir = path
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

I added `-n` because it doesn't require network connectivity and seemed to still work, but apparently it breaks sometimes when a remote has never been queried before, so, we remove it again.


<!--- Block(jiraPrefix) --->
## Jira ID

[XX-XX]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
