### PR TITLE
fix(values): default box config when failed to load

### DIFF
--- a/internal/codegen/values.go
+++ b/internal/codegen/values.go
@@ -168,8 +168,11 @@ func NewValues(ctx context.Context, sm *configuration.ServiceManifest, mods []*m
 		})
 	}
 
-	//nolint:errcheck // Why: expose if available
-	vals.Runtime.Box, _ = box.LoadBox()
+	var err error
+	vals.Runtime.Box, err = box.LoadBox()
+	if err != nil {
+		vals.Runtime.Box = &box.Config{}
+	}
 
 	// If we're a repository, add repository information
 	if r, err := gogit.PlainOpen(""); err == nil {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Currently, if the box config fails to load we set a nil value. This causes nil pointer dereferences. Now, we set a value to prevent that from ocurring.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
