### PR TITLE
feat: multi-type repo support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 // indirect
+	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -453,8 +453,8 @@ github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMK
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=
-github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
+github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -16,6 +16,7 @@ import (
 	"github.com/getoutreach/stencil/internal/modules"
 	"github.com/getoutreach/stencil/pkg/configuration"
 	"github.com/getoutreach/stencil/pkg/extensions"
+	"github.com/getoutreach/stencil/pkg/extensions/apiv1"
 	"github.com/getoutreach/stencil/pkg/stencil"
 	"github.com/go-git/go-billy/v5/util"
 	"github.com/pkg/errors"
@@ -64,6 +65,13 @@ func (s *Stencil) RegisterExtensions(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// RegisterInprocExtensions registers the input ext extension directly. This API is used in
+// unit tests to render modules with templates that invoke native extensions: input 'ext' can be
+// either an actual extension or a mock one (feeding fake data into the template).
+func (s *Stencil) RegisterInprocExtensions(name string, ext apiv1.Implementation) {
+	s.ext.RegisterInprocExtension(name, ext)
 }
 
 // GenerateLockfile generates a stencil.Lockfile based

--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -199,7 +199,7 @@ func (s *Stencil) getTemplates(ctx context.Context, log logrus.FieldLogger) ([]*
 		if err != nil {
 			return nil, err
 		}
-		if mf.Type != configuration.TemplateRepositoryTypeStd {
+		if !mf.Type.Contains(configuration.TemplateRepositoryTypeTemplates) {
 			log.Debugf("Skipping template discovery for module %q, not a template module (type %s)", m.Name, mf.Type)
 			continue
 		}

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -154,8 +154,8 @@ func (m *Module) RegisterExtensions(ctx context.Context, log logrus.FieldLogger,
 		return err
 	}
 
-	// Only register extensions if we're a extension repository
-	if mf.Type != configuration.TemplateRepositoryTypeExt {
+	// Only register extensions if this repository declares extensions explicitly in its type.
+	if !mf.Type.Contains(configuration.TemplateRepositoryTypeExt) {
 		return nil
 	}
 

--- a/internal/modules/module_test.go
+++ b/internal/modules/module_test.go
@@ -20,7 +20,7 @@ func TestCanFetchModule(t *testing.T) {
 
 	manifest, err := m.Manifest(ctx)
 	assert.NilError(t, err, "failed to call Manifest() on module")
-	assert.Equal(t, manifest.Type, configuration.TemplateRepositoryTypeStd, "failed to validate returned manifest")
+	assert.Assert(t, manifest.Type.Contains(configuration.TemplateRepositoryTypeTemplates), "failed to validate returned manifest")
 
 	fs, err := m.GetFS(ctx)
 	assert.NilError(t, err, "failed to call GetFS() on module")

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -69,22 +69,6 @@ type ServiceManifest struct {
 	Replacements map[string]string `yaml:"replacements,omitempty"`
 }
 
-// TemplateRepositoryType specifies what type of a template
-// repository a repository is.
-type TemplateRepositoryType string
-
-// This block contains all of the TemplateRepositoryType values
-const (
-	// TemplateRepositoryTypeExt denotes a repository as being
-	// an extension repository. This means that it contains
-	// a go extension. This repository may also contain go-templates.
-	TemplateRepositoryTypeExt TemplateRepositoryType = "extension"
-
-	// TemplateRepositoryTypeStd denotes a repository as being a
-	// standard template repository. This is the default
-	TemplateRepositoryTypeStd TemplateRepositoryType = ""
-)
-
 // TemplateRepository is a repository of template files.
 type TemplateRepository struct {
 	// Name is the name of this module. This should be a valid go import path
@@ -112,8 +96,9 @@ type TemplateRepositoryManifest struct {
 	// Modules are template repositories that this manifest requires
 	Modules []*TemplateRepository `yaml:"modules"`
 
-	// Type is the type of repository this is
-	Type TemplateRepositoryType `yaml:"type,omitempty"`
+	// Type stores a comma-separated list of template repository types served by the current module.
+	// Use the TemplateRepositoryTypes.Contains method to check.
+	Type TemplateRepositoryTypes `yaml:"type,omitempty"`
 
 	// PostRunCommand is a command to be ran after rendering and post-processors
 	// have been ran on the project

--- a/pkg/configuration/type.go
+++ b/pkg/configuration/type.go
@@ -1,0 +1,83 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+// Description: types of stencil repos
+
+package configuration
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TemplateRepositoryType specifies what type of a stencil repository the current one is.
+type TemplateRepositoryType string
+
+// This block contains all of the TemplateRepositoryType values
+const (
+	// TemplateRepositoryTypeExt denotes a repository as being
+	// an extension repository. This means that it contains
+	// a go extension. This repository may also contain go-templates if
+	// this type is used together with the TemplateRepositoryTypeTemplates.
+	TemplateRepositoryTypeExt TemplateRepositoryType = "extension"
+
+	// TemplateRepositoryTypeTemplates denotes a repository as being a standard template repository.
+	// When the same module/repo serves more than one type, join this explicit value with other
+	// types, e.g. "templates,extension".
+	TemplateRepositoryTypeTemplates TemplateRepositoryType = "templates"
+)
+
+// TemplateRepositoryTypes specifies what type of a stencil repository the current one is.
+// Use Contains to check for a type - it has special handling for the default case.
+// Even though it is a struct, it is marshalled and unmarshalled as a string with comma separated
+// values of TemplateRepositoryType.
+type TemplateRepositoryTypes struct {
+	types []TemplateRepositoryType
+}
+
+// MarshalYAML marshals TemplateRepositoryTypes as a string with comma-separated values.
+func (ts TemplateRepositoryTypes) MarshalYAML() (interface{}, error) {
+	var csv []string
+	for _, t := range ts.types {
+		csv = append(csv, string(t))
+	}
+	return strings.Join(csv, ","), nil
+}
+
+// UnmarshalYAML unmarshals TemplateRepositoryTypes from a string with comma-separated values.
+func (ts *TemplateRepositoryTypes) UnmarshalYAML(value *yaml.Node) error {
+	var csv string
+	if err := value.Decode(&csv); err != nil {
+		return err
+	}
+
+	if csv == "" {
+		// empty type defaults to templates only (we do not support repos with no purpose)
+		// leave the slice empty for a consistent unmarshal/marshal roundtrip
+		ts.types = nil
+		return nil
+	}
+
+	items := strings.Split(csv, ",")
+	types := []TemplateRepositoryType{}
+	for _, i := range items {
+		types = append(types, TemplateRepositoryType(i))
+	}
+	ts.types = types
+	return nil
+}
+
+// Contains returns true if current repo needs to serve inpt type, with default assumed
+// to be a templates-only repo (we do not support repos with no purpose).
+func (ts TemplateRepositoryTypes) Contains(t TemplateRepositoryType) bool {
+	if len(ts.types) == 0 {
+		// empty types defaults to templates only (we do not support repos with no purpose)
+		return t == TemplateRepositoryTypeTemplates
+	}
+	for _, ti := range ts.types {
+		if ti == t {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/configuration/type_test.go
+++ b/pkg/configuration/type_test.go
@@ -1,0 +1,74 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+// Description: This file contains tests for the configuration pac
+
+package configuration_test
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+	"gotest.tools/v3/assert"
+
+	"github.com/getoutreach/stencil/pkg/configuration"
+)
+
+func TestTemplateRepositoryType(t *testing.T) {
+	assert.NilError(t, nil)
+	tests := []struct {
+		Name           string
+		In             string
+		Contains       []configuration.TemplateRepositoryType
+		DoesNotContain []configuration.TemplateRepositoryType
+	}{
+		{
+			Name:           "empty",
+			In:             "",
+			Contains:       []configuration.TemplateRepositoryType{configuration.TemplateRepositoryTypeTemplates},
+			DoesNotContain: []configuration.TemplateRepositoryType{configuration.TemplateRepositoryTypeExt},
+		},
+		{
+			Name:           "templates",
+			In:             "templates",
+			Contains:       []configuration.TemplateRepositoryType{configuration.TemplateRepositoryTypeTemplates},
+			DoesNotContain: []configuration.TemplateRepositoryType{configuration.TemplateRepositoryTypeExt},
+		},
+		{
+			Name:           "extension",
+			In:             "extension",
+			Contains:       []configuration.TemplateRepositoryType{configuration.TemplateRepositoryTypeExt},
+			DoesNotContain: []configuration.TemplateRepositoryType{configuration.TemplateRepositoryTypeTemplates},
+		},
+		{
+			Name: "both",
+			In:   "extension,templates",
+			Contains: []configuration.TemplateRepositoryType{
+				configuration.TemplateRepositoryTypeExt,
+				configuration.TemplateRepositoryTypeTemplates,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test // for the parallel closure
+		t.Run(test.Name, func(t *testing.T) {
+			//t.Parallel()
+			var ts configuration.TemplateRepositoryTypes
+			err := yaml.Unmarshal([]byte(test.In), &ts)
+			assert.NilError(t, err)
+			for _, typ := range test.Contains {
+				assert.Assert(t, ts.Contains(typ))
+			}
+			for _, typ := range test.DoesNotContain {
+				assert.Assert(t, !ts.Contains(typ))
+			}
+			// rountrip marshal
+			b, err := ts.MarshalYAML()
+			assert.NilError(t, err)
+			s, isString := b.(string)
+
+			assert.Equal(t, true, isString)
+			assert.Equal(t, test.In, s, "roundtrip marshal failed")
+		})
+	}
+}

--- a/pkg/extensions/apiv1/apiv1.go
+++ b/pkg/extensions/apiv1/apiv1.go
@@ -12,6 +12,7 @@ import "encoding/gob"
 // init registers known types
 func init() { //nolint:gochecknoinits // Why: see comment
 	gob.Register([]interface{}{})
+	gob.Register(map[string]interface{}{})
 }
 
 // This block contains the constants for the go-plugin

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -134,6 +134,13 @@ func (h *Host) RegisterExtension(ctx context.Context, source, name, version stri
 	return nil
 }
 
+// RegisterInprocExtension registers an extension that is implemented within the same process
+// directly with the host. Please limit the use of this API for unit testing only!
+func (h *Host) RegisterInprocExtension(name string, ext apiv1.Implementation) {
+	h.log.WithField("extension", name).Debug("Registered inproc extension")
+	h.extensions[name] = ext
+}
+
 // getExtensionPath returns the path to an extension binary
 func (h *Host) getExtensionPath(version, name, repo string) string {
 	homeDir, _ := os.UserHomeDir() //nolint:errcheck // Why: signature doesn't allow it, yet

--- a/pkg/stenciltest/inproc_ext.go
+++ b/pkg/stenciltest/inproc_ext.go
@@ -1,0 +1,60 @@
+package stenciltest
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/getoutreach/stencil/pkg/extensions/apiv1"
+	"github.com/pkg/errors"
+)
+
+// inprocExt wraps test-provided implementation and 'simulates' the transport layer between
+// the template and the target extension. This is done to ensure that ALL responses from the
+// extension are undergoing same JSON-based encoding and decoding logic.
+//
+// Reason: assume the test uses real extension implementation in order to test in-repo extension
+// and this extension returns some 'local struct' as a response to ExecTemplateFunction call. When
+// this plugin is invoked by stencil, the GRPC transport layers of the stencil and the plugin
+// convert the result struct to JSON and then back as a generic interface{} that consists of
+// either primitives or map[string]interface{} or []interface[], losing the original type info.
+//
+// If we do not wrap here, type-specific 'plugin structs' are fed directly into the Go template,
+// making their fields and methods available to the template. Since the JSON layer is missing,
+// things may work 'nicely' in a unit test, but completely break when invoked with the transport
+// from multiple reasons: 'methods' are lost, JSON marshalling can fail, JSON field names can be
+// different if json tags are set on the struct, and many more.
+type inprocExt struct {
+	ext apiv1.Implementation
+}
+
+// GetConfig delegates the call as is
+func (e inprocExt) GetConfig() (*apiv1.Config, error) {
+	return e.ext.GetConfig()
+}
+
+// GetTemplateFunctions delegates the calls as is
+func (e inprocExt) GetTemplateFunctions() ([]*apiv1.TemplateFunction, error) {
+	return e.ext.GetTemplateFunctions()
+}
+
+// ExecuteTemplateFunction executes a provided template function on the target, JSONifies
+// its response and then decodes the result JSON bytes as a plain interface{}, losing the
+// source type. See docs on inprocExt for a reason.
+func (e inprocExt) ExecuteTemplateFunction(t *apiv1.TemplateFunctionExec) (interface{}, error) {
+	resp, err := e.ext.ExecuteTemplateFunction(t)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode extension response: %w", err)
+	}
+
+	var respVal interface{}
+	if err := json.Unmarshal(b, &respVal); err != nil {
+		return nil, errors.Wrap(err, "failed to decode etension response back into a generic interface")
+	}
+
+	return respVal, nil
+}

--- a/pkg/stenciltest/stenciltest.go
+++ b/pkg/stenciltest/stenciltest.go
@@ -154,8 +154,7 @@ func (t *Template) Run(save bool) {
 					continue
 				}
 
-				// Create snapshots with .snapshot ext to keep them away from regular linters until we find a better way
-				// to invoke linters on these snapshots. See Jira below for extra details
+				// Create snapshots with a .snapshot ext to keep them away from linters, see Jira for more details.
 				// TODO(jaredallard)[DTSS-2086]: figure out what to do with the snapshot codegen.File directive
 				snapshotName := f.Name() + ".snapshot"
 				success := got.Run(snapshotName, func(got *testing.T) {

--- a/pkg/stenciltest/stenciltest.go
+++ b/pkg/stenciltest/stenciltest.go
@@ -95,8 +95,12 @@ func (t *Template) Args(args map[string]interface{}) *Template {
 // It is up to the unit test to provide each extension used by their template with this API.
 // Unit tests can decide if they can use the real implementation of the extension AS IS or if a
 // mock extension is needed to feed fake data per test case.
+//
+// Note: even though input extension is registered inproc, its response to ExecuteTemplateFunction
+// will be encoded as JSON and decoded back as a plain inteface{} to simulate the GRPC transport
+// layer between stencil and the same extension. Refer to the inprocExt struct docs for details.
 func (t *Template) Ext(name string, ext apiv1.Implementation) *Template {
-	t.exts[name] = ext
+	t.exts[name] = inprocExt{ext: ext}
 	return t
 }
 

--- a/pkg/stenciltest/stenciltest.go
+++ b/pkg/stenciltest/stenciltest.go
@@ -154,7 +154,11 @@ func (t *Template) Run(save bool) {
 					continue
 				}
 
-				success := got.Run(f.Name(), func(got *testing.T) {
+				// Create snapshots with .snapshot ext to keep them away from regular linters until we find a better way
+				// to invoke linters on these snapshots. See Jira below for extra details
+				// TODO(jaredallard)[DTSS-2086]: figure out what to do with the snapshot codegen.File directive
+				snapshotName := f.Name() + ".snapshot"
+				success := got.Run(snapshotName, func(got *testing.T) {
 					snapshot := cupaloy.New(cupaloy.ShouldUpdate(func() bool { return save }), cupaloy.CreateNewAutomatically(true))
 					snapshot.SnapshotT(got, f)
 				})


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
With smartstore and clerk repos, we would love to have stencil support a repo with both templates and plugin (extension) colocated together (otherwise we need stencil-smartstore and stencil-smartstore-ext and it would be really annoying to maintain them separately).

This PR includes:
* [BREAKING] intro new TemplateRepositoryTypes and replace the stencil module type from a plain string to  TemplateRepositoryTypes
* add MarshalYAML/UnmarshalYAML for the new TemplateRepositoryTypes to treat the in/out as plain string.
* [BREAKING] remove TemplateRepositoryTypeStd - leaving it as empty and as an equivalent of "templates" will be terribly confusing people, I added TemplateRepositoryTypeTemplates instead
* unit tests

Also tested in orchestration with bootstrap + stencil-smartstore PR pending here: https://github.com/getoutreach/stencil-smartstore/pull/1
<!--- Block(jiraPrefix) --->

## Jira ID

[QSS-1119]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[QSS-1119]: https://outreach-io.atlassian.net/browse/QSS-1119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ