### PR TITLE
feat(modules): support resolving dependencies of in-memory modules

### DIFF
--- a/internal/cmd/stencil/stencil.go
+++ b/internal/cmd/stencil/stencil.go
@@ -102,7 +102,11 @@ func (c *Command) Run(ctx context.Context) error {
 	}
 
 	c.log.Info("Fetching dependencies")
-	mods, err := modules.GetModulesForService(ctx, c.token, c.manifest, c.log)
+	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		ServiceManifest: c.manifest,
+		Token:           c.token,
+		Log:             c.log,
+	})
 	if err != nil {
 		return errors.Wrap(err, "failed to process modules list")
 	}

--- a/pkg/stenciltest/stenciltest.go
+++ b/pkg/stenciltest/stenciltest.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/bradleyjkemp/cupaloy"
+	"github.com/getoutreach/gobox/pkg/cli/github"
 	"github.com/getoutreach/stencil/internal/codegen"
 	"github.com/getoutreach/stencil/internal/modules"
 	"github.com/getoutreach/stencil/internal/modules/modulestest"
@@ -51,6 +52,9 @@ type Template struct {
 	// MUST error.
 	errStr string
 
+	// log is the logger to use when running stencil
+	log logrus.FieldLogger
+
 	// persist denotes if we should save a snapshot or not
 	// This is meant for tests.
 	persist bool
@@ -75,12 +79,16 @@ func New(t *testing.T, templatePath string, additionalTemplates ...string) *Temp
 		t.Fatal(err)
 	}
 
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+
 	return &Template{
 		t:                   t,
 		m:                   &m,
 		path:                templatePath,
 		additionalTemplates: additionalTemplates,
 		persist:             true,
+		log:                 log,
 		exts:                map[string]apiv1.Implementation{},
 	}
 }
@@ -122,24 +130,21 @@ func getTemplateRepositoryNames(trs []*configuration.TemplateRepository) []strin
 	return deps
 }
 
-// modulesFromTemplateRepository creates new modules from the passed in TemplateRepositories
-func modulesFromTemplateRepository(trs []*configuration.TemplateRepository) ([]*modules.Module, error) {
-	var mods []*modules.Module
-	for _, tr := range trs {
-		// Use the present version or main
-		if tr.Version == "" {
-			tr.Version = "main"
-		}
-
-		m, err := modules.New(context.Background(), "", tr)
-		if err != nil {
-			return nil, fmt.Errorf("could not create a new modules for %s: %w", tr.Name, err)
-		}
-
-		mods = append(mods, m)
+// getModuleDependencies returns modules that are dependencies of the current module
+// the top-level manifest should be used to create the module that is passed in to ensure
+// that the version criteria is met.
+func (t *Template) getModuleDependencies(ctx context.Context, m *modules.Module) ([]*modules.Module, error) {
+	token, err := github.GetToken()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to get github token: %v", err)
 	}
 
-	return mods, nil
+	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		Token:  token,
+		Module: m,
+		Log:    t.log,
+	})
+	return mods, err
 }
 
 // Run runs the test.
@@ -148,26 +153,29 @@ func (t *Template) Run(save bool) {
 		deps := getTemplateRepositoryNames(t.m.Modules)
 
 		m, err := modulestest.NewModuleFromTemplates(
-			t.m.Arguments, "modulestest", deps, append([]string{t.path}, t.additionalTemplates...)...)
+			t.m.Arguments, t.m.Name, deps, append([]string{t.path}, t.additionalTemplates...)...)
 		if err != nil {
 			got.Fatalf("failed to create module from template %q", t.path)
 		}
 
-		mods, err := modulesFromTemplateRepository(t.m.Modules)
+		mods, err := t.getModuleDependencies(context.Background(), m)
 		if err != nil {
 			got.Fatalf("could not get modules: %v ", err)
 		}
 		mods = append(mods, m)
 
-		mf := &configuration.ServiceManifest{Name: "testing", Arguments: t.args,
-			Modules: []*configuration.TemplateRepository{{Name: m.Name}}}
-		st := codegen.NewStencil(mf, mods, logrus.New())
+		mf := &configuration.ServiceManifest{
+			Name:      "testing",
+			Arguments: t.args,
+			Modules:   []*configuration.TemplateRepository{{Name: m.Name}},
+		}
+		st := codegen.NewStencil(mf, mods, t.log)
 
 		for name, ext := range t.exts {
 			st.RegisterInprocExtensions(name, ext)
 		}
 
-		tpls, err := st.Render(context.Background(), logrus.New())
+		tpls, err := st.Render(context.Background(), t.log)
 		if err != nil {
 			if t.errStr != "" {
 				// if t.errStr was set then we expected an error, since that

--- a/pkg/stenciltest/stenciltest_test.go
+++ b/pkg/stenciltest/stenciltest_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/getoutreach/stencil/pkg/configuration"
 	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 )
 
@@ -15,6 +16,7 @@ func TestMain(t *testing.T) {
 		m:                   &configuration.TemplateRepositoryManifest{Name: "testing"},
 		t:                   t,
 		persist:             false,
+		log:                 logrus.New(),
 	}
 	st.Run(false)
 }
@@ -26,6 +28,7 @@ func TestErrorHandling(t *testing.T) {
 		m:                   &configuration.TemplateRepositoryManifest{Name: "testing"},
 		t:                   t,
 		persist:             false,
+		log:                 logrus.New(),
 	}
 	st.ErrorContains("sad")
 	st.Run(false)
@@ -36,6 +39,7 @@ func TestErrorHandling(t *testing.T) {
 		m:                   &configuration.TemplateRepositoryManifest{Name: "testing"},
 		t:                   t,
 		persist:             false,
+		log:                 logrus.New(),
 	}
 	st.ErrorContains("sad pikachu")
 	st.Run(false)
@@ -52,6 +56,7 @@ func TestArgs(t *testing.T) {
 		}},
 		t:       t,
 		persist: false,
+		log:     logrus.New(),
 	}
 	st.Args(map[string]interface{}{"hello": "world"})
 	st.Run(false)
@@ -71,31 +76,6 @@ func TestGetTemplateRepositoryNames(t *testing.T) {
 	result := getTemplateRepositoryNames(trs)
 
 	assert.DeepEqual(t, result, []string{"test1", "test2"})
-}
-
-func TestModulesFromTemplateRepository(t *testing.T) {
-	trs := []*configuration.TemplateRepository{
-		{
-			Name:    "test1",
-			Version: "test",
-		},
-		{
-			Name: "test2",
-		},
-	}
-
-	result, err := modulesFromTemplateRepository(trs)
-	if err != nil {
-		t.Fatalf("unexpected error while creating modules: %v", err)
-	}
-
-	// Ensure we respect the passed in version
-	assert.Equal(t, result[0].Name, "test1")
-	assert.Equal(t, result[0].Version, "test")
-
-	// Ensure we default to main
-	assert.Equal(t, result[1].Name, "test2")
-	assert.Equal(t, result[1].Version, "main")
 }
 
 // Doing this just to bump up coverage numbers, we essentially test this w/ the Template


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds support for resolving the dependencies of modules in-memory. This adds the notion of `dontResolve` to a `rm` (`ResolvedModule`)  that prevents a module from ever attempting to be resolved again (we re-resolve modules to ensure that additive criterias are considered).

This is used in combination with the new `ModuleResolveOptions` type that is passed to `GetModulesForService` that supports setting `Replacements` to be used to like the current `replacements` option in a `service.yaml`, but for in-memory modules.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
