### PR TITLE
fix: make sure stenciltest.Run shows all bad templates or templates with outdated snapshot in one run

### DIFF
--- a/pkg/stenciltest/stenciltest.go
+++ b/pkg/stenciltest/stenciltest.go
@@ -157,13 +157,11 @@ func (t *Template) Run(save bool) {
 				// Create snapshots with a .snapshot ext to keep them away from linters, see Jira for more details.
 				// TODO(jaredallard)[DTSS-2086]: figure out what to do with the snapshot codegen.File directive
 				snapshotName := f.Name() + ".snapshot"
-				success := got.Run(snapshotName, func(got *testing.T) {
+				// if a sub-test fails, it will report its own error, no need to check its success return
+				got.Run(snapshotName, func(got *testing.T) {
 					snapshot := cupaloy.New(cupaloy.ShouldUpdate(func() bool { return save }), cupaloy.CreateNewAutomatically(true))
 					snapshot.SnapshotT(got, f)
 				})
-				if !success {
-					got.Fatalf("Generated file %q did not match snapshot", f.Name())
-				}
 			}
 
 			// only ever process one template

--- a/pkg/stenciltest/stenciltest.go
+++ b/pkg/stenciltest/stenciltest.go
@@ -157,7 +157,10 @@ func (t *Template) Run(save bool) {
 				// Create snapshots with a .snapshot ext to keep them away from linters, see Jira for more details.
 				// TODO(jaredallard)[DTSS-2086]: figure out what to do with the snapshot codegen.File directive
 				snapshotName := f.Name() + ".snapshot"
-				// if a sub-test fails, it will report its own error, no need to check its success return
+				// Run each template file as a sub-test, if the sub-test fails, it will report its own error.
+				// Even if one of the templates fail, we let the test continue - otherwise devs need to go thru
+				// 'onion peeling' excercise to create a bulk of new snapshots or re-run test multiple times to
+				// reveal distinct errors for all the templates changed in one PR.
 				got.Run(snapshotName, func(got *testing.T) {
 					snapshot := cupaloy.New(cupaloy.ShouldUpdate(func() bool { return save }), cupaloy.CreateNewAutomatically(true))
 					snapshot.SnapshotT(got, f)


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
This PR allows stenciltest.Run to continue trying rest of the templates and avoid stopping if a single one of them fails. This is useful if test if the 'save' flag is true. This is useful if this test wants to generate a large bulk of snapshot files - in this case input arg will be true and we do not want to test to stop until all snapshots are generated. It is also useful when errors between templates are 'distinct' - devs run the test once and see all the sub-test errors in one shot.

<!--- Block(jiraPrefix) --->

## Jira ID

[DTSS-00]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
