### PR TITLE
fix: better jsonschema validation errors

### DIFF
--- a/internal/codegen/tpl_stencil_arg.go
+++ b/internal/codegen/tpl_stencil_arg.go
@@ -210,7 +210,7 @@ func (s *TplStencil) validateArg(pth string, arg *configuration.Argument, v inte
 			for _, validationErr := range validationError.DetailedOutput().Errors {
 				path, err := buildErrorPath(validationErr.AbsoluteKeywordLocation)
 				if err != nil {
-					s.log.Errorf("Validation failed but failed to determine cause: %v", err)
+					s.log.Errorf("Validation failed but could not determine cause: %v", err)
 				}
 				s.log.Errorf("Encountered a validation error for %q: %v", path, validationErr.Error)
 			}

--- a/internal/codegen/tpl_stencil_arg_test.go
+++ b/internal/codegen/tpl_stencil_arg_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/getoutreach/stencil/internal/modules/modulestest"
 	"github.com/getoutreach/stencil/pkg/configuration"
 	"github.com/sirupsen/logrus"
+	"gotest.tools/v3/assert"
 )
 
 type testTpl struct {
@@ -338,5 +339,48 @@ func TestTplStencil_Arg(t *testing.T) {
 				t.Errorf("TplStencil.Arg() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuildErrorPath(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		absoluteKeywordLocation string
+		expected                string
+		expectErr               bool
+	}{
+		{
+			name:                    "simple schema",
+			absoluteKeywordLocation: "file:///home/test/getoutreach/stencil/manifest.yaml/arguments/releaseOptions.allowMajorVersions#/type",
+			expected:                "arguments.releaseOptions.allowMajorVersions",
+			expectErr:               false,
+		},
+		{
+			name:                    "complex schema",
+			absoluteKeywordLocation: "file:///Users/test/getoutreach/stencil-smartstore/testapps/orgschemagrpc/manifest.yaml/arguments/postgreSQL#/items/properties/name/pattern",
+			expected:                "arguments.postgreSQL.items.properties.name",
+			expectErr:               false,
+		},
+		{
+			name:                    "missing manifest",
+			absoluteKeywordLocation: "file:///Users/test/getoutreach/stencil-smartstore/testapps/orgschemagrpc/arguments/postgreSQL#/items/properties/name/pattern",
+			expected:                "arguments.postgreSQL.items.properties.name",
+			expectErr:               true,
+		},
+	}
+
+	for _, tc := range testCases {
+		result, err := buildErrorPath(tc.absoluteKeywordLocation)
+		if tc.expectErr {
+			if err == nil {
+				t.Fatalf("expectd and error but got none")
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("did not expect error, but got: %v", err)
+		}
+
+		assert.Equal(t, result, tc.expected)
 	}
 }

--- a/internal/codegen/tpl_stencil_arg_test.go
+++ b/internal/codegen/tpl_stencil_arg_test.go
@@ -67,6 +67,7 @@ func fakeTemplate(t *testing.T, args map[string]interface{},
 		t.Fatal(err)
 	}
 	test.t = tpls[0]
+	test.log = log
 
 	return test
 }
@@ -134,6 +135,7 @@ func fakeTemplateMultipleModules(t *testing.T, serviceManifestArgs map[string]in
 		t.Fatal(err)
 	}
 	test.t = tpls[0]
+	test.log = log
 
 	return test
 }
@@ -350,19 +352,22 @@ func TestBuildErrorPath(t *testing.T) {
 		expectErr               bool
 	}{
 		{
-			name:                    "simple schema",
+			name: "simple schema",
+			//nolint:lll // Why: realistic test case
 			absoluteKeywordLocation: "file:///home/test/getoutreach/stencil/manifest.yaml/arguments/releaseOptions.allowMajorVersions#/type",
 			expected:                "arguments.releaseOptions.allowMajorVersions",
 			expectErr:               false,
 		},
 		{
-			name:                    "complex schema",
+			name: "complex schema",
+			//nolint:lll // Why: realistic test case
 			absoluteKeywordLocation: "file:///Users/test/getoutreach/stencil-smartstore/testapps/orgschemagrpc/manifest.yaml/arguments/postgreSQL#/items/properties/name/pattern",
 			expected:                "arguments.postgreSQL.items.properties.name",
 			expectErr:               false,
 		},
 		{
-			name:                    "missing manifest",
+			name: "missing manifest",
+			//nolint:lll // Why: realistic test case
 			absoluteKeywordLocation: "file:///Users/test/getoutreach/stencil-smartstore/testapps/orgschemagrpc/arguments/postgreSQL#/items/properties/name/pattern",
 			expected:                "arguments.postgreSQL.items.properties.name",
 			expectErr:               true,


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR introduces better error messages for jsonschema validation. If there is a validation error, it will now look like:

```
ERRO[0007] Encountered a validation error for "arguments.releaseOptions.allowMajorVersions": expected boolean, but got string 
ERRO[0007] failed to run: run codegen: failed to render template "github.com/getoutreach/stencil-base/.releaserc.yaml.tpl": template: github.com/getoutreach/stencil-base/.releaserc.yaml.tpl:19:21: executing "github.com/getoutreach/stencil-base/.releaserc.yaml.tpl" at <stencil.Arg>: error calling Arg: module "github.com/getoutreach/stencil-base" validation failed 
```

It also provides the full path even for complex schemas (like smartstore) that include nested field validations.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3149]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3149]: https://outreach-io.atlassian.net/browse/DT-3149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ