### PR TITLE
fix: use full manifest in tests

### DIFF
--- a/internal/codegen/stencil_test.go
+++ b/internal/codegen/stencil_test.go
@@ -68,11 +68,17 @@ func TestModuleHookRender(t *testing.T) {
 	ctx := context.Background()
 
 	// create modules
-	m1, err := modulestest.NewModuleFromTemplates(nil, "testing1", nil, "testdata/module-hook/m1.tpl")
+	m1man := &configuration.TemplateRepositoryManifest{
+		Name: "testing1",
+	}
+	m1, err := modulestest.NewModuleFromTemplates(m1man, "testdata/module-hook/m1.tpl")
 	if err != nil {
 		t.Errorf("failed to create module 1: %v", err)
 	}
-	m2, err := modulestest.NewModuleFromTemplates(nil, "testing2", nil, "testdata/module-hook/m2.tpl")
+	m2man := &configuration.TemplateRepositoryManifest{
+		Name: "testing2",
+	}
+	m2, err := modulestest.NewModuleFromTemplates(m2man, "testdata/module-hook/m2.tpl")
 	if err != nil {
 		t.Errorf("failed to create module 2: %v", err)
 	}

--- a/internal/codegen/tpl_stencil_arg_test.go
+++ b/internal/codegen/tpl_stencil_arg_test.go
@@ -30,7 +30,11 @@ func fakeTemplate(t *testing.T, args map[string]interface{},
 	test := &testTpl{}
 	log := logrus.New()
 
-	m, err := modulestest.NewModuleFromTemplates(requestArgs, "test", nil)
+	man := &configuration.TemplateRepositoryManifest{
+		Name:      "test",
+		Arguments: requestArgs,
+	}
+	m, err := modulestest.NewModuleFromTemplates(man)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +86,11 @@ func fakeTemplateMultipleModules(t *testing.T, serviceManifestArgs map[string]in
 			continue
 		}
 
-		m, err := modulestest.NewModuleFromTemplates(args[i], fmt.Sprintf("test-%d", i), nil, "testdata/args/test.tpl")
+		man := &configuration.TemplateRepositoryManifest{
+			Name:      fmt.Sprintf("test-%d", i),
+			Arguments: args[i],
+		}
+		m, err := modulestest.NewModuleFromTemplates(man, "testdata/args/test.tpl")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -90,8 +98,17 @@ func fakeTemplateMultipleModules(t *testing.T, serviceManifestArgs map[string]in
 		mods[i] = m
 	}
 
+	var trs []*configuration.TemplateRepository
+	for _, imp := range importList {
+		trs = append(trs, &configuration.TemplateRepository{Name: imp})
+	}
+	man := &configuration.TemplateRepositoryManifest{
+		Name:      "test-0",
+		Arguments: args[0],
+		Modules:   trs,
+	}
 	var err error
-	mods[0], err = modulestest.NewModuleFromTemplates(args[0], "test-0", importList, "testdata/args/test.tpl")
+	mods[0], err = modulestest.NewModuleFromTemplates(man, "testdata/args/test.tpl")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/codegen/values_test.go
+++ b/internal/codegen/values_test.go
@@ -94,7 +94,10 @@ func TestValues(t *testing.T) {
 func TestGeneratedValues(t *testing.T) {
 	log := logrus.New()
 
-	m, err := modulestest.NewModuleFromTemplates(map[string]configuration.Argument{}, "testing", []string{}, "testdata/values/values.tpl")
+	man := &configuration.TemplateRepositoryManifest{
+		Name: "testing",
+	}
+	m, err := modulestest.NewModuleFromTemplates(man, "testdata/values/values.tpl")
 	assert.NilError(t, err, "failed to create module")
 
 	st := NewStencil(&configuration.ServiceManifest{

--- a/internal/modules/module_test.go
+++ b/internal/modules/module_test.go
@@ -243,12 +243,25 @@ func TestShouldResolveInMemoryModule(t *testing.T) {
 
 	// require test-dep which is also an in-memory module to make sure that we can resolve at least once
 	// an in-memory module
-	m, err := modulestest.NewModuleFromTemplates(map[string]configuration.Argument{}, "test", []string{"test-dep"})
+
+	man := &configuration.TemplateRepositoryManifest{
+		Name: "test",
+		Modules: []*configuration.TemplateRepository{
+			{Name: "test-dep"},
+		},
+	}
+	m, err := modulestest.NewModuleFromTemplates(man)
 	assert.NilError(t, err, "failed to create module")
 
 	// this relies on the top-level to ensure that re-resolving still picks
 	// the in-memory module
-	mDep, err := modulestest.NewModuleFromTemplates(map[string]configuration.Argument{}, "test-dep", []string{"test"})
+	man = &configuration.TemplateRepositoryManifest{
+		Name: "test-dep",
+		Modules: []*configuration.TemplateRepository{
+			{Name: "test"},
+		},
+	}
+	mDep, err := modulestest.NewModuleFromTemplates(man)
 	assert.NilError(t, err, "failed to create dep module")
 
 	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{

--- a/pkg/stenciltest/stenciltest.go
+++ b/pkg/stenciltest/stenciltest.go
@@ -121,15 +121,6 @@ func (t *Template) ErrorContains(msg string) {
 	t.errStr = msg
 }
 
-// getTemplateRepositoryNames retrieves the names from the passed in TemplateRepositories
-func getTemplateRepositoryNames(trs []*configuration.TemplateRepository) []string {
-	deps := make([]string, len(trs))
-	for i, tr := range trs {
-		deps[i] = tr.Name
-	}
-	return deps
-}
-
 // getModuleDependencies returns modules that are dependencies of the current module
 // the top-level manifest should be used to create the module that is passed in to ensure
 // that the version criteria is met.
@@ -150,10 +141,7 @@ func (t *Template) getModuleDependencies(ctx context.Context, m *modules.Module)
 // Run runs the test.
 func (t *Template) Run(save bool) {
 	t.t.Run(t.path, func(got *testing.T) {
-		deps := getTemplateRepositoryNames(t.m.Modules)
-
-		m, err := modulestest.NewModuleFromTemplates(
-			t.m.Arguments, t.m.Name, deps, append([]string{t.path}, t.additionalTemplates...)...)
+		m, err := modulestest.NewModuleFromTemplates(t.m, append([]string{t.path}, t.additionalTemplates...)...)
 		if err != nil {
 			got.Fatalf("failed to create module from template %q", t.path)
 		}

--- a/pkg/stenciltest/stenciltest_test.go
+++ b/pkg/stenciltest/stenciltest_test.go
@@ -62,22 +62,6 @@ func TestArgs(t *testing.T) {
 	st.Run(false)
 }
 
-func TestGetTemplateRepositoryNames(t *testing.T) {
-	trs := []*configuration.TemplateRepository{
-		{
-			Name:    "test1",
-			Version: "test",
-		},
-		{
-			Name: "test2",
-		},
-	}
-
-	result := getTemplateRepositoryNames(trs)
-
-	assert.DeepEqual(t, result, []string{"test1", "test2"})
-}
-
 // Doing this just to bump up coverage numbers, we essentially test this w/ the Template
 // constructors in each test.
 func TestCoverageHack(t *testing.T) {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Uses the full manifest when running tests. This makes sure all present and future fields get passed through without extra housekeeping. 

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-2896]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-2896]: https://outreach-io.atlassian.net/browse/DT-2896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ