### PR TITLE
feat(codegen/stencil): add stencil.Exists tpl function

### DIFF
--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -140,7 +140,9 @@ func (s *TplStencil) ReadFile(name string) (string, error) {
 //	{{- end }}
 func (s *TplStencil) Exists(name string) bool {
 	f, ok := s.exists(name)
-	f.Close() // close the file handle, since we don't need it
+	if ok {
+		f.Close() // close the file handle, since we don't need it
+	}
 	return ok
 }
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds a `stencil.Exists` template function to check if a file exists in the current directory. The logic behind this function is that when a [go-template function returns an error, the template execution is halted](https://pkg.go.dev/text/template#FuncMap). This makes it painful to use `stencil.ReadFile` when doing custom "static-like" logic. While it'd be more effective to add a `catch` or `stencil.Call` function to handle that error for the user, we have more we'll want to do there in the future for a `ApplyTemplate` revamp to better support template helpers, so I'm not doing that yet.

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2808]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2808]: https://outreach-io.atlassian.net/browse/DT-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ