### PR TITLE
fix(jsonschema): provide more explicit schema error

### DIFF
--- a/internal/codegen/tpl_stencil_arg.go
+++ b/internal/codegen/tpl_stencil_arg.go
@@ -205,17 +205,8 @@ func (s *TplStencil) validateArg(pth string, arg *configuration.Argument, v inte
 	if err := schema.Validate(v); err != nil {
 		var validationError *jsonschema.ValidationError
 		if errors.As(err, &validationError) {
-			// If there's only one error, return it directly, otherwise
-			// return the full list of errors.
-			errs := validationError.DetailedOutput().Errors
-			out := ""
-			if len(errs) == 1 {
-				out = errs[0].Error
-			} else {
-				out = fmt.Sprintf("%#v", validationError.DetailedOutput().Errors)
-			}
-
-			return fmt.Errorf("module %q argument %q validation failed: %s", s.t.Module.Name, pth, out)
+			return fmt.Errorf("module %q argument %q validation failed: %#v",
+				s.t.Module.Name, pth, validationError.DetailedOutput())
 		}
 
 		return errors.Wrapf(err, "module %q argument %q validation failed", s.t.Module.Name, pth)


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

- If there is a single JSON schema validation error, a lot of the path information currently gets thrown away, so the user cannot determine where exactly in the service.yaml the validation is failing.  
- This removes the filtering in the case where there is just 1 error so that the entire detailed error is displayed


Before change (does not indicate any path information beyond the top-level service.yaml argument)
```
ERRO[0010] failed to run: run codegen: 
failed to render template "github.com/getoutreach/stencil-smartstore/_helpers.tpl": 
template: github.com/getoutreach/stencil-smartstore/_helpers.tpl:5:25:
executing "github.com/getoutreach/stencil-smartstore/_helpers.tpl" at <stencil.Arg>: 
error calling Arg: module "github.com/getoutreach/stencil-smartstore" argument "postgreSQL" validation failed: does not match pattern '^[a-z_\\-]+$'
```

After change
```
ERRO[0011] failed to run: run codegen: 
failed to render template "github.com/getoutreach/stencil-smartstore/_helpers.tpl": template: github.com/getoutreach/stencil-smartstore/_helpers.tpl:5:25: 
executing "github.com/getoutreach/stencil-smartstore/_helpers.tpl" at <stencil.Arg>: 
error calling Arg: module "github.com/getoutreach/stencil-smartstore" argument "postgreSQL" validation failed: 
jsonschema.Detailed{Valid:false, KeywordLocation:"", AbsoluteKeywordLocation:"file:///Users/sam.nguyen/src/stencil-smartstore/testapps/orgschemagrpc/manifest.yaml/arguments/postgreSQL#", InstanceLocation:"", Error:"", Errors:[]jsonschema.Detailed{jsonschema.Detailed{Valid:false, KeywordLocation:"/items/properties/name/pattern", AbsoluteKeywordLocation:"file:///Users/sam.nguyen/src/stencil-smartstore/testapps/orgschemagrpc/manifest.yaml/arguments/postgreSQL#/items/properties/name/pattern", InstanceLocation:"/0/name", Error:"does not match pattern '^[a-z_\\\\-]+$'", Errors:[]jsonschema.Detailed(nil)}}}
```

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

- I also tried JSON encoding the error but it gets escaped so there are a lot of `\` in the output


<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
