### PR TITLE
fix(lockfile): remove generated, dont show deleted/skipped files in lock

### DIFF
--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
-	"time"
 
 	"github.com/getoutreach/gobox/pkg/app"
 	"github.com/getoutreach/stencil/internal/modules"
@@ -78,12 +77,16 @@ func (s *Stencil) RegisterInprocExtensions(name string, ext apiv1.Implementation
 // on a list of templates.
 func (s *Stencil) GenerateLockfile(tpls []*Template) *stencil.Lockfile {
 	l := &stencil.Lockfile{
-		Version:   app.Info().Version,
-		Generated: time.Now().UTC(),
+		Version: app.Info().Version,
 	}
 
 	for _, tpl := range tpls {
 		for _, f := range tpl.Files {
+			// Don't write files we skipped, or deleted, to the lockfile
+			if f.Skipped || f.Deleted {
+				continue
+			}
+
 			l.Files = append(l.Files, &stencil.LockfileFileEntry{
 				Name:     f.Name(),
 				Template: tpl.Path,

--- a/internal/codegen/stencil_test.go
+++ b/internal/codegen/stencil_test.go
@@ -46,8 +46,7 @@ func TestBasicE2ERender(t *testing.T) {
 
 	lock := st.GenerateLockfile(tpls)
 	assert.DeepEqual(t, lock, &stencil.Lockfile{
-		Version:   app.Info().Version,
-		Generated: lock.Generated,
+		Version: app.Info().Version,
 		Modules: []*stencil.LockfileModuleEntry{
 			{
 				Name:    "testing",

--- a/pkg/stencil/stencil.go
+++ b/pkg/stencil/stencil.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -61,9 +60,6 @@ type Lockfile struct {
 	// Version correlates to the version of bootstrap
 	// that generated this file.
 	Version string `yaml:"version"`
-
-	// Generated was the last time this file was modified
-	Generated time.Time `yaml:"generated"`
 
 	// Modules is a list of modules and their versions that was
 	// used the last time stencil was ran.

--- a/pkg/stencil/stencil_test.go
+++ b/pkg/stencil/stencil_test.go
@@ -6,7 +6,6 @@ package stencil_test
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/getoutreach/stencil/pkg/stencil"
 )
@@ -20,8 +19,8 @@ func ExampleLoadLockfile() {
 		return
 	}
 
-	fmt.Println(l.Generated.UTC().Format(time.RFC3339Nano))
+	fmt.Println(l.Version)
 
 	// Output:
-	// 2022-04-01T00:25:51.047307Z
+	// v1.6.2
 }

--- a/pkg/stencil/testdata/stencil.lock
+++ b/pkg/stencil/testdata/stencil.lock
@@ -1,4 +1,3 @@
 version: v1.6.2
-generated: 2022-04-01T00:25:51.047307Z
 modules: []
 files: []


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR removes the `generated` field from the `stencil.lock` file, this doesn't really serve a purpose but it sure does like to cause merge conflicts.

Also removed is `skipped` and `deleted` files from the lockfile, this caused sorting issues and they didn't really need to be written because they don't get written.


<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->
