### PR TITLE
fix(extensions): support map[interface{}]interface{}

### DIFF
--- a/pkg/extensions/apiv1/apiv1.go
+++ b/pkg/extensions/apiv1/apiv1.go
@@ -13,6 +13,7 @@ import "encoding/gob"
 func init() { //nolint:gochecknoinits // Why: see comment
 	gob.Register([]interface{}{})
 	gob.Register(map[string]interface{}{})
+	gob.Register(map[interface{}]interface{}{})
 }
 
 // This block contains the constants for the go-plugin


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

With the move to different yaml/json libraries sometimes we can get `map[interface{}]interface{}` instead of `map[string]interface{}`, we should generally support that anyways, so we register that type now.

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2808]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2808]: https://outreach-io.atlassian.net/browse/DT-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ