### PR TITLE
feat: allow unauthenticated github client, better handle local modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
 	github.com/charmbracelet/glamour v0.5.0
-	github.com/getoutreach/gobox v1.39.2
+	github.com/getoutreach/gobox v1.40.0
 
 	// This version has util.Walk
 	// https://github.com/go-git/go-billy/commit/7ab80d7c013de28ffbb1ca64b9bbf8dd1cbd81c5

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/getoutreach/gobox v1.39.2 h1:HXo+kCgU8hflwNs3myL7hPYdrPsjZJCf96LOUIdqRN4=
-github.com/getoutreach/gobox v1.39.2/go.mod h1:YXsuwQHx9zRwriX8vcoP0LsL5qW1zM4cAmzHZlLe3hs=
+github.com/getoutreach/gobox v1.40.0 h1:IAfhk8iA0APksbPzF/kvEBL8RH85dHm0GDQnCrm3Gws=
+github.com/getoutreach/gobox v1.40.0/go.mod h1:YXsuwQHx9zRwriX8vcoP0LsL5qW1zM4cAmzHZlLe3hs=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=

--- a/internal/cmd/stencil/stencil.go
+++ b/internal/cmd/stencil/stencil.go
@@ -202,7 +202,7 @@ func (c *Command) checkForMajorVersions(ctx context.Context, mods []*modules.Mod
 func (c *Command) promptMajorVersion(ctx context.Context, m *modules.Module, lastm *stencil.LockfileModuleEntry) error {
 	c.log.Infof("Major version bump detected for %q (%s -> %s)", m.Name, lastm.Version, m.Version)
 
-	gh, err := github.NewClient()
+	gh, err := github.NewClient(github.WithAllowUnauthenticated(), github.WithLogger(c.log))
 	if err != nil {
 		return errors.Wrap(err, "failed to fetch release notes (create github client)")
 	}

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -146,7 +146,7 @@ func (h *Host) getExtensionPath(version, name, repo string) string {
 // 	repo: stencil-plugin
 // 	name: github.com/getoutreach/stencil-plugin
 func (h *Host) downloadFromRemote(ctx context.Context, org, repo, name string) (string, error) {
-	ghc, err := github.NewClient()
+	ghc, err := github.NewClient(github.WithAllowUnauthenticated(), github.WithLogger(h.log))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**What this PR does**: This PR updates the github client calls to allow no auth, passing a logger where possible. I also changed the handling of local module replacements to support no `file://` prefix (which always felt terse) but also to report errors when the replacement isn't found. This should increase the UX of local replacements.