### PR TITLE
feat(arguments): support from to alias to another module's argument

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,5 +3,4 @@
 *.md
 
 ###Block(prettierignoreExtras)
-
 ###EndBlock(prettierignoreExtras)

--- a/docs/content/en/commands/stencil.md
+++ b/docs/content/en/commands/stencil.md
@@ -19,24 +19,28 @@ USAGE:
    stencil [global options] command [command options] [arguments...]
 
 VERSION:
-   v1.15.1
+   v1.24.0
 
 DESCRIPTION:
    a smart templating engine for service development
 
 COMMANDS:
-   describe
-   create
+   describe  
+   create    
+   docs      
+   updater   Commands for interacting with the built-in updater
    help, h   Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --dry-run, --dryrun   Don't write files to disk (default: false)
-   --frozen-lockfile     Use versions from the lockfile instead of the latest (default: false)
-   --skip-update         skips the updater check (default: false)
-   --debug               enables debug logging for all components (i.e updater) (default: false)
-   --enable-prereleases  Enable considering pre-releases when checking for updates (default: false)
-   --force-update-check  Force checking for an update (default: false)
-   --help, -h            show help (default: false)
-   --version, -v         print the version (default: false)
+   --dry-run, --dryrun             Don't write files to disk (default: false)
+   --frozen-lockfile               Use versions from the lockfile instead of the latest (default: false)
+   --use-prerelease                Use prerelease versions of stencil modules (default: false)
+   --allow-major-version-upgrades  Allow major version upgrades without confirmation (default: false)
+   --skip-update                   skips the updater check (default: false)
+   --debug                         enables debug logging for all components that use logrus (default: false)
+   --enable-prereleases            Enable considering pre-releases when checking for updates (default: false)
+   --force-update-check            Force checking for an update (default: false)
+   --help, -h                      show help (default: false)
+   --version, -v                   print the version (default: false)
 
 ```

--- a/docs/content/en/commands/stencil_create.md
+++ b/docs/content/en/commands/stencil_create.md
@@ -22,11 +22,11 @@ DESCRIPTION:
    Commands to create template repositories, or stencil powered repositories
 
 COMMANDS:
-   module, templaterepository
+   module, templaterepository  
    help, h                     Shows a list of commands or help for one command
 
 OPTIONS:
    --help, -h  show help (default: false)
-
+   
 
 ```

--- a/docs/content/en/commands/stencil_create_module.md
+++ b/docs/content/en/commands/stencil_create_module.md
@@ -13,7 +13,7 @@ menu:
 
 ```bash
 NAME:
-   stencil create module -
+   stencil create module - 
 
 USAGE:
    stencil create module [command options] create module <name>
@@ -24,6 +24,6 @@ DESCRIPTION:
 OPTIONS:
    --native-extension  Generates a native extension (default: false)
    --help, -h          show help (default: false)
-
+   
 
 ```

--- a/docs/content/en/commands/stencil_describe.md
+++ b/docs/content/en/commands/stencil_describe.md
@@ -13,7 +13,7 @@ menu:
 
 ```bash
 NAME:
-   stencil describe -
+   stencil describe - 
 
 USAGE:
    stencil describe [command options] [arguments...]
@@ -23,6 +23,6 @@ DESCRIPTION:
 
 OPTIONS:
    --help, -h  show help (default: false)
-
+   
 
 ```

--- a/docs/content/en/functions/file.Block.md
+++ b/docs/content/en/functions/file.Block.md
@@ -10,6 +10,7 @@ menu:
     parent: "functions"
 ---
 
+
 ```go-text-template
 ###Block(name)
 Hello, world!
@@ -27,3 +28,5 @@ Hello, world!
 {{ file.Block "name" }}
 ###EndBlock(name)
 ```
+
+

--- a/docs/content/en/functions/file.Create.md
+++ b/docs/content/en/functions/file.Create.md
@@ -10,7 +10,9 @@ menu:
     parent: "functions"
 ---
 
+
 If the template has a single file with no contents this file replaces it\.
+
 
 ```go-text-template
 {{- define "command" }}
@@ -30,3 +32,5 @@ func main() {
 {{- stencil.ApplyTemplate "command" | file.SetContents }}
 {{- end }}
 ```
+
+

--- a/docs/content/en/functions/file.Delete.md
+++ b/docs/content/en/functions/file.Delete.md
@@ -10,6 +10,9 @@ menu:
     parent: "functions"
 ---
 
+
 ```go-text-template
 {{ file.Delete }}
 ```
+
+

--- a/docs/content/en/functions/file.Path.md
+++ b/docs/content/en/functions/file.Path.md
@@ -10,6 +10,9 @@ menu:
     parent: "functions"
 ---
 
+
 ```go-text-template
 {{ file.Path }}
 ```
+
+

--- a/docs/content/en/functions/file.SetContents.md
+++ b/docs/content/en/functions/file.SetContents.md
@@ -10,8 +10,12 @@ menu:
     parent: "functions"
 ---
 
+
 This is useful for programmatic file generation within a template\.
+
 
 ```go-text-template
 {{ file.SetContents "Hello, world!" }}
 ```
+
+

--- a/docs/content/en/functions/file.SetPath.md
+++ b/docs/content/en/functions/file.SetPath.md
@@ -10,8 +10,12 @@ menu:
     parent: "functions"
 ---
 
+
 ```go-text-template
 {{ $_ := file.SetPath "new/path/to/file.txt" }}
 ```
 
+
 Note: The $\_ is required to ensure \<nil\> isn't outputted into the template\.
+
+

--- a/docs/content/en/functions/file.Skip.md
+++ b/docs/content/en/functions/file.Skip.md
@@ -10,6 +10,9 @@ menu:
     parent: "functions"
 ---
 
+
 ```go-text-template
 {{ $_ := file.Skip "A reason to skip this reason" }}
 ```
+
+

--- a/docs/content/en/functions/file.Static.md
+++ b/docs/content/en/functions/file.Static.md
@@ -10,8 +10,12 @@ menu:
     parent: "functions"
 ---
 
+
 Marking a file is equivalent to calling file\.Skip\, but instead file\.Skip is only called if the file already exists\. This is useful for files you want to generate but only once\. It's generally recommended that you do not do this as it limits your ability to change the file in the future\.
+
 
 ```go-text-template
 {{ $_ := file.Static }}
 ```
+
+

--- a/docs/content/en/functions/stencil.AddToModuleHook.md
+++ b/docs/content/en/functions/stencil.AddToModuleHook.md
@@ -10,9 +10,13 @@ menu:
     parent: "functions"
 ---
 
+
 This functions write to module hook owned by another module for it to operate on\. These are not strongly typed so it's best practice to look at how the owning module uses it for now\. Module hooks must always be written to with a list to ensure that they can always be written to multiple times\.
+
 
 ```go-text-template
 {{- /* This writes to a module hook */}}
 {{ stencil.AddToModuleHook "github.com/myorg/repo" "myModuleHook" (list "myData") }}
 ```
+
+

--- a/docs/content/en/functions/stencil.ApplyTemplate.md
+++ b/docs/content/en/functions/stencil.ApplyTemplate.md
@@ -10,7 +10,9 @@ menu:
     parent: "functions"
 ---
 
+
 This function does not support rendering a template from another module\.
+
 
 ```go-text-template
 {{- define "command"}}
@@ -26,3 +28,5 @@ func main() {
 
 {{- stencil.ApplyTemplate "command" | file.SetContents }}
 ```
+
+

--- a/docs/content/en/functions/stencil.Arg.md
+++ b/docs/content/en/functions/stencil.Arg.md
@@ -10,6 +10,12 @@ menu:
     parent: "functions"
 ---
 
+
 ```go-text-template
 {{- stencil.Arg "name" }}
 ```
+
+
+Note: Using \`stencil\.Arg\` with no path returns all arguments and is equivalent to \`stencil\.Args\`\. However\, that is DEPRECATED along with \`stencil\.Args\` as it doesn't provide default types\, or check the JSON schema\, or track which module calls what argument\.
+
+

--- a/docs/content/en/functions/stencil.Args.md
+++ b/docs/content/en/functions/stencil.Args.md
@@ -2,7 +2,7 @@
 title: stencil.Args
 linktitle: stencil.Args
 description: >
-  Args returns all arguments passed to stencil from the service's manifest
+  
 date: 2022-05-18
 categories: [functions]
 menu:
@@ -10,8 +10,17 @@ menu:
     parent: "functions"
 ---
 
+Deprecated: Use Arg instead\. Args returns all arguments passed to stencil from the service's manifest
+
+
 Note: This doesn't set default values and is instead representative of \_all\_ data passed in its raw form\.
+
+
+This is deprecated and will be removed in a future release\.
+
 
 ```go-text-template
 {{- (stencil.Args).name }}
 ```
+
+

--- a/docs/content/en/functions/stencil.GetModuleHook.md
+++ b/docs/content/en/functions/stencil.GetModuleHook.md
@@ -10,7 +10,9 @@ menu:
     parent: "functions"
 ---
 
+
 This is incredibly useful for allowing other modules to write to files that your module owns\. Think of them as extension points for your module\. The value returned by this function is always a \[\]interface\{\}\, aka a list\.
+
 
 ```go-text-template
 {{- /* This returns a []interface{} */}}
@@ -19,3 +21,5 @@ This is incredibly useful for allowing other modules to write to files that your
   {{ . }}
 {{- end }}
 ```
+
+

--- a/docs/content/en/functions/stencil.ReadFile.md
+++ b/docs/content/en/functions/stencil.ReadFile.md
@@ -10,6 +10,9 @@ menu:
     parent: "functions"
 ---
 
+
 ```go-text-template
 {{ stencil.ReadFile "myfile.txt" }}
 ```
+
+

--- a/docs/content/en/reference/template-module.md
+++ b/docs/content/en/reference/template-module.md
@@ -55,6 +55,7 @@ The important keys that a module has are listed below, but an exhaustive list ca
   - `schema` - a JSON schema for the argument
   - `required` - whether or not the argument is required to be set
   - `default` - a default value for the argument, cannot be set when required is true
+	- `from` - aliases this argument to another module's argument. Only supports one-level deep.
 
 #### Writing a JSON Schema
 
@@ -80,6 +81,29 @@ type: array
 items:
 	type: string
 ```
+
+#### Aliasing an argument with `from`
+
+Aliasing an argument allows you to reference another argument from within the module. For example, if you have an argument called `description` and you want to alias it to another argument called from the module `github.com/getoutreach/stencil-base`, you can do so like so:
+
+```yaml
+# your module
+arguments:
+	description:
+		from: github.com/getoutreach/stencil-base
+
+# github.com/getoutreach/stencil-base
+arguments:
+	description:
+		schema:
+			type: string
+```
+
+There's a few limitations with aliasing arguments:
+
+ * Aliasing an argument to another argument that is itself aliased is not allowed.
+ * When `from` is used, no other properties on the argument being aliased can be set.
+ * When aliasing to a module, that module _must_ be listed in the `modules` key of the module aliasing the argument.
 
 ## Module Hooks
 

--- a/docs/content/en/reference/template-module.md
+++ b/docs/content/en/reference/template-module.md
@@ -55,7 +55,7 @@ The important keys that a module has are listed below, but an exhaustive list ca
   - `schema` - a JSON schema for the argument
   - `required` - whether or not the argument is required to be set
   - `default` - a default value for the argument, cannot be set when required is true
-	- `from` - aliases this argument to another module's argument. Only supports one-level deep.
+  - `from` - aliases this argument to another module's argument. Only supports one-level deep.
 
 #### Writing a JSON Schema
 

--- a/docs/gen/commands/main.go
+++ b/docs/gen/commands/main.go
@@ -8,7 +8,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -126,7 +125,7 @@ func generateMarkdown() ([]file, error) {
 // saveMarkdown writes the markdown files to disk.
 func saveMarkdown(files []file) error {
 	for _, f := range files {
-		if err := ioutil.WriteFile(filepath.Join("content", "en", "commands", f.Name+".md"), []byte(f.Contents), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join("content", "en", "commands", f.Name+".md"), []byte(f.Contents), 0644); err != nil {
 			return err
 		}
 	}

--- a/docs/gen/commands/main.go
+++ b/docs/gen/commands/main.go
@@ -73,7 +73,6 @@ func generateMarkdown() ([]file, error) {
 			}
 
 			if parsingCommands {
-
 				//   describe, d -> describe
 				command := strings.Split(strings.TrimSpace(strings.Split(line, ",")[0]), " ")[0]
 
@@ -83,7 +82,9 @@ func generateMarkdown() ([]file, error) {
 				}
 
 				// args + new command
-				newArgs := append(args, command)
+				newArgs := make([]string, len(args)+1)
+				copy(newArgs, args)
+				newArgs[len(newArgs)-1] = command
 				fmt.Println("Discovered command:", strings.Join(newArgs, " "))
 				commands = append(commands, newArgs)
 			}

--- a/docs/gen/commands/main.go
+++ b/docs/gen/commands/main.go
@@ -75,7 +75,7 @@ func generateMarkdown() ([]file, error) {
 			if parsingCommands {
 
 				//   describe, d -> describe
-				command := strings.TrimSpace(strings.Split(line, ",")[0])
+				command := strings.Split(strings.TrimSpace(strings.Split(line, ",")[0]), " ")[0]
 
 				// skip the help command because it results in duplicates
 				if command == "help" {

--- a/docs/gen/functions/main.go
+++ b/docs/gen/functions/main.go
@@ -8,7 +8,6 @@ package main
 import (
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,7 +77,7 @@ func generateMarkdown() ([]file, error) {
 // saveMarkdown writes the markdown files to disk.
 func saveMarkdown(files []file) error {
 	for _, f := range files {
-		if err := ioutil.WriteFile(filepath.Join("content", "en", "functions", f.Name+".md"), []byte(f.Contents), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join("content", "en", "functions", f.Name+".md"), []byte(f.Contents), 0644); err != nil {
 			return err
 		}
 	}

--- a/internal/codegen/stencil_test.go
+++ b/internal/codegen/stencil_test.go
@@ -69,11 +69,11 @@ func TestModuleHookRender(t *testing.T) {
 	ctx := context.Background()
 
 	// create modules
-	m1, err := modulestest.NewModuleFromTemplates(nil, "testing1", "testdata/module-hook/m1.tpl")
+	m1, err := modulestest.NewModuleFromTemplates(nil, "testing1", nil, "testdata/module-hook/m1.tpl")
 	if err != nil {
 		t.Errorf("failed to create module 1: %v", err)
 	}
-	m2, err := modulestest.NewModuleFromTemplates(nil, "testing2", "testdata/module-hook/m2.tpl")
+	m2, err := modulestest.NewModuleFromTemplates(nil, "testing2", nil, "testdata/module-hook/m2.tpl")
 	if err != nil {
 		t.Errorf("failed to create module 2: %v", err)
 	}

--- a/internal/codegen/tpl_file.go
+++ b/internal/codegen/tpl_file.go
@@ -145,7 +145,7 @@ func (f *TplFile) Create(path string, mode os.FileMode, modTime time.Time) (out,
 
 // RemoveAll deletes all the contents in the provided path
 //
-//	{{ file.RemoveAll }}
+//	{{ file.RemoveAll "path" }}
 func (f *TplFile) RemoveAll(path string) (out, err error) {
 	if err := os.RemoveAll(path); err != nil {
 		return err, err

--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -108,6 +108,8 @@ func (s *TplStencil) AddToModuleHook(module, name string, data interface{}) (out
 // Note: This doesn't set default values and is instead
 // representative of _all_ data passed in its raw form.
 //
+// This is deprecated and will be removed in a future release.
+//
 //	{{- (stencil.Args).name }}
 func (s *TplStencil) Args() map[string]interface{} {
 	return s.s.m.Arguments

--- a/internal/codegen/tpl_stencil_arg.go
+++ b/internal/codegen/tpl_stencil_arg.go
@@ -1,0 +1,222 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+// Description: This file contains the code for the stencil.Arg
+// template function.
+
+package codegen
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/getoutreach/stencil/internal/dotnotation"
+	"github.com/getoutreach/stencil/pkg/configuration"
+	"github.com/pkg/errors"
+	"github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// Arg returns the value of an argument in the service's manifest
+//
+//	{{- stencil.Arg "name" }}
+func (s *TplStencil) Arg(pth string) (interface{}, error) {
+	if pth == "" {
+		// Deprecated: Arg(pth) will be required in the future. See note on
+		// Args().
+		return s.Args(), nil
+	}
+
+	// This is a TODO because I don't know if template functions
+	// can even get a context passed to them
+	ctx := context.TODO()
+
+	mf, err := s.t.Module.Manifest(ctx)
+	if err != nil {
+		// In theory this should never happen because we've
+		// already parsed the manifest. But, just in case
+		// we handle this here.
+		return nil, err
+	}
+
+	if _, ok := mf.Arguments[pth]; !ok {
+		return "", fmt.Errorf("module %q doesn't list argument %q as an argument in its manifest", s.t.Module.Name, pth)
+	}
+	arg := mf.Arguments[pth]
+
+	// If there's a "from" we should handle that now before anything else,
+	// so that its definition is used.
+	if arg.From != "" {
+		fromArg, err := s.resolveFrom(ctx, pth, &arg)
+		if err != nil {
+			return "", err
+		}
+		// Guaranteed to not be nil
+		arg = *fromArg
+	}
+
+	mapInf := make(map[interface{}]interface{})
+	for k, v := range s.s.m.Arguments {
+		mapInf[k] = v
+	}
+
+	// if not set then we return a default value based on the denoted type
+	v, err := dotnotation.Get(mapInf, pth)
+	if err != nil {
+		v, err = s.resolveDefault(pth, &arg)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// validate the data
+	if arg.Schema != nil {
+		if err := s.validateArg(pth, &arg, v); err != nil {
+			return nil, err
+		}
+	}
+
+	return v, nil
+}
+
+// resolveDefault resolves the default value of an argument from the manifest
+func (s *TplStencil) resolveDefault(pth string, arg *configuration.Argument) (interface{}, error) {
+	if arg.Default != nil {
+		return arg.Default, nil
+	}
+
+	if arg.Required {
+		return nil, fmt.Errorf("module %q requires argument %q but is not set", s.t.Module.Name, pth)
+	}
+
+	// json schema convention is to define "type" as the top level key.
+	typ, ok := arg.Schema["type"]
+	if !ok {
+		// fallback to the deprecated arg.Type
+		typ = arg.Type //nolint:staticcheck // Why: Compat
+
+		// If arg.Type isn't set then we have no type information
+		// so return nothing. This is likely problematic so a linter
+		// should warn on this.
+		if arg.Type == "" { //nolint:staticcheck // Why: Compat
+			return nil, nil
+		}
+	}
+	typs, ok := typ.(string)
+	if !ok {
+		return nil, fmt.Errorf("module %q argument %q has invalid type: %v", s.t.Module.Name, pth, typ)
+	}
+
+	var v interface{}
+	switch typs {
+	case "map", "object":
+		v = make(map[interface{}]interface{})
+	case "list", "array":
+		v = []interface{}{}
+	case "boolean", "bool":
+		v = false
+	case "integer", "int", "number":
+		v = 0
+	case "string":
+		v = ""
+	default:
+		return "", fmt.Errorf("module %q argument %q has invalid type %q", s.t.Module.Name, pth, typs)
+	}
+
+	return v, nil
+}
+
+// resolveFrom resoles the "from" field of an argument
+func (s *TplStencil) resolveFrom(ctx context.Context, pth string, arg *configuration.Argument) (*configuration.Argument, error) {
+	foundModuleInDeps := false
+	ourMf, err := s.t.Module.Manifest(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure that the module imports the referenced module
+	for _, m := range ourMf.Modules {
+		if m.Name == arg.From {
+			foundModuleInDeps = true
+		}
+	}
+	if !foundModuleInDeps {
+		return nil, fmt.Errorf(
+			"module %q argument %q references an argument in module %q, but doesn't list it as a dependency",
+			s.t.Module.Name, pth, arg.From,
+		)
+	}
+
+	// Get the manifest for the referenced module
+	var fromMf *configuration.TemplateRepositoryManifest
+	for _, m := range s.s.modules {
+		if m.Name == arg.From {
+			mf, err := m.Manifest(ctx)
+			if err != nil {
+				return nil, err
+			}
+			fromMf = &mf
+
+			// Found the module, break
+			break
+		}
+	}
+	if fromMf == nil {
+		return nil, fmt.Errorf(
+			"module %q argument %q references an argument in module %q, but wasn't imported by stencil (this is a bug)",
+			s.t.Module.Name, pth, arg.From,
+		)
+	}
+
+	// Ensure that the module imported exposes that argument
+	fromArg, ok := fromMf.Arguments[pth]
+	if !ok {
+		return nil, fmt.Errorf(
+			"module %q argument %q references an argument in module %q, but the module does not expose that argument",
+			s.t.Module.Name, pth, arg.From,
+		)
+	}
+	return &fromArg, nil
+}
+
+// validateArg validates an argument against the schema
+func (s *TplStencil) validateArg(pth string, arg *configuration.Argument, v interface{}) error {
+	schemaBuf := new(bytes.Buffer)
+	if err := json.NewEncoder(schemaBuf).Encode(arg.Schema); err != nil {
+		return errors.Wrap(err, "failed to encode schema into JSON")
+	}
+
+	jsc := jsonschema.NewCompiler()
+	jsc.Draft = jsonschema.Draft2020
+
+	schemaURL := "manifest.yaml/arguments/" + pth
+	if err := jsc.AddResource(schemaURL, schemaBuf); err != nil {
+		return errors.Wrapf(err, "failed to add argument '%s' json schema to compiler", pth)
+	}
+
+	schema, err := jsc.Compile(schemaURL)
+	if err != nil {
+		return errors.Wrapf(err, "failed to compile argument '%s' schema", pth)
+	}
+
+	if err := schema.Validate(v); err != nil {
+		var validationError *jsonschema.ValidationError
+		if errors.As(err, &validationError) {
+			// If there's only one error, return it directly, otherwise
+			// return the full list of errors.
+			errs := validationError.DetailedOutput().Errors
+			out := ""
+			if len(errs) == 1 {
+				out = errs[0].Error
+			} else {
+				out = fmt.Sprintf("%#v", validationError.DetailedOutput().Errors)
+			}
+
+			return fmt.Errorf("module %q argument %q validation failed: %s", s.t.Module.Name, pth, out)
+		}
+
+		return errors.Wrapf(err, "module %q argument %q validation failed", s.t.Module.Name, pth)
+	}
+
+	return nil
+}

--- a/internal/codegen/tpl_stencil_arg.go
+++ b/internal/codegen/tpl_stencil_arg.go
@@ -20,10 +20,13 @@ import (
 // Arg returns the value of an argument in the service's manifest
 //
 //	{{- stencil.Arg "name" }}
+//
+// Note: Using `stencil.Arg` with no path returns all arguments
+// and is equivalent to `stencil.Args`. However, that is DEPRECATED
+// along with `stencil.Args` as it doesn't provide default types, or
+// check the JSON schema, or track which module calls what argument.
 func (s *TplStencil) Arg(pth string) (interface{}, error) {
 	if pth == "" {
-		// Deprecated: Arg(pth) will be required in the future. See note on
-		// Args().
 		return s.Args(), nil
 	}
 

--- a/internal/codegen/tpl_stencil_arg_test.go
+++ b/internal/codegen/tpl_stencil_arg_test.go
@@ -277,6 +277,33 @@ func TestTplStencil_Arg(t *testing.T) {
 			want:    "world",
 			wantErr: false,
 		},
+		{
+			name: "should support from schema fail",
+			fields: fakeTemplateMultipleModules(t,
+				map[string]interface{}{
+					"hello": "world",
+				},
+				// test-0
+				map[string]configuration.Argument{
+					"hello": {
+						From: "test-1",
+					},
+				},
+				// test-1
+				map[string]configuration.Argument{
+					"hello": {
+						Schema: map[string]interface{}{
+							"type": "number",
+						},
+					},
+				},
+			),
+			args: args{
+				pth: "hello",
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/codegen/tpl_stencil_arg_test.go
+++ b/internal/codegen/tpl_stencil_arg_test.go
@@ -7,6 +7,7 @@ package codegen
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -29,7 +30,7 @@ func fakeTemplate(t *testing.T, args map[string]interface{},
 	test := &testTpl{}
 	log := logrus.New()
 
-	m, err := modulestest.NewModuleFromTemplates(requestArgs, "test")
+	m, err := modulestest.NewModuleFromTemplates(requestArgs, "test", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,6 +52,60 @@ func fakeTemplate(t *testing.T, args map[string]interface{},
 		Arguments: args,
 		Modules:   []*configuration.TemplateRepository{{Name: m.Name}},
 	}, []*modules.Module{m}, log)
+
+	// use the first template from the module
+	// which we've created earlier after loading the module in the
+	// NewModuleFromTemplates call. This won't be used, but it's
+	// enough to set up the correct environment for running template test functions.
+	tpls, err := test.s.getTemplates(context.Background(), log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	test.t = tpls[0]
+
+	return test
+}
+
+// fakeTemplateMultipleModules returns a faked struct suitable for testing
+// that has multiple modules in the service manifest, the first arguments list
+// is for the first module, the second is for the second module, and so forth.
+// the first module will import all other modules
+func fakeTemplateMultipleModules(t *testing.T, serviceManifestArgs map[string]interface{},
+	args ...map[string]configuration.Argument) *testTpl {
+	test := &testTpl{}
+	log := logrus.New()
+
+	mods := make([]*modules.Module, len(args))
+	importList := []string{}
+	for i := range args {
+		if i == 0 {
+			continue
+		}
+
+		m, err := modulestest.NewModuleFromTemplates(args[i], fmt.Sprintf("test-%d", i), nil, "testdata/args/test.tpl")
+		if err != nil {
+			t.Fatal(err)
+		}
+		importList = append(importList, m.Name)
+		mods[i] = m
+	}
+
+	var err error
+	mods[0], err = modulestest.NewModuleFromTemplates(args[0], "test-0", importList, "testdata/args/test.tpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	moduleTr := make([]*configuration.TemplateRepository, len(mods))
+	for i := range mods {
+		moduleTr[i] = &configuration.TemplateRepository{Name: mods[i].Name}
+	}
+
+	test.s = NewStencil(&configuration.ServiceManifest{
+		Name:      "testing",
+		Arguments: serviceManifestArgs,
+		Modules:   moduleTr,
+	}, mods, log)
 
 	// use the first template from the module
 	// which we've created earlier after loading the module in the
@@ -193,6 +248,33 @@ func TestTplStencil_Arg(t *testing.T) {
 				pth: "hello",
 			},
 			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "should support from",
+			fields: fakeTemplateMultipleModules(t,
+				map[string]interface{}{
+					"hello": "world",
+				},
+				// test-0
+				map[string]configuration.Argument{
+					"hello": {
+						From: "test-1",
+					},
+				},
+				// test-1
+				map[string]configuration.Argument{
+					"hello": {
+						Schema: map[string]interface{}{
+							"type": "string",
+						},
+					},
+				},
+			),
+			args: args{
+				pth: "hello",
+			},
+			want:    "world",
 			wantErr: false,
 		},
 	}

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -146,6 +146,12 @@ type Argument struct {
 	// Values is a list of possible values for this, if empty all input is
 	// considered valid.
 	Values []string `yaml:"values"`
+
+	// From is a reference to an argument in another module, if this is
+	// set, all other fields are ignored and instead the module referenced
+	// field's are used instead. The name of the argument, the key in the map,
+	// must be the same across both modules.
+	From string `yaml:"from"`
 }
 
 // ValidateName ensures that the name of a service in the manifest

--- a/pkg/stenciltest/stenciltest.go
+++ b/pkg/stenciltest/stenciltest.go
@@ -115,7 +115,7 @@ func (t *Template) ErrorContains(msg string) {
 // Run runs the test.
 func (t *Template) Run(save bool) {
 	t.t.Run(t.path, func(got *testing.T) {
-		m, err := modulestest.NewModuleFromTemplates(t.m.Arguments, "modulestest", append([]string{t.path}, t.additionalTemplates...)...)
+		m, err := modulestest.NewModuleFromTemplates(t.m.Arguments, "modulestest", nil, append([]string{t.path}, t.additionalTemplates...)...)
 		if err != nil {
 			got.Fatalf("failed to create module from template %q", t.path)
 		}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds a new `from` field to the argument module spec. `from` alias the current argument name, based on the key in the `arguments` map, to another module's argument spec.

**Example**:

```yaml
name: test-0
arguments:
  hello:
    from: test-1

name: test-1
arguments:
  hello:
    schema:
      type: string
```

`test-0.hello` would inherti all the properties of the `test-1.hello` argument.

There's a few special rules here:

 * When `from` is set, no other keys apply. e.g. if you have `from` and `schema`, `schema` would be ignored in favor of the `schema` in the module referenced. There is no sort of merging.
 * An argument using `from` must declare it as a dependency in the `modules` list for `from` to work, otherwise a runtime-error will occur

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->
