### PR TITLE
feat(tpl): add stencil.ReadBlocks to parse blocks from arbitrary files

### DIFF
--- a/docs/content/en/functions/stencil.ReadBlocks.md
+++ b/docs/content/en/functions/stencil.ReadBlocks.md
@@ -1,0 +1,30 @@
+---
+title: stencil.ReadBlocks
+linktitle: stencil.ReadBlocks
+description: >
+  
+date: 2022-05-18
+categories: [functions]
+menu:
+  docs:
+    parent: "functions"
+---
+
+ReadBlocks parses a file and attempts to read the blocks from it\, and their data\.
+
+
+As a special case\, if the file does not exist\, an empty map is returned instead of an error\.
+
+
+\*\*NOTE\*\*: This function does not guarantee that blocks are able to be read during runtime\. for example\, if you try to read the blocks of a file from another module there is no guarantee that that file will exist before you run this function\. Nor is there the ability to tell stencil to do that \(stencil does not have any order guarantees\)\. Keep that in mind when using this function\.
+
+
+```go-text-template
+{{- $blocks := stencil.ReadBlocks "myfile.txt" }}
+{{- range $name, $data := $blocks }}
+  {{- $name }}
+  {{- $data }}
+{{- end }}
+```
+
+

--- a/internal/codegen/tpl_stencil_test.go
+++ b/internal/codegen/tpl_stencil_test.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Outreach Corporation. All Rights Reserved.
+
+// Description: This file contains the public API for templates
+// for stencil
+
+package codegen
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTplStencil_ReadBlocks(t *testing.T) {
+	type fields struct {
+	}
+	type args struct {
+		fpath string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "should read blocks from a file",
+			args: args{
+				fpath: "testdata/blocks-test.txt",
+			},
+			want: map[string]string{
+				"helloWorld": "Hello, world!",
+				"e2e":        "content",
+			},
+		},
+		{
+			name: "should error on out of chroot path",
+			args: args{
+				fpath: "../testdata/blocks-test.txt",
+			},
+			wantErr: true,
+		},
+		{
+			name: "should return no data on non-existent file",
+			args: args{
+				fpath: "testdata/does-not-exist.txt",
+			},
+			want: map[string]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &TplStencil{}
+			got, err := s.ReadBlocks(tt.args.fpath)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TplStencil.ReadBlocks() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TplStencil.ReadBlocks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/codegen/tpl_stencil_test.go
+++ b/internal/codegen/tpl_stencil_test.go
@@ -8,6 +8,8 @@ package codegen
 import (
 	"reflect"
 	"testing"
+
+	"github.com/go-git/go-billy/v5"
 )
 
 func TestTplStencil_ReadBlocks(t *testing.T) {
@@ -21,7 +23,7 @@ func TestTplStencil_ReadBlocks(t *testing.T) {
 		fields  fields
 		args    args
 		want    map[string]string
-		wantErr bool
+		wantErr error
 	}{
 		{
 			name: "should read blocks from a file",
@@ -38,7 +40,7 @@ func TestTplStencil_ReadBlocks(t *testing.T) {
 			args: args{
 				fpath: "../testdata/blocks-test.txt",
 			},
-			wantErr: true,
+			wantErr: billy.ErrCrossedBoundary,
 		},
 		{
 			name: "should return no data on non-existent file",
@@ -52,7 +54,9 @@ func TestTplStencil_ReadBlocks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &TplStencil{}
 			got, err := s.ReadBlocks(tt.args.fpath)
-			if (err != nil) != tt.wantErr {
+
+			// String checking because errors.Is isn't working
+			if (tt.wantErr != nil) && err.Error() != tt.wantErr.Error() {
 				t.Errorf("TplStencil.ReadBlocks() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds `stencil.ReadBlocks "path"` to read the blocks out of an arbitrary path. This is useful for moving files from one place to the other, or some other attempt at reading the blocks of another file.


<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->
