### PR TITLE
feat: cache stencil modules using commit

### DIFF
--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/getoutreach/gobox/pkg/cli/github"
+	"github.com/getoutreach/gobox/pkg/cli/updater/resolver"
 	"github.com/getoutreach/stencil/pkg/configuration"
 	"github.com/getoutreach/stencil/pkg/extensions"
 	"github.com/go-git/go-billy/v5"
@@ -121,7 +122,10 @@ func (m *Module) RegisterExtensions(ctx context.Context, log logrus.FieldLogger,
 		return nil
 	}
 
-	return ext.RegisterExtension(ctx, m.URI, m.Name, m.Version)
+	version := &resolver.Version{
+		Tag: m.Version,
+	}
+	return ext.RegisterExtension(ctx, m.URI, m.Name, version)
 }
 
 // Manifest downloads the module if not already downloaded and returns a parsed

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -173,8 +173,8 @@ func getVersionWithCommit(ctx context.Context, token cfg.SecretData, repoURL str
 			return nil, errors.Wrap(err, "failed to get latest version")
 		}
 		return v, nil
-
 	}
+
 	v, err = resolver.Resolve(ctx, token, &resolver.Criteria{
 		URL:         repoURL,
 		Constraints: []string{version.Tag},

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -14,6 +14,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/blang/semver/v4"
+	"github.com/getoutreach/gobox/pkg/cfg"
 	"github.com/getoutreach/gobox/pkg/cli/github"
 	"github.com/getoutreach/gobox/pkg/cli/updater/archive"
 	"github.com/getoutreach/gobox/pkg/cli/updater/release"
@@ -109,7 +111,7 @@ func (h *Host) GetExtensionCaller(ctx context.Context) (*ExtensionCaller, error)
 // RegisterExtension registers a ext from a given source
 // and compiles/downloads it. A client is then created
 // that is able to communicate with the ext.
-func (h *Host) RegisterExtension(ctx context.Context, source, name, version string) error { //nolint:funlen // Why: OK length.
+func (h *Host) RegisterExtension(ctx context.Context, source, name string, version *resolver.Version) error { //nolint:funlen // Why: OK length.
 	h.log.WithField("extension", name).WithField("source", source).Debug("Registered extension")
 
 	u, err := giturls.Parse(source)
@@ -148,11 +150,39 @@ func (h *Host) RegisterInprocExtension(name string, ext apiv1.Implementation) {
 }
 
 // getExtensionPath returns the path to an extension binary
-func (h *Host) getExtensionPath(version, name string) string {
+func (h *Host) getExtensionPath(commit, name string) string {
+	fmt.Printf("commit: %v\n", commit)
 	homeDir, _ := os.UserHomeDir() //nolint:errcheck // Why: signature doesn't allow it, yet
-	path := filepath.Join(homeDir, ".outreach", ".cache", "stencil", "extensions", name, fmt.Sprintf("@%s", version), filepath.Base(name))
+	path := filepath.Join(homeDir, ".outreach", ".cache", "stencil", "extensions", name, fmt.Sprintf("@%s", commit), filepath.Base(name))
 	os.MkdirAll(filepath.Dir(path), 0o755) //nolint:errcheck // Why: signature doesn't allow it, yet
 	return path
+}
+
+// getVersionWithCommit retrieves a new version with the commit present.
+func getVersionWithCommit(ctx context.Context, token cfg.SecretData, repoURL string,
+	version *resolver.Version) (*resolver.Version, error) {
+	var v *resolver.Version
+	var err error
+	// We assume that if the tag does not comply with semver it is a channel (e.g. unstable).
+	if _, err := semver.ParseTolerant(version.Tag); err != nil {
+		v, err = resolver.Resolve(ctx, token, &resolver.Criteria{
+			URL:     repoURL,
+			Channel: version.Tag,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get latest version")
+		}
+		return v, nil
+
+	}
+	v, err = resolver.Resolve(ctx, token, &resolver.Criteria{
+		URL:         repoURL,
+		Constraints: []string{version.Tag},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get latest version")
+	}
+	return v, nil
 }
 
 // downloadFromRemote downloads a release from github and extracts it to disk
@@ -162,7 +192,8 @@ func (h *Host) getExtensionPath(version, name string) string {
 //	org: getoutreach
 //	repo: stencil-plugin
 //	name: github.com/getoutreach/stencil-plugin
-func (h *Host) downloadFromRemote(ctx context.Context, name, version string) (string, error) {
+func (h *Host) downloadFromRemote(ctx context.Context, name string,
+	version *resolver.Version) (string, error) {
 	token, err := github.GetToken()
 	if err != nil {
 		h.log.WithError(err).Warn("Failed to get github token, falling back to anonymous")
@@ -170,19 +201,28 @@ func (h *Host) downloadFromRemote(ctx context.Context, name, version string) (st
 
 	repoURL := "https://" + name
 
-	if version == "" {
+	if version.Tag == "" {
 		v, err := resolver.Resolve(ctx, token, &resolver.Criteria{
 			URL: repoURL,
 		})
 		if err != nil {
 			return "", errors.Wrap(err, "failed to get latest version")
 		}
-		version = v.Tag
+		version = v
+	}
+
+	if version.Commit == "" {
+		v, err := getVersionWithCommit(ctx, token, repoURL, version)
+		if err != nil {
+			return "", errors.Wrap(err, "retrieving commit")
+
+		}
+		version = v
 	}
 
 	// Check if the version we're pulling already exists and is executable before downloading
 	// it again.
-	dlPath := h.getExtensionPath(version, name)
+	dlPath := h.getExtensionPath(version.Commit, name)
 	if info, err := os.Stat(dlPath); err == nil && info.Mode() == 0o755 {
 		return dlPath, nil
 	}
@@ -191,7 +231,7 @@ func (h *Host) downloadFromRemote(ctx context.Context, name, version string) (st
 	a, archiveName, _, err := release.Fetch(ctx, token, &release.FetchOptions{
 		AssetName: filepath.Base(name) + "_*_" + runtime.GOOS + "_" + runtime.GOARCH + ".tar.gz",
 		RepoURL:   repoURL,
-		Tag:       version,
+		Tag:       version.Tag,
 	})
 	if err != nil {
 		return "", errors.Wrap(err, "failed to fetch release")

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -150,10 +150,10 @@ func (h *Host) RegisterInprocExtension(name string, ext apiv1.Implementation) {
 }
 
 // getExtensionPath returns the path to an extension binary
-func (h *Host) getExtensionPath(commit, name string) string {
-	fmt.Printf("commit: %v\n", commit)
+func (h *Host) getExtensionPath(version *resolver.Version, name string) string {
 	homeDir, _ := os.UserHomeDir() //nolint:errcheck // Why: signature doesn't allow it, yet
-	path := filepath.Join(homeDir, ".outreach", ".cache", "stencil", "extensions", name, fmt.Sprintf("@%s", commit), filepath.Base(name))
+	path := filepath.Join(homeDir, ".outreach", ".cache", "stencil", "extensions",
+		name, fmt.Sprintf("@%s", version.Commit), filepath.Base(name))
 	os.MkdirAll(filepath.Dir(path), 0o755) //nolint:errcheck // Why: signature doesn't allow it, yet
 	return path
 }
@@ -222,7 +222,7 @@ func (h *Host) downloadFromRemote(ctx context.Context, name string,
 
 	// Check if the version we're pulling already exists and is executable before downloading
 	// it again.
-	dlPath := h.getExtensionPath(version.Commit, name)
+	dlPath := h.getExtensionPath(version, name)
 	if info, err := os.Stat(dlPath); err == nil && info.Mode() == 0o755 {
 		return dlPath, nil
 	}

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/getoutreach/gobox/pkg/cli/updater/resolver"
 	"github.com/getoutreach/stencil/pkg/extensions"
 	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
@@ -17,7 +18,10 @@ func TestCanImportNativeExtension(t *testing.T) {
 	ext := extensions.NewHost(logrus.New())
 	defer ext.Close()
 
-	err := ext.RegisterExtension(ctx, "https://github.com/getoutreach/stencil-golang", "github.com/getoutreach/stencil-golang", "v1.3.0")
+	version := &resolver.Version{
+		Tag: "v1.3.0",
+	}
+	err := ext.RegisterExtension(ctx, "https://github.com/getoutreach/stencil-golang", "github.com/getoutreach/stencil-golang", version)
 	assert.NilError(t, err, "failed to register extension")
 
 	caller, err := ext.GetExtensionCaller(ctx)


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Uses the commit for caching instead of the tag. This helps ensure we grab the same version even when we change the tag. Most commonly this happens with `unstable` as it is a dynamic tag.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3191]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3191]: https://outreach-io.atlassian.net/browse/DT-3191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ