### PR TITLE
fix: only support []interface{} for hooks, module hooks render properly

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,8 @@
       "envFile": "${workspaceRoot}/.vscode/private.env",
       "go.testEnvFile": "${workspaceRoot}/.vscode/private.env",
       "program": "${workspaceRoot}/cmd/stencil/",
-      "buildFlags": "-tags=or_dev"
+      "buildFlags": "-tags=or_dev",
+      "cwd": "../oats"
     },
     {
       "name": "Attach to dev container",

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-github/v43 v43.0.0
 	github.com/hashicorp/go-hclog v1.0.0
 	github.com/hashicorp/go-plugin v1.4.3
-	github.com/imdario/mergo v0.3.12
+	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli/v2 v2.4.0
@@ -27,7 +27,10 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-require github.com/google/go-cmp v0.5.7
+require (
+	github.com/davecgh/go-spew v1.1.1
+	github.com/google/go-cmp v0.5.7
+)
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
@@ -44,7 +47,6 @@ require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/emirpasic/gods v1.12.1 // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect

--- a/internal/cmd/stencil/stencil.go
+++ b/internal/cmd/stencil/stencil.go
@@ -287,8 +287,8 @@ func (c *Command) writeFiles(st *codegen.Stencil, tpls []*codegen.Template) erro
 	c.log.Infof("Writing template(s) to disk")
 	for _, tpl := range tpls {
 		c.log.Debugf(" -> %s (%s)", tpl.Module.Name, tpl.Path)
-		for _, f := range tpl.Files {
-			if err := c.writeFile(f); err != nil {
+		for i := range tpl.Files {
+			if err := c.writeFile(tpl.Files[i]); err != nil {
 				return err
 			}
 		}

--- a/internal/codegen/file.go
+++ b/internal/codegen/file.go
@@ -77,9 +77,17 @@ func (f *File) AddDeprecationNotice(msg string) {
 	f.Warnings = append(f.Warnings, msg)
 }
 
-// SetPath updates the path of this file
-func (f *File) SetPath(path string) {
+// SetPath updates the path of this file. This causes
+// the blocks to be parsed again.
+func (f *File) SetPath(path string) error {
+	blocks, err := parseBlocks(path)
+	if err != nil {
+		return err
+	}
+	f.blocks = blocks
 	f.path = path
+
+	return nil
 }
 
 // SetMode updates the mode of the file

--- a/internal/codegen/template_test.go
+++ b/internal/codegen/template_test.go
@@ -32,7 +32,6 @@ func TestSingleFileRender(t *testing.T) {
 
 	tpl, err := NewTemplate(m, "virtual-file.tpl", 0o644, time.Now(), []byte("hello world!"), logrus.New())
 	assert.NilError(t, err, "failed to create basic template")
-	assert.Equal(t, len(tpl.Files), 1, "expected NewTemplate() to create first file")
 
 	sm := &configuration.ServiceManifest{Name: "testing"}
 

--- a/internal/codegen/template_test.go
+++ b/internal/codegen/template_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/getoutreach/stencil/internal/modules"
 	"github.com/getoutreach/stencil/pkg/configuration"
 	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 )
 
@@ -29,7 +30,7 @@ var applyTemplatePassthroughTemplate string
 func TestSingleFileRender(t *testing.T) {
 	m := modules.NewWithFS(context.Background(), "testing", memfs.New())
 
-	tpl, err := NewTemplate(m, "virtual-file.tpl", 0o644, time.Now(), []byte("hello world!"))
+	tpl, err := NewTemplate(m, "virtual-file.tpl", 0o644, time.Now(), []byte("hello world!"), logrus.New())
 	assert.NilError(t, err, "failed to create basic template")
 	assert.Equal(t, len(tpl.Files), 1, "expected NewTemplate() to create first file")
 
@@ -49,7 +50,8 @@ func TestMultiFileRender(t *testing.T) {
 
 	m := modules.NewWithFS(context.Background(), "testing", fs)
 
-	tpl, err := NewTemplate(m, "multi-file.tpl", 0o644, time.Now(), []byte(multiFileTemplate))
+	tpl, err := NewTemplate(m, "multi-file.tpl", 0o644,
+		time.Now(), []byte(multiFileTemplate), logrus.New())
 	assert.NilError(t, err, "failed to create template")
 
 	sm := &configuration.ServiceManifest{Name: "testing", Arguments: map[string]interface{}{
@@ -74,7 +76,8 @@ func TestMultiFileWithInputRender(t *testing.T) {
 
 	m := modules.NewWithFS(context.Background(), "testing", fs)
 
-	tpl, err := NewTemplate(m, "multi-file-input.tpl", 0o644, time.Now(), []byte(multiFileInputTemplate))
+	tpl, err := NewTemplate(m, "multi-file-input.tpl", 0o644,
+		time.Now(), []byte(multiFileInputTemplate), logrus.New())
 	assert.NilError(t, err, "failed to create template")
 
 	sm := &configuration.ServiceManifest{Name: "testing", Arguments: map[string]interface{}{
@@ -99,7 +102,8 @@ func TestApplyTemplateArgumentPassthrough(t *testing.T) {
 
 	m := modules.NewWithFS(context.Background(), "testing", fs)
 
-	tpl, err := NewTemplate(m, "apply-template-passthrough.tpl", 0o644, time.Now(), []byte(applyTemplatePassthroughTemplate))
+	tpl, err := NewTemplate(m, "apply-template-passthrough.tpl", 0o644,
+		time.Now(), []byte(applyTemplatePassthroughTemplate), logrus.New())
 	assert.NilError(t, err, "failed to create template")
 
 	sm := &configuration.ServiceManifest{Name: "testing", Arguments: map[string]interface{}{

--- a/internal/codegen/tpl.go
+++ b/internal/codegen/tpl.go
@@ -5,10 +5,14 @@
 
 package codegen
 
-import "text/template"
+import (
+	"text/template"
+
+	"github.com/sirupsen/logrus"
+)
 
 // NewFuncMap returns the standard func map for a template
-func NewFuncMap(st *Stencil, t *Template) template.FuncMap {
+func NewFuncMap(st *Stencil, t *Template, log logrus.FieldLogger) template.FuncMap {
 	// We allow tplst & tplf to be nil in the case of
 	// .Parse() of a template, where they need to be present
 	// but aren't actually executed by the template
@@ -16,10 +20,10 @@ func NewFuncMap(st *Stencil, t *Template) template.FuncMap {
 	var tplst *TplStencil
 	var tplf *TplFile
 	if st != nil {
-		tplst = &TplStencil{st, t}
+		tplst = &TplStencil{st, t, log}
 	}
 	if t != nil {
-		tplf = &TplFile{t.Files[0], t}
+		tplf = &TplFile{t.Files[0], t, log}
 	}
 
 	// build the function map

--- a/internal/codegen/tpl_file.go
+++ b/internal/codegen/tpl_file.go
@@ -8,6 +8,8 @@ package codegen
 import (
 	"os"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 // TplFile is the current file we're writing output to in a
@@ -21,6 +23,9 @@ type TplFile struct {
 
 	// t is the current template
 	t *Template
+
+	// log is the logger to use for debugging
+	log logrus.FieldLogger
 }
 
 // Block returns the contents of a given block
@@ -38,15 +43,14 @@ type TplFile struct {
 //   ###Block(name)
 //   {{ - /* Short hand syntax, but adds newline if no contents */}}
 //   {{ file.Block "name" }}
-//   ###ndBlock(name)
+//   ###EndBlock(name)
 func (f *TplFile) Block(name string) string {
 	return f.f.Block(name)
 }
 
 // SetPath changes the path of the current file
 func (f *TplFile) SetPath(path string) error {
-	f.f.SetPath(path)
-	return nil
+	return f.f.SetPath(path)
 }
 
 // SetContents sets the contents of the current file
@@ -76,6 +80,14 @@ func (f *TplFile) Static() error {
 	}
 
 	return nil
+}
+
+// Path returns the current path of the file we're
+// writing to.
+//
+//   {{ file.Path }}
+func (f *TplFile) Path() string {
+	return f.f.path
 }
 
 // Create creates a new file that is rendered by the current


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This PR changes module hooks to only accept slices and to return `[]interface{}` instead of `interface{}`. This brings us better in line with the true value of hooks, which is for multiple items.

Module hooks previously erroneously shared a slice between first pass and second pass. This would result in module hooks working but not persisting their contents because of how the template default file system works. This is now fixed by clearing `Files` between runs, which is the only mutated field of a template struct. This is also more memory efficient. This will be improved upon when we move to a selective rerender system in the future.

Debugging has also been beefed up by adding module hook logs into the `--debug` logs.

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
