### PR TITLE
fix: bubble up tpl function errors

### DIFF
--- a/internal/codegen/tpl_file.go
+++ b/internal/codegen/tpl_file.go
@@ -55,8 +55,9 @@ func (f *TplFile) Block(name string) string {
 //
 // Note: The $_ is required to ensure <nil> isn't outputted into
 // the template.
-func (f *TplFile) SetPath(path string) error {
-	return f.f.SetPath(path)
+func (f *TplFile) SetPath(path string) (out, err error) {
+	err = f.f.SetPath(path)
+	return err, err
 }
 
 // SetContents sets the contents of file being rendered to the value
@@ -94,13 +95,14 @@ func (f *TplFile) Delete() error {
 // the file in the future.
 //
 //   {{ $_ := file.Static }}
-func (f *TplFile) Static() error {
+func (f *TplFile) Static() (out, err error) {
 	// if the file already exists, skip it
 	if _, err := os.Stat(f.f.path); err == nil {
-		return f.Skip("Static file, output already exists")
+		err := f.Skip("Static file, output already exists")
+		return err, err
 	}
 
-	return nil
+	return nil, nil
 }
 
 // Path returns the current path of the file we're writing to
@@ -131,23 +133,22 @@ func (f *TplFile) Path() string {
 //   {{- file.Create (printf "cmd/%s.go" $commandName) 0600 now }}
 //   {{- stencil.ApplyTemplate "command" | file.SetContents }}
 //   {{- end }}
-func (f *TplFile) Create(path string, mode os.FileMode, modTime time.Time) error {
-	var err error
+func (f *TplFile) Create(path string, mode os.FileMode, modTime time.Time) (out, err error) {
 	f.f, err = NewFile(path, mode, modTime)
 	if err != nil {
-		return err
+		return err, err
 	}
 
 	f.t.Files = append(f.t.Files, f.f)
-	return nil
+	return nil, nil
 }
 
 // RemoveAll deletes all the contents in the provided path
 //
 //   {{ file.RemoveAll }}
-func (f *TplFile) RemoveAll(path string) error {
+func (f *TplFile) RemoveAll(path string) (out, err error) {
 	if err := os.RemoveAll(path); err != nil {
-		return err
+		return err, err
 	}
-	return nil
+	return nil, nil
 }

--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -65,10 +65,10 @@ func (s *TplStencil) GetModuleHook(name string) []interface{} {
 //
 //   {{- /* This writes to a module hook */}}
 //   {{ stencil.AddToModuleHook "github.com/myorg/repo" "myModuleHook" (list "myData") }}
-func (s *TplStencil) AddToModuleHook(module, name string, data interface{}) error {
+func (s *TplStencil) AddToModuleHook(module, name string, data interface{}) (out, err error) {
 	// Only modify on first pass
 	if !s.s.isFirstPass {
-		return nil
+		return nil, nil
 	}
 
 	// key is <module>/<name>
@@ -78,13 +78,15 @@ func (s *TplStencil) AddToModuleHook(module, name string, data interface{}) erro
 
 	v := reflect.ValueOf(data)
 	if !v.IsValid() {
-		return fmt.Errorf("third parameter, data, must be set")
+		err := fmt.Errorf("third parameter, data, must be set")
+		return err, err
 	}
 
 	// we only allow slices or maps to allow multiple templates to
 	// write to the same block
 	if v.Kind() != reflect.Slice {
-		return fmt.Errorf("unsupported module block data type %q, supported type is slice", v.Kind())
+		err := fmt.Errorf("unsupported module block data type %q, supported type is slice", v.Kind())
+		return err, err
 	}
 
 	// convert the slice into a []interface{}
@@ -100,7 +102,7 @@ func (s *TplStencil) AddToModuleHook(module, name string, data interface{}) erro
 		s.s.sharedData[k] = interfaceSlice
 	}
 
-	return nil
+	return nil, nil
 }
 
 // Arg returns the value of an argument in the service's manifest


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

Custom template function will only raise their error correctly they return two arguments, the second of which being an error. This PR makes sure all our custom function that return an error return two arguments so the second one can raise the correct error.

<!--- Block(jiraPrefix) --->

## Jira ID

[DTSS-1817]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

New error for missing start block:

```
ERRO[0005] failed to run: run codegen: failed to render template 1 "github.com/getoutreach/stencil-golang/cmd/main_cli.go.tpl": template: github.com/getoutreach/stencil-golang/cmd/main_cli.go.tpl:87:7: executing "github.com/getoutreach/stencil-golang/cmd/main_cli.go.tpl" at <file.Create>: error calling Create: invalid EndBlock when not inside of a block, at cmd/polaroid-cli/polaroid-cli.go:17
ERRO[0009] failed to run: failed to run stencil: exit status 1
```

Old error for missing start block:

```
time="2022-05-17T17:36:04-07:00" level=error msg="failed to run: run codegen: failed to render template \"[github.com/getoutreach/stencil-golang/cmd/main_cli.go.tpl:23:7|http://github.com/getoutreach/stencil-golang/cmd/main_cli.go.tpl\|github.com/getoutreach/stencil-golang/cmd/main_cli.go.tpl\>": template: <http://github.com/getoutreach/stencil-golang/cmd/main_cli.go.tpl:89:28|github.com/getoutreach/stencil-golang/cmd/main_cli.go.tpl:89:28>: executing \"<http://github.com/getoutreach/stencil-golang/cmd/main_cli.go.tpl\|github.com/getoutreach/stencil-golang/cmd/main_cli.go.tpl\>" at [stencil.ApplyTemplate]: error calling ApplyTemplate: template: <http://github.com/getoutreach/stencil-golang/cmd/main_cli.go.tpl:23:7]: executing \"main-cli\" at [file.Block]: error calling Block: runtime error: invalid memory address or nil pointer dereference"
```

<!--- EndBlock(custom) -->


[DTSS-1817]: https://outreach-io.atlassian.net/browse/DTSS-1817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ