### PR TITLE
fix: allow digits in block name

### DIFF
--- a/internal/codegen/blocks.go
+++ b/internal/codegen/blocks.go
@@ -15,7 +15,7 @@ import (
 
 // blockPattern is the regex used for parsing block commands.
 // For unit testing of this regex and explanation, see https://regex101.com/r/nFgOz0/1
-var blockPattern = regexp.MustCompile(`^\s*(///|###|<!---)\s*([a-zA-Z ]+)\(([a-zA-Z ]+)\)`)
+var blockPattern = regexp.MustCompile(`^\s*(///|###|<!---)\s*([a-zA-Z ]+)\(([a-zA-Z0-9 ]+)\)`)
 
 // parseBlocks reads the blocks from an existing file
 func parseBlocks(filePath string) (map[string]string, error) {

--- a/internal/codegen/blocks_test.go
+++ b/internal/codegen/blocks_test.go
@@ -14,6 +14,7 @@ func TestParseBlocks(t *testing.T) {
 	blocks, err := parseBlocks("testdata/blocks-test.txt")
 	assert.NilError(t, err, "expected parseBlocks() not to fail")
 	assert.Equal(t, blocks["helloWorld"], "Hello, world!", "expected parseBlocks() to parse basic block")
+	assert.Equal(t, blocks["e2e"], "content", "expected parseBlocks() to parse e2e block")
 }
 
 func TestDanglingBlock(t *testing.T) {

--- a/internal/codegen/testdata/blocks-test.txt
+++ b/internal/codegen/testdata/blocks-test.txt
@@ -1,3 +1,7 @@
 ###Block(helloWorld)
 Hello, world!
 ###EndBlock(helloWorld)
+
+###Block(e2e)
+content
+###EndBlock(e2e)


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

We added block `circleE2EExtra` in stencil-circleci [some time ago](https://github.com/getoutreach/stencil-circleci/pull/13) but it is not working because the block name includes digit which is not matched as valid block name by stencil. This PR introduces digits in block names.

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2042]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2042]: https://outreach-io.atlassian.net/browse/DT-2042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ