### PR TITLE
fix(modules): properly persist channel resolve information

### DIFF
--- a/bootstrap.lock
+++ b/bootstrap.lock
@@ -3,4 +3,4 @@
 version: v10.3.0-rc.11
 generated: 2022-08-10T14:54:43Z
 versions:
-  devbase: main
+  devbase: jaredallard/fix/asdf-race-condition

--- a/bootstrap.lock
+++ b/bootstrap.lock
@@ -3,4 +3,4 @@
 version: v10.3.0-rc.11
 generated: 2022-08-10T14:54:43Z
 versions:
-  devbase: jaredallard/fix/asdf-race-condition
+  devbase: v2.4.0-rc.3

--- a/cmd/stencil/stencil.go
+++ b/cmd/stencil/stencil.go
@@ -110,6 +110,7 @@ func main() {
 		},
 		&cli.BoolFlag{
 			Name:    "debug",
+			Usage:   "Enables debug logging for version resolution, template render, and other useful information",
 			Aliases: []string{"d"},
 		},
 		///EndBlock(flags)

--- a/cmd/stencil/stencil.go
+++ b/cmd/stencil/stencil.go
@@ -108,6 +108,10 @@ func main() {
 			Name:  "allow-major-version-upgrades",
 			Usage: "Allow major version upgrades without confirmation",
 		},
+		&cli.BoolFlag{
+			Name:    "debug",
+			Aliases: []string{"d"},
+		},
 		///EndBlock(flags)
 	}
 	app.Commands = []*cli.Command{

--- a/internal/cmd/stencil/stencil.go
+++ b/internal/cmd/stencil/stencil.go
@@ -104,7 +104,7 @@ func (c *Command) Run(ctx context.Context) error {
 	}
 
 	c.log.Info("Fetching dependencies")
-	mods, err := modules.GetModulesForService(ctx, c.token, c.manifest)
+	mods, err := modules.GetModulesForService(ctx, c.token, c.manifest, c.log)
 	if err != nil {
 		return errors.Wrap(err, "failed to process modules list")
 	}

--- a/internal/modules/module_test.go
+++ b/internal/modules/module_test.go
@@ -137,7 +137,7 @@ func TestFailOnIncompatibleConstraints(t *testing.T) {
 	}, newLogger())
 	assert.Error(t, err,
 		//nolint:lll // Why: That's the error :(
-		"failed to resolve module 'github.com/getoutreach/stencil-base' with constraints\n└─ testing-service (top-level) wants >=0.5.0\n  └─ nested_constraint wants ~0.3.0\n: no version found matching criteria",
+		"failed to resolve module 'github.com/getoutreach/stencil-base' with constraints\n└─ testing-service (top-level) wants >=0.5.0\n  └─ nested_constraint@v0.0.0-+ wants ~0.3.0\n: no version found matching criteria",
 		"expected GetModulesForService() to error")
 }
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

The version resolver does a great job of persisting constraints across version resolves, but it did not calculate channels properly. This fixes that to calculate channels, and error when more than one channel is requested (since we do not know the logical flow of a channel in terms of promotion)

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2808]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2808]: https://outreach-io.atlassian.net/browse/DT-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ