### PR TITLE
feat: Add file.RemoveAll directive for templates

### DIFF
--- a/internal/codegen/tpl_file.go
+++ b/internal/codegen/tpl_file.go
@@ -141,3 +141,13 @@ func (f *TplFile) Create(path string, mode os.FileMode, modTime time.Time) error
 	f.t.Files = append(f.t.Files, f.f)
 	return nil
 }
+
+// RemoveAll deletes all the contents in the provided path
+//
+//   {{ file.RemoveAll }}
+func (f *TplFile) RemoveAll(path string) error {
+	if err := os.RemoveAll(path); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
Adds a file.RemoveAll directive to remove all files within the given path. This is needed so that stencil modules can delete all files if needed. This was supported by bootstrap and hence this change fixes the breaking feature.
```
{{- file.RemoveAll $path}}
```

<!--- Block(jiraPrefix) --->

## Jira ID

[DP-3732]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
I created a local `stencil` binary and ran on a test repo to verify the change.
<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DP-3732]: https://outreach-io.atlassian.net/browse/DP-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ