### PR TITLE
feat(blocks): use safer block format (v2)

### DIFF
--- a/internal/codegen/blocks.go
+++ b/internal/codegen/blocks.go
@@ -9,9 +9,13 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 )
+
+// endStatement is a constant for the end of a statement
+const endStatement = "EndBlock"
 
 // blockPattern is the regex used for parsing block commands.
 // For unit testing of this regex and explanation, see https://regex101.com/r/EHkH5O/1
@@ -19,7 +23,7 @@ var blockPattern = regexp.MustCompile(`^\s*(///|###|<!---)\s*([a-zA-Z ]+)\(([a-z
 
 // v2BlockPattern is the new regex for parsing blocks
 // For unit testing of this regex and explanation, see https://regex101.com/r/EHkH5O/1
-var v2BlockPattern = regexp.MustCompile(`^\s*(//|##|--|<!--)\s{0,1}<<Stencil::([a-zA-Z ]+)\(([a-zA-Z0-9 ]+)\)>>`)
+var v2BlockPattern = regexp.MustCompile(`^\s*(//|##|--|<!--)\s{0,1}<<(/?)Stencil::([a-zA-Z ]+)(\([a-zA-Z0-9 ]+\))?>>`)
 
 // parseBlocks reads the blocks from an existing file
 func parseBlocks(filePath string) (map[string]string, error) {
@@ -38,7 +42,43 @@ func parseBlocks(filePath string) (map[string]string, error) {
 		line := scanner.Text()
 		matches := blockPattern.FindStringSubmatch(line)
 		if len(matches) == 0 {
-			matches = v2BlockPattern.FindStringSubmatch(line)
+			// 0: full match
+			// 1: comment prefix
+			// 2: / if end of block
+			// 3: block name
+			// 4: block args, if present
+			v2Matches := v2BlockPattern.FindStringSubmatch(line)
+			if len(v2Matches) == 5 {
+				cmd := v2Matches[3]
+				if v2Matches[2] == "/" {
+					if cmd == endStatement {
+						return nil, fmt.Errorf("line %d: Stencil::EndBlock with a <</, should use <</Stencil::Block>> instead", i+1)
+					}
+
+					// If there is a /, it's a closing tag and we should
+					// translate it to a closing block command
+					cmd = endStatement
+					if v2Matches[4] != "" {
+						return nil, fmt.Errorf("line %d: expected no arguments to <</Stencil::Block>>", i+1)
+					}
+
+					v2Matches[4] = fmt.Sprintf("(%s)", curBlockName)
+				} else if cmd == endStatement {
+					// If it's not a closing tag, but the command is EndBlock,
+					// we should error. This is because we don't want to
+					// allow users to use the old EndBlock command
+					// without a closing tag
+					return nil, errors.Errorf("line %d: EndBlock command must be used with a closing tag", i+1)
+				}
+
+				// fake the old matches format so we can reuse the same code
+				matches = []string{
+					v2Matches[0],
+					v2Matches[1],
+					cmd,
+					strings.TrimPrefix(strings.TrimSuffix(v2Matches[4], ")"), "("),
+				}
+			}
 		}
 		isCommand := false
 
@@ -56,7 +96,7 @@ func parseBlocks(filePath string) (map[string]string, error) {
 					return nil, fmt.Errorf("invalid Block when already inside of a block, at %s:%d", filePath, i+1)
 				}
 				curBlockName = blockName
-			case "EndBlock":
+			case endStatement:
 				blockName := matches[3]
 
 				if curBlockName == "" {

--- a/internal/codegen/blocks.go
+++ b/internal/codegen/blocks.go
@@ -68,7 +68,7 @@ func parseBlocks(filePath string) (map[string]string, error) {
 					// we should error. This is because we don't want to
 					// allow users to use the old EndBlock command
 					// without a closing tag
-					return nil, errors.Errorf("line %d: EndBlock command must be used with a closing tag", i+1)
+					return nil, errors.Errorf("line %d: <<Stencil::EndBlock>> should be <</Stencil::Block>>", i+1)
 				}
 
 				// fake the old matches format so we can reuse the same code

--- a/internal/codegen/blocks.go
+++ b/internal/codegen/blocks.go
@@ -18,7 +18,7 @@ import (
 const endStatement = "EndBlock"
 
 // blockPattern is the regex used for parsing block commands.
-// For unit testing of this regex and explanation, see https://regex101.com/r/EHkH5O/1
+// For unit testing of this regex and explanation, see https://regex101.com/r/nFgOz0/1
 var blockPattern = regexp.MustCompile(`^\s*(///|###|<!---)\s*([a-zA-Z ]+)\(([a-zA-Z0-9 ]+)\)`)
 
 // v2BlockPattern is the new regex for parsing blocks

--- a/internal/codegen/blocks_test.go
+++ b/internal/codegen/blocks_test.go
@@ -42,3 +42,10 @@ func TestWrongEndBlock(t *testing.T) {
 		"invalid EndBlock, found EndBlock with name \"wrongend\" while inside of block with name \"helloWorld\", at testdata/wrongendblock-test.txt:3", //nolint:lll
 		"expected parseBlocks() to fail")
 }
+
+func TestParseV2Blocks(t *testing.T) {
+	blocks, err := parseBlocks("testdata/v2blocks-test.txt")
+	assert.NilError(t, err, "expected parseBlocks() not to fail")
+	assert.Equal(t, blocks["helloWorld"], "Hello, world!", "expected parseBlocks() to parse basic block")
+	assert.Equal(t, blocks["e2e"], "content", "expected parseBlocks() to parse e2e block")
+}

--- a/internal/codegen/blocks_test.go
+++ b/internal/codegen/blocks_test.go
@@ -47,5 +47,11 @@ func TestParseV2Blocks(t *testing.T) {
 	blocks, err := parseBlocks("testdata/v2blocks-test.txt")
 	assert.NilError(t, err, "expected parseBlocks() not to fail")
 	assert.Equal(t, blocks["helloWorld"], "Hello, world!", "expected parseBlocks() to parse basic block")
-	assert.Equal(t, blocks["e2e"], "content", "expected parseBlocks() to parse e2e block")
+}
+
+func TestV2BlocksErrors(t *testing.T) {
+	_, err := parseBlocks("testdata/v2blocks-invalid.txt")
+	if err == nil {
+		t.Fatal("expected parseBlocks() to fail")
+	}
 }

--- a/internal/codegen/testdata/v2blocks-invalid.txt
+++ b/internal/codegen/testdata/v2blocks-invalid.txt
@@ -1,0 +1,12 @@
+# This is invalid because it passes arguments to EndBlock
+## <<Stencil::Block(pikapika)>>
+Pika pika!
+## <</Stencil::Block(pikapika)>>
+
+# This is invalid because it used EndBlock with a <</
+## <<Stencil::Block(helloWorld)>>
+## <</Stencil::EndBlock>>
+
+# This is invalid because it used EndBlock without a <</
+## <<Stencil::Block(helloWorld)>>
+## <<Stencil::EndBlock>>

--- a/internal/codegen/testdata/v2blocks-test.txt
+++ b/internal/codegen/testdata/v2blocks-test.txt
@@ -1,7 +1,3 @@
 ## <<Stencil::Block(helloWorld)>>
 Hello, world!
-## <<Stencil::EndBlock(helloWorld)>>
-
-## <<Stencil::Block(e2e)>>
-content
-## <<Stencil::EndBlock(e2e)>>
+## <</Stencil::Block>>

--- a/internal/codegen/testdata/v2blocks-test.txt
+++ b/internal/codegen/testdata/v2blocks-test.txt
@@ -1,0 +1,7 @@
+## <<Stencil::Block(helloWorld)>>
+Hello, world!
+## <<Stencil::EndBlock(helloWorld)>>
+
+## <<Stencil::Block(e2e)>>
+content
+## <<Stencil::EndBlock(e2e)>>


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds a new block format (v2) to get around issues with comment fomatters that would break the traditional `///`, among other cases, blocks.

The new block format looks like so:

```go
// <<Stencil::Block(name)>>
fmt.Println("Block stuff does block things")
// <</Stencil::Block>>
```

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-0]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->
