### PR TITLE
feat: prerelease templaterepositories by default, support module version override

### DIFF
--- a/cmd/stencil/create_templaterepository.go
+++ b/cmd/stencil/create_templaterepository.go
@@ -57,6 +57,11 @@ func NewCreateTemplateRepositoryCommand() *cli.Command {
 				Modules: []*configuration.TemplateRepository{{
 					Name: "github.com/getoutreach/stencil-template-base",
 				}},
+				Arguments: map[string]interface{}{
+					"releaseOptions": map[string]interface{}{
+						"enablePrereleases": true,
+					},
+				},
 			}
 
 			if _, err := os.Stat(manifestFileName); err == nil {
@@ -82,7 +87,7 @@ func NewCreateTemplateRepositoryCommand() *cli.Command {
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			cmd.Stdin = os.Stdin
-			return errors.Wrap(cmd.Run(), "failed ot run stancil")
+			return errors.Wrap(cmd.Run(), "failed to run stancil")
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/google/go-github/v43 v43.0.0
 	github.com/hashicorp/go-hclog v1.0.0
 	github.com/hashicorp/go-plugin v1.4.3
-	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli/v2 v2.4.0
@@ -63,6 +62,7 @@ require (
 	github.com/honeycombio/beeline-go v1.4.1 // indirect
 	github.com/honeycombio/libhoney-go v1.15.8 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/internal/modules/modules.go
+++ b/internal/modules/modules.go
@@ -77,8 +77,9 @@ func getModulesForService(ctx context.Context, sm *configuration.ServiceManifest
 				continue
 			}
 
-			// GC the old module
-			modules[d.Name] = nil
+			// GC the old module, we're not going to use it, and it'll be
+			// replaced later.
+			delete(modules, d.Name)
 		}
 
 		// create a module struct for this module, this resolves the latest version if

--- a/internal/modules/modules.go
+++ b/internal/modules/modules.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"path"
 
+	"github.com/blang/semver/v4"
 	"github.com/getoutreach/stencil/pkg/configuration"
 	"github.com/pkg/errors"
 	giturls "github.com/whilp/git-urls"
@@ -54,9 +55,30 @@ func getModulesForService(ctx context.Context, sm *configuration.ServiceManifest
 			d.Name = path.Join(u.Host, u.Path)
 		}
 
-		// If we already used this dependency once, don't fetch it again.
+		// If we already used this dependency once, only fetch it again if
+		// this is a newer version to enable modules to request a specific version.
+		//
+		// IDEA: In the future we should probably warn the user when this happens
+		// because it's probably non-deterministic.
 		if _, ok := modules[d.Name]; ok {
-			continue
+			newV, err := semver.ParseTolerant(d.Version)
+			if err != nil {
+				// Handle when we're using a local version
+				newV = semver.MustParse("0.0.0")
+			}
+			curV, err := semver.ParseTolerant(modules[d.Name].Version)
+			if err != nil {
+				curV = semver.MustParse("0.0.0")
+			}
+
+			// The new version is less than the one we already found, so
+			// we skip downloading the module here.
+			if newV.LTE(curV) {
+				continue
+			}
+
+			// GC the old module
+			modules[d.Name] = nil
 		}
 
 		// create a module struct for this module, this resolves the latest version if

--- a/stencil.lock
+++ b/stencil.lock
@@ -1,5 +1,5 @@
-version: v1.10.0
-generated: 2022-04-21T16:59:11.535336Z
+version: v1.11.1
+generated: 2022-04-29T02:41:28.419135Z
 modules:
 - name: github.com/getoutreach/stencil-base
   url: https://github.com/getoutreach/stencil-base


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This PR updates `create templaterepository` to default to pre-releasing them. I also fixed an issue with top level modules being unable to override dependency versions, with a note on a better path forward for the future.

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
