### PR TITLE
fix: support from manifest arugments in tests

### DIFF
--- a/internal/cmd/stencil/stencil.go
+++ b/internal/cmd/stencil/stencil.go
@@ -102,7 +102,11 @@ func (c *Command) Run(ctx context.Context) error {
 	}
 
 	c.log.Info("Fetching dependencies")
-	mods, err := modules.GetModulesForService(ctx, c.token, c.manifest, c.log)
+	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		ServiceManifest: c.manifest,
+		Token:           c.token,
+		Log:             c.log,
+	})
 	if err != nil {
 		return errors.Wrap(err, "failed to process modules list")
 	}

--- a/internal/codegen/stencil_test.go
+++ b/internal/codegen/stencil_test.go
@@ -68,11 +68,17 @@ func TestModuleHookRender(t *testing.T) {
 	ctx := context.Background()
 
 	// create modules
-	m1, err := modulestest.NewModuleFromTemplates(nil, "testing1", nil, "testdata/module-hook/m1.tpl")
+	m1man := &configuration.TemplateRepositoryManifest{
+		Name: "testing1",
+	}
+	m1, err := modulestest.NewModuleFromTemplates(m1man, "testdata/module-hook/m1.tpl")
 	if err != nil {
 		t.Errorf("failed to create module 1: %v", err)
 	}
-	m2, err := modulestest.NewModuleFromTemplates(nil, "testing2", nil, "testdata/module-hook/m2.tpl")
+	m2man := &configuration.TemplateRepositoryManifest{
+		Name: "testing2",
+	}
+	m2, err := modulestest.NewModuleFromTemplates(m2man, "testdata/module-hook/m2.tpl")
 	if err != nil {
 		t.Errorf("failed to create module 2: %v", err)
 	}

--- a/internal/codegen/tpl_stencil_arg_test.go
+++ b/internal/codegen/tpl_stencil_arg_test.go
@@ -30,7 +30,11 @@ func fakeTemplate(t *testing.T, args map[string]interface{},
 	test := &testTpl{}
 	log := logrus.New()
 
-	m, err := modulestest.NewModuleFromTemplates(requestArgs, "test", nil)
+	man := &configuration.TemplateRepositoryManifest{
+		Name:      "test",
+		Arguments: requestArgs,
+	}
+	m, err := modulestest.NewModuleFromTemplates(man)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +86,11 @@ func fakeTemplateMultipleModules(t *testing.T, serviceManifestArgs map[string]in
 			continue
 		}
 
-		m, err := modulestest.NewModuleFromTemplates(args[i], fmt.Sprintf("test-%d", i), nil, "testdata/args/test.tpl")
+		man := &configuration.TemplateRepositoryManifest{
+			Name:      fmt.Sprintf("test-%d", i),
+			Arguments: args[i],
+		}
+		m, err := modulestest.NewModuleFromTemplates(man, "testdata/args/test.tpl")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -90,8 +98,17 @@ func fakeTemplateMultipleModules(t *testing.T, serviceManifestArgs map[string]in
 		mods[i] = m
 	}
 
+	var trs []*configuration.TemplateRepository
+	for _, imp := range importList {
+		trs = append(trs, &configuration.TemplateRepository{Name: imp})
+	}
+	man := &configuration.TemplateRepositoryManifest{
+		Name:      "test-0",
+		Arguments: args[0],
+		Modules:   trs,
+	}
 	var err error
-	mods[0], err = modulestest.NewModuleFromTemplates(args[0], "test-0", importList, "testdata/args/test.tpl")
+	mods[0], err = modulestest.NewModuleFromTemplates(man, "testdata/args/test.tpl")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/codegen/values_test.go
+++ b/internal/codegen/values_test.go
@@ -94,7 +94,10 @@ func TestValues(t *testing.T) {
 func TestGeneratedValues(t *testing.T) {
 	log := logrus.New()
 
-	m, err := modulestest.NewModuleFromTemplates(map[string]configuration.Argument{}, "testing", []string{}, "testdata/values/values.tpl")
+	man := &configuration.TemplateRepositoryManifest{
+		Name: "testing",
+	}
+	m, err := modulestest.NewModuleFromTemplates(man, "testdata/values/values.tpl")
 	assert.NilError(t, err, "failed to create module")
 
 	st := NewStencil(&configuration.ServiceManifest{

--- a/internal/modules/module_test.go
+++ b/internal/modules/module_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/getoutreach/stencil/internal/modules"
+	"github.com/getoutreach/stencil/internal/modules/modulestest"
 	"github.com/getoutreach/stencil/pkg/configuration"
 	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
@@ -51,7 +52,7 @@ func TestReplacementLocalModule(t *testing.T) {
 		},
 	}
 
-	mods, err := modules.GetModulesForService(context.Background(), "", sm, newLogger())
+	mods, err := modules.GetModulesForService(context.Background(), &modules.ModuleResolveOptions{ServiceManifest: sm, Log: newLogger()})
 	assert.NilError(t, err, "expected GetModulesForService() to not error")
 	assert.Equal(t, len(mods), 1, "expected exactly one module to be returned")
 	assert.Equal(t, mods[0].URI, sm.Replacements["github.com/getoutreach/stencil-base"],
@@ -60,35 +61,41 @@ func TestReplacementLocalModule(t *testing.T) {
 
 func TestCanGetLatestVersion(t *testing.T) {
 	ctx := context.Background()
-	mods, err := modules.GetModulesForService(ctx, "", &configuration.ServiceManifest{
-		Name: "testing-service",
-		Modules: []*configuration.TemplateRepository{
-			{
-				Name: "github.com/getoutreach/stencil-base",
+	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		ServiceManifest: &configuration.ServiceManifest{
+			Name: "testing-service",
+			Modules: []*configuration.TemplateRepository{
+				{
+					Name: "github.com/getoutreach/stencil-base",
+				},
 			},
 		},
-	}, newLogger())
+		Log: newLogger(),
+	})
 	assert.NilError(t, err, "failed to call GetModulesForService()")
 	assert.Assert(t, len(mods) >= 1, "expected at least one module to be returned")
 }
 
 func TestHandleMultipleConstraints(t *testing.T) {
 	ctx := context.Background()
-	mods, err := modules.GetModulesForService(ctx, "", &configuration.ServiceManifest{
-		Name: "testing-service",
-		Modules: []*configuration.TemplateRepository{
-			{
-				Name:    "github.com/getoutreach/stencil-base",
-				Version: "=<0.5.0",
+	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		ServiceManifest: &configuration.ServiceManifest{
+			Name: "testing-service",
+			Modules: []*configuration.TemplateRepository{
+				{
+					Name:    "github.com/getoutreach/stencil-base",
+					Version: "=<0.5.0",
+				},
+				{
+					Name: "nested_constraint",
+				},
 			},
-			{
-				Name: "nested_constraint",
+			Replacements: map[string]string{
+				"nested_constraint": "file://testdata/nested_constraint",
 			},
 		},
-		Replacements: map[string]string{
-			"nested_constraint": "file://testdata/nested_constraint",
-		},
-	}, newLogger())
+		Log: newLogger(),
+	})
 	assert.NilError(t, err, "failed to call GetModulesForService()")
 	assert.Equal(t, len(mods), 2, "expected exactly two modules to be returned")
 
@@ -108,18 +115,21 @@ func TestHandleMultipleConstraints(t *testing.T) {
 
 func TestHandleNestedModules(t *testing.T) {
 	ctx := context.Background()
-	mods, err := modules.GetModulesForService(ctx, "", &configuration.ServiceManifest{
-		Name: "testing-service",
-		Modules: []*configuration.TemplateRepository{
-			{
-				Name: "a",
+	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		ServiceManifest: &configuration.ServiceManifest{
+			Name: "testing-service",
+			Modules: []*configuration.TemplateRepository{
+				{
+					Name: "a",
+				},
+			},
+			Replacements: map[string]string{
+				"a": "file://testdata/nested_modules/a",
+				"b": "file://testdata/nested_modules/b",
 			},
 		},
-		Replacements: map[string]string{
-			"a": "file://testdata/nested_modules/a",
-			"b": "file://testdata/nested_modules/b",
-		},
-	}, newLogger())
+		Log: newLogger(),
+	})
 	assert.NilError(t, err, "failed to call GetModulesForService()")
 	assert.Equal(t, len(mods), 2, "expected exactly two modules to be returned")
 	assert.Equal(t, mods[0].Name, "a", "expected module to match")
@@ -128,22 +138,25 @@ func TestHandleNestedModules(t *testing.T) {
 
 func TestFailOnIncompatibleConstraints(t *testing.T) {
 	ctx := context.Background()
-	_, err := modules.GetModulesForService(ctx, "", &configuration.ServiceManifest{
-		Name: "testing-service",
-		Modules: []*configuration.TemplateRepository{
-			{
-				Name:    "github.com/getoutreach/stencil-base",
-				Version: ">=0.5.0",
+	_, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		ServiceManifest: &configuration.ServiceManifest{
+			Name: "testing-service",
+			Modules: []*configuration.TemplateRepository{
+				{
+					Name:    "github.com/getoutreach/stencil-base",
+					Version: ">=0.5.0",
+				},
+				{
+					// wants patch of 0.3.0
+					Name: "nested_constraint",
+				},
 			},
-			{
-				// wants patch of 0.3.0
-				Name: "nested_constraint",
+			Replacements: map[string]string{
+				"nested_constraint": "file://testdata/nested_constraint",
 			},
 		},
-		Replacements: map[string]string{
-			"nested_constraint": "file://testdata/nested_constraint",
-		},
-	}, newLogger())
+		Log: newLogger(),
+	})
 	assert.Error(t, err,
 		//nolint:lll // Why: That's the error :(
 		"failed to resolve module 'github.com/getoutreach/stencil-base' with constraints\n└─ testing-service (top-level) wants >=0.5.0\n  └─ nested_constraint@v0.0.0-+ wants ~0.3.0\n: no version found matching criteria",
@@ -152,16 +165,19 @@ func TestFailOnIncompatibleConstraints(t *testing.T) {
 
 func TestSupportChannelAndConstraint(t *testing.T) {
 	ctx := context.Background()
-	mods, err := modules.GetModulesForService(ctx, "", &configuration.ServiceManifest{
-		Name: "testing-service",
-		Modules: []*configuration.TemplateRepository{
-			{
-				Name:    "github.com/getoutreach/stencil-base",
-				Channel: "rc",
-				Version: "v0.6.0-rc.4",
+	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		ServiceManifest: &configuration.ServiceManifest{
+			Name: "testing-service",
+			Modules: []*configuration.TemplateRepository{
+				{
+					Name:    "github.com/getoutreach/stencil-base",
+					Channel: "rc",
+					Version: "v0.6.0-rc.4",
+				},
 			},
 		},
-	}, newLogger())
+		Log: newLogger(),
+	})
 	assert.NilError(t, err, "failed to call GetModulesForService()")
 	assert.Equal(t, len(mods), 1, "expected exactly one module to be returned")
 	assert.Equal(t, mods[0].Version, "v0.6.0-rc.4", "expected module to match")
@@ -169,15 +185,18 @@ func TestSupportChannelAndConstraint(t *testing.T) {
 
 func TestCanUseBranch(t *testing.T) {
 	ctx := context.Background()
-	mods, err := modules.GetModulesForService(ctx, "", &configuration.ServiceManifest{
-		Name: "testing-service",
-		Modules: []*configuration.TemplateRepository{
-			{
-				Name:    "github.com/getoutreach/stencil-base",
-				Channel: "main",
+	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		ServiceManifest: &configuration.ServiceManifest{
+			Name: "testing-service",
+			Modules: []*configuration.TemplateRepository{
+				{
+					Name:    "github.com/getoutreach/stencil-base",
+					Channel: "main",
+				},
 			},
 		},
-	}, newLogger())
+		Log: newLogger(),
+	})
 	assert.NilError(t, err, "failed to call GetModulesForService()")
 
 	var mod *modules.Module
@@ -197,18 +216,21 @@ func TestCanUseBranch(t *testing.T) {
 func TestCanRespectChannels(t *testing.T) {
 	t.Skip("Breaks when a module isn't currently on an rc version")
 	ctx := context.Background()
-	mods, err := modules.GetModulesForService(ctx, "", &configuration.ServiceManifest{
-		Name: "testing-service",
-		Modules: []*configuration.TemplateRepository{
-			{
-				Name:    "github.com/getoutreach/stencil-base",
-				Channel: "rc",
-			},
-			{
-				Name: "github.com/getoutreach/stencil-base",
+	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		ServiceManifest: &configuration.ServiceManifest{
+			Name: "testing-service",
+			Modules: []*configuration.TemplateRepository{
+				{
+					Name:    "github.com/getoutreach/stencil-base",
+					Channel: "rc",
+				},
+				{
+					Name: "github.com/getoutreach/stencil-base",
+				},
 			},
 		},
-	}, newLogger())
+		Log: newLogger(),
+	})
 	assert.NilError(t, err, "failed to call GetModulesForService()")
 	assert.Equal(t, len(mods), 1, "expected exactly one module to be returned")
 	if !strings.Contains(mods[0].Version, "-rc.") {
@@ -216,20 +238,54 @@ func TestCanRespectChannels(t *testing.T) {
 	}
 }
 
+func TestShouldResolveInMemoryModule(t *testing.T) {
+	ctx := context.Background()
+
+	// require test-dep which is also an in-memory module to make sure that we can resolve at least once
+	// an in-memory module
+	m, err := modulestest.NewModuleFromTemplates(map[string]configuration.Argument{}, "test", []string{"test-dep"})
+	assert.NilError(t, err, "failed to create module")
+
+	// this relies on the top-level to ensure that re-resolving still picks
+	// the in-memory module
+	mDep, err := modulestest.NewModuleFromTemplates(map[string]configuration.Argument{}, "test-dep", []string{"test"})
+	assert.NilError(t, err, "failed to create dep module")
+
+	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		Module:       m,
+		Replacements: map[string]*modules.Module{"test-dep": mDep},
+		Log:          newLogger(),
+	})
+	assert.NilError(t, err, "failed to call GetModulesForService()")
+	assert.Equal(t, len(mods), 2, "expected exactly two modules to be returned")
+
+	var mod *modules.Module
+	for _, m := range mods {
+		if m.Name == "test" {
+			mod = m
+			break
+		}
+	}
+	assert.Equal(t, mod.Name, m.Name, "expected module to match")
+}
+
 func TestShouldErrorOnTwoDifferentChannels(t *testing.T) {
 	ctx := context.Background()
-	_, err := modules.GetModulesForService(ctx, "", &configuration.ServiceManifest{
-		Name: "testing-service",
-		Modules: []*configuration.TemplateRepository{
-			{
-				Name:    "github.com/getoutreach/stencil-base",
-				Channel: "rc",
-			},
-			{
-				Name:    "github.com/getoutreach/stencil-base",
-				Channel: "unstable",
+	_, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		ServiceManifest: &configuration.ServiceManifest{
+			Name: "testing-service",
+			Modules: []*configuration.TemplateRepository{
+				{
+					Name:    "github.com/getoutreach/stencil-base",
+					Channel: "rc",
+				},
+				{
+					Name:    "github.com/getoutreach/stencil-base",
+					Channel: "unstable",
+				},
 			},
 		},
-	}, newLogger())
+		Log: newLogger(),
+	})
 	assert.ErrorContains(t, err, "previously resolved with channel", "expected GetModulesForService() to error")
 }

--- a/internal/modules/module_test.go
+++ b/internal/modules/module_test.go
@@ -243,12 +243,25 @@ func TestShouldResolveInMemoryModule(t *testing.T) {
 
 	// require test-dep which is also an in-memory module to make sure that we can resolve at least once
 	// an in-memory module
-	m, err := modulestest.NewModuleFromTemplates(map[string]configuration.Argument{}, "test", []string{"test-dep"})
+
+	man := &configuration.TemplateRepositoryManifest{
+		Name: "test",
+		Modules: []*configuration.TemplateRepository{
+			{Name: "test-dep"},
+		},
+	}
+	m, err := modulestest.NewModuleFromTemplates(man)
 	assert.NilError(t, err, "failed to create module")
 
 	// this relies on the top-level to ensure that re-resolving still picks
 	// the in-memory module
-	mDep, err := modulestest.NewModuleFromTemplates(map[string]configuration.Argument{}, "test-dep", []string{"test"})
+	man = &configuration.TemplateRepositoryManifest{
+		Name: "test-dep",
+		Modules: []*configuration.TemplateRepository{
+			{Name: "test"},
+		},
+	}
+	mDep, err := modulestest.NewModuleFromTemplates(man)
 	assert.NilError(t, err, "failed to create dep module")
 
 	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{

--- a/pkg/stenciltest/stenciltest.go
+++ b/pkg/stenciltest/stenciltest.go
@@ -113,7 +113,7 @@ func (t *Template) ErrorContains(msg string) {
 	t.errStr = msg
 }
 
-// getTemplateRepositoryNames retrieves the naems from the passed in TemplateRepositories
+// getTemplateRepositoryNames retrieves the names from the passed in TemplateRepositories
 func getTemplateRepositoryNames(trs []*configuration.TemplateRepository) []string {
 	deps := make([]string, len(trs))
 	for i, tr := range trs {

--- a/pkg/stenciltest/stenciltest.go
+++ b/pkg/stenciltest/stenciltest.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/getoutreach/gobox/pkg/cli/github"
 	"github.com/getoutreach/stencil/internal/codegen"
 	"github.com/getoutreach/stencil/internal/modules"
 	"github.com/getoutreach/stencil/internal/modules/modulestest"
@@ -51,6 +52,9 @@ type Template struct {
 	// MUST error.
 	errStr string
 
+	// log is the logger to use when running stencil
+	log logrus.FieldLogger
+
 	// persist denotes if we should save a snapshot or not
 	// This is meant for tests.
 	persist bool
@@ -75,12 +79,16 @@ func New(t *testing.T, templatePath string, additionalTemplates ...string) *Temp
 		t.Fatal(err)
 	}
 
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
 	return &Template{
 		t:                   t,
 		m:                   &m,
 		path:                templatePath,
 		additionalTemplates: additionalTemplates,
 		persist:             true,
+		log:                 log,
 		exts:                map[string]apiv1.Implementation{},
 	}
 }
@@ -122,24 +130,21 @@ func getTemplateRepositoryNames(trs []*configuration.TemplateRepository) []strin
 	return deps
 }
 
-// modulesFromTemplateRepository creates new modules from the passed in TemplateRepositories
-func modulesFromTemplateRepository(trs []*configuration.TemplateRepository) ([]*modules.Module, error) {
-	var mods []*modules.Module
-	for _, tr := range trs {
-		// Use the present version or main
-		if tr.Version == "" {
-			tr.Version = "main"
-		}
-
-		m, err := modules.New(context.Background(), "", tr)
-		if err != nil {
-			return nil, fmt.Errorf("could not create a new modules for %s: %w", tr.Name, err)
-		}
-
-		mods = append(mods, m)
+// getModuleDependencies returns modules that are dependencies of the current module
+// the top-level manifest should be used to create the module that is passed in to ensure
+// that the version criteria is met.
+func (t *Template) getModuleDependencies(ctx context.Context, m *modules.Module) ([]*modules.Module, error) {
+	token, err := github.GetToken()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to get github token: %v", err)
 	}
 
-	return mods, nil
+	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		Token:  token,
+		Module: m,
+		Log:    t.log,
+	})
+	return mods, err
 }
 
 // Run runs the test.
@@ -148,26 +153,29 @@ func (t *Template) Run(save bool) {
 		deps := getTemplateRepositoryNames(t.m.Modules)
 
 		m, err := modulestest.NewModuleFromTemplates(
-			t.m.Arguments, "modulestest", deps, append([]string{t.path}, t.additionalTemplates...)...)
+			t.m.Arguments, t.m.Name, deps, append([]string{t.path}, t.additionalTemplates...)...)
 		if err != nil {
 			got.Fatalf("failed to create module from template %q", t.path)
 		}
 
-		mods, err := modulesFromTemplateRepository(t.m.Modules)
+		mods, err := t.getModuleDependencies(context.Background(), m)
 		if err != nil {
 			got.Fatalf("could not get modules: %v ", err)
 		}
 		mods = append(mods, m)
 
-		mf := &configuration.ServiceManifest{Name: "testing", Arguments: t.args,
-			Modules: []*configuration.TemplateRepository{{Name: m.Name}}}
-		st := codegen.NewStencil(mf, mods, logrus.New())
+		mf := &configuration.ServiceManifest{
+			Name:      "testing",
+			Arguments: t.args,
+			Modules:   []*configuration.TemplateRepository{{Name: m.Name}},
+		}
+		st := codegen.NewStencil(mf, mods, t.log)
 
 		for name, ext := range t.exts {
 			st.RegisterInprocExtensions(name, ext)
 		}
 
-		tpls, err := st.Render(context.Background(), logrus.New())
+		tpls, err := st.Render(context.Background(), t.log)
 		if err != nil {
 			if t.errStr != "" {
 				// if t.errStr was set then we expected an error, since that

--- a/pkg/stenciltest/stenciltest.go
+++ b/pkg/stenciltest/stenciltest.go
@@ -121,15 +121,6 @@ func (t *Template) ErrorContains(msg string) {
 	t.errStr = msg
 }
 
-// getTemplateRepositoryNames retrieves the names from the passed in TemplateRepositories
-func getTemplateRepositoryNames(trs []*configuration.TemplateRepository) []string {
-	deps := make([]string, len(trs))
-	for i, tr := range trs {
-		deps[i] = tr.Name
-	}
-	return deps
-}
-
 // getModuleDependencies returns modules that are dependencies of the current module
 // the top-level manifest should be used to create the module that is passed in to ensure
 // that the version criteria is met.
@@ -150,10 +141,7 @@ func (t *Template) getModuleDependencies(ctx context.Context, m *modules.Module)
 // Run runs the test.
 func (t *Template) Run(save bool) {
 	t.t.Run(t.path, func(got *testing.T) {
-		deps := getTemplateRepositoryNames(t.m.Modules)
-
-		m, err := modulestest.NewModuleFromTemplates(
-			t.m.Arguments, t.m.Name, deps, append([]string{t.path}, t.additionalTemplates...)...)
+		m, err := modulestest.NewModuleFromTemplates(t.m, append([]string{t.path}, t.additionalTemplates...)...)
 		if err != nil {
 			got.Fatalf("failed to create module from template %q", t.path)
 		}

--- a/pkg/stenciltest/stenciltest_test.go
+++ b/pkg/stenciltest/stenciltest_test.go
@@ -62,22 +62,6 @@ func TestArgs(t *testing.T) {
 	st.Run(false)
 }
 
-func TestGetTemplateRepositoryNames(t *testing.T) {
-	trs := []*configuration.TemplateRepository{
-		{
-			Name:    "test1",
-			Version: "test",
-		},
-		{
-			Name: "test2",
-		},
-	}
-
-	result := getTemplateRepositoryNames(trs)
-
-	assert.DeepEqual(t, result, []string{"test1", "test2"})
-}
-
 // Doing this just to bump up coverage numbers, we essentially test this w/ the Template
 // constructors in each test.
 func TestCoverageHack(t *testing.T) {

--- a/pkg/stenciltest/stenciltest_test.go
+++ b/pkg/stenciltest/stenciltest_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/getoutreach/stencil/pkg/configuration"
 	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 )
 
@@ -15,6 +16,7 @@ func TestMain(t *testing.T) {
 		m:                   &configuration.TemplateRepositoryManifest{Name: "testing"},
 		t:                   t,
 		persist:             false,
+		log:                 logrus.New(),
 	}
 	st.Run(false)
 }
@@ -26,6 +28,7 @@ func TestErrorHandling(t *testing.T) {
 		m:                   &configuration.TemplateRepositoryManifest{Name: "testing"},
 		t:                   t,
 		persist:             false,
+		log:                 logrus.New(),
 	}
 	st.ErrorContains("sad")
 	st.Run(false)
@@ -36,6 +39,7 @@ func TestErrorHandling(t *testing.T) {
 		m:                   &configuration.TemplateRepositoryManifest{Name: "testing"},
 		t:                   t,
 		persist:             false,
+		log:                 logrus.New(),
 	}
 	st.ErrorContains("sad pikachu")
 	st.Run(false)
@@ -52,6 +56,7 @@ func TestArgs(t *testing.T) {
 		}},
 		t:       t,
 		persist: false,
+		log:     logrus.New(),
 	}
 	st.Args(map[string]interface{}{"hello": "world"})
 	st.Run(false)
@@ -71,31 +76,6 @@ func TestGetTemplateRepositoryNames(t *testing.T) {
 	result := getTemplateRepositoryNames(trs)
 
 	assert.DeepEqual(t, result, []string{"test1", "test2"})
-}
-
-func TestModulesFromTemplateRepository(t *testing.T) {
-	trs := []*configuration.TemplateRepository{
-		{
-			Name:    "test1",
-			Version: "test",
-		},
-		{
-			Name: "test2",
-		},
-	}
-
-	result, err := modulesFromTemplateRepository(trs)
-	if err != nil {
-		t.Fatalf("unexpected error while creating modules: %v", err)
-	}
-
-	// Ensure we respect the passed in version
-	assert.Equal(t, result[0].Name, "test1")
-	assert.Equal(t, result[0].Version, "test")
-
-	// Ensure we default to main
-	assert.Equal(t, result[1].Name, "test2")
-	assert.Equal(t, result[1].Version, "main")
 }
 
 // Doing this just to bump up coverage numbers, we essentially test this w/ the Template

--- a/pkg/stenciltest/stenciltest_test.go
+++ b/pkg/stenciltest/stenciltest_test.go
@@ -57,6 +57,47 @@ func TestArgs(t *testing.T) {
 	st.Run(false)
 }
 
+func TestGetTemplateRepositoryNames(t *testing.T) {
+	trs := []*configuration.TemplateRepository{
+		{
+			Name:    "test1",
+			Version: "test",
+		},
+		{
+			Name: "test2",
+		},
+	}
+
+	result := getTemplateRepositoryNames(trs)
+
+	assert.DeepEqual(t, result, []string{"test1", "test2"})
+}
+
+func TestModulesFromTemplateRepository(t *testing.T) {
+	trs := []*configuration.TemplateRepository{
+		{
+			Name:    "test1",
+			Version: "test",
+		},
+		{
+			Name: "test2",
+		},
+	}
+
+	result, err := modulesFromTemplateRepository(trs)
+	if err != nil {
+		t.Fatalf("unexpected error while creating modules: %v", err)
+	}
+
+	// Ensure we respect the passed in version
+	assert.Equal(t, result[0].Name, "test1")
+	assert.Equal(t, result[0].Version, "test")
+
+	// Ensure we default to main
+	assert.Equal(t, result[1].Name, "test2")
+	assert.Equal(t, result[1].Version, "main")
+}
+
 // Doing this just to bump up coverage numbers, we essentially test this w/ the Template
 // constructors in each test.
 func TestCoverageHack(t *testing.T) {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Support from was a matter of loading dependent modules in tests.

You can see this working in https://github.com/getoutreach/stencil-outreach/pull/59.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-2896]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-2896]: https://outreach-io.atlassian.net/browse/DT-2896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ