### PR TITLE
feat: support multiple templating engines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.19
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
-	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
 	github.com/charmbracelet/glamour v0.6.0
@@ -29,9 +28,14 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-require github.com/hashicorp/go-multierror v1.1.1
+require (
+	github.com/CloudyKit/jet/v6 v6.2.0
+	github.com/Masterminds/sprig/v3 v3.2.3
+	github.com/hashicorp/go-multierror v1.1.1
+)
 
 require (
+	github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
@@ -98,7 +102,7 @@ require (
 	github.com/schollz/progressbar/v3 v3.9.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
-	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,10 @@ github.com/AlecAivazis/survey/v2 v2.3.6 h1:NvTuVHISgTHEHeBFqt6BHOe4Ny/NwGZr7w+F8
 github.com/AlecAivazis/survey/v2 v2.3.6/go.mod h1:4AuI9b7RjAR+G7v9+C4YSlX/YL3K3cWNXgWXOhllqvI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53 h1:sR+/8Yb4slttB4vD+b9btVEnWgL3Q00OBTzVT8B9C0c=
+github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=
+github.com/CloudyKit/jet/v6 v6.2.0 h1:EpcZ6SR9n28BUGtNJSvlBqf90IpjeFr36Tizxhn/oME=
+github.com/CloudyKit/jet/v6 v6.2.0/go.mod h1:d3ypHeIRNo2+XyqnGA8s+aphtcVpjP5hPwP/Lzo7Ro4=
 github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.5.0/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -562,9 +566,8 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
-github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=

--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 
 	"github.com/getoutreach/gobox/pkg/app"
+	"github.com/getoutreach/stencil/internal/engine"
 	"github.com/getoutreach/stencil/internal/modules"
 	"github.com/getoutreach/stencil/pkg/configuration"
 	"github.com/getoutreach/stencil/pkg/extensions"
@@ -225,6 +226,20 @@ func (s *Stencil) PostRun(ctx context.Context, log logrus.FieldLogger) error {
 	return nil
 }
 
+// isTemplateFile determines if the provided name is a template file
+func (s *Stencil) isTemplateFile(name string) bool {
+	ext := filepath.Ext(name)
+	tplExts := engine.GetEngineExtensions()
+	for _, e := range tplExts {
+		if e == ext {
+			return true
+		}
+	}
+
+	// not a template, nothing was equal above
+	return false
+}
+
 // getTemplates takes all modules attached to this stencil
 // struct and returns all templates exposed by it.
 func (s *Stencil) getTemplates(ctx context.Context, log logrus.FieldLogger) ([]*Template, error) {
@@ -268,8 +283,8 @@ func (s *Stencil) getTemplates(ctx context.Context, log logrus.FieldLogger) ([]*
 				return err
 			}
 
-			// Skip files without a .tpl extension
-			if filepath.Ext(path) != ".tpl" {
+			// Skip files that do not appear to be template files
+			if !s.isTemplateFile(path) {
 				return nil
 			}
 

--- a/internal/codegen/stencil_test.go
+++ b/internal/codegen/stencil_test.go
@@ -26,7 +26,7 @@ func TestBasicE2ERender(t *testing.T) {
 	f.Close()
 
 	// create a stub template
-	f, err := fs.Create("test-template.tpl")
+	f, err := fs.Create("templates/test-template.tpl")
 	assert.NilError(t, err, "failed to create stub template")
 	f.Write([]byte("{{ .Config.Name }}"))
 	f.Close()

--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -10,9 +10,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"reflect"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/getoutreach/stencil/internal/engine"
 	"github.com/go-git/go-billy/v5"
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/pkg/errors"
@@ -245,7 +247,8 @@ func (s *TplStencil) ApplyTemplate(name string, dataSli ...interface{}) (string,
 	}
 
 	var buf bytes.Buffer
-	if err := s.t.Module.GetTemplate().ExecuteTemplate(&buf, name, data); err != nil {
+	if err := s.t.Module.GetTemplate(engine.GetEngineNameForExtension(filepath.Ext(s.t.Path))).
+		Render(name, &buf, nil, data); err != nil {
 		return "", err
 	}
 

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,0 +1,77 @@
+// Copyright 2023 Outreach Corporation. All Rights Reserved.
+
+// Description: This file contains the engines for rendering templates.
+
+// Package engine contains logic for the template engines supported by stencil.
+package engine
+
+import (
+	"github.com/getoutreach/stencil/internal/engine/htmltemplate"
+	"github.com/getoutreach/stencil/internal/engine/jet"
+	"github.com/getoutreach/stencil/internal/engine/texttemplate"
+)
+
+// Name is the name of a template engine
+type Name string
+
+// Contains the name of valid template rendering engines
+const (
+	// NameTextTemplate is the name of the text/template go-template engine
+	NameTextTemplate Name = "go-template:text/template"
+
+	// NameHTMLTemplate is the name of the html/template go-template engine
+	NameHTMLTemplate Name = "go-template:html/template"
+
+	// NameJet is the name of the jet templating language engine
+	NameJet Name = "jet"
+)
+
+// engines is a map of all the engines that are available
+var engines = map[Name]NewInstance{
+	NameTextTemplate: func(moduleName string) (Instance, error) {
+		return texttemplate.NewInstance(moduleName)
+	},
+	NameHTMLTemplate: func(moduleName string) (Instance, error) {
+		return htmltemplate.NewInstance(moduleName)
+	},
+	NameJet: func(moduleName string) (Instance, error) {
+		return jet.NewInstance(moduleName)
+	},
+}
+
+// engineForExtensions is a map to engine names for a given extension
+var engineForExtensions = map[Name][]string{
+	NameHTMLTemplate: {".htpl"},
+	NameTextTemplate: {".tpl"},
+	NameJet:          {".jet"},
+}
+
+// GetEngine returns a NewInstance function for the given engine name
+func GetEngine(name Name) (NewInstance, bool) {
+	eng, ok := engines[name]
+	return eng, ok
+}
+
+// GetEngineNameForExtension returns the engine name for a given
+// extension
+func GetEngineNameForExtension(ext string) Name {
+	for name, exts := range engineForExtensions {
+		for _, e := range exts {
+			if e == ext {
+				return name
+			}
+		}
+	}
+
+	return ""
+}
+
+// GetEngineExtensions returns all valid template extensions for
+// all engines.
+func GetEngineExtensions() []string {
+	all := []string{}
+	for _, exts := range engineForExtensions {
+		all = append(all, exts...)
+	}
+	return all
+}

--- a/internal/engine/htmltemplate/htmltemplate.go
+++ b/internal/engine/htmltemplate/htmltemplate.go
@@ -1,0 +1,48 @@
+// Copyright 2023 Outreach Corporation. All Rights Reserved.
+
+// Description: This file implements the html/template go-template renderer
+// as an engine.
+
+// Package htmltemplate implements a html/template engine using the go-template
+// renderer as an engine.
+package htmltemplate
+
+import (
+	"html/template"
+	"io"
+
+	"github.com/Masterminds/sprig/v3"
+)
+
+// NewInstance returns a new instance of the html/template go-template engine
+func NewInstance(moduleName string) (*Instance, error) {
+	return &Instance{
+		t: template.New(moduleName).Funcs(sprig.HtmlFuncMap()),
+	}, nil
+}
+
+// Instance is an instance of a html/template go-template engine
+type Instance struct {
+	// t is the underlying template used by this engine instance
+	t *template.Template
+}
+
+// Parse parses a template and adds it to the current template instance
+func (i *Instance) Parse(name string, r io.Reader, fns map[string]any) error {
+	contents, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	_, err = i.t.New(name).Funcs(fns).Parse(string(contents))
+	return err
+}
+
+// Render renders a template into the provide writer
+func (i *Instance) Render(name string, out io.Writer, fns map[string]any, args any) error {
+	tpl := i.t
+	if fns != nil {
+		tpl = tpl.Funcs(fns)
+	}
+	return tpl.ExecuteTemplate(out, name, args)
+}

--- a/internal/engine/interface.go
+++ b/internal/engine/interface.go
@@ -1,0 +1,24 @@
+// Copyright 2023 Outreach Corporation. All Rights Reserved.
+
+// Description: This file contains the interface(s) for engines
+// to implement.
+
+package engine
+
+import "io"
+
+// NewInstance is a function that returns a new instance of an engine.
+// All engines must implement this.
+type NewInstance func(moduleName string) (Instance, error)
+
+// Instance is an instance of an engine. An instance uses a global backing
+// engine that enables cross-template rendering an function calls, when
+// applicable to the underlying engine (e.g., go-templates)
+type Instance interface {
+	// Parse parses a template and adds it to the current engine. Depending
+	// on the underlying implementation it may be executed.
+	Parse(name string, r io.Reader, fns map[string]any) error
+
+	// Render renders the template to the given writer
+	Render(name string, out io.Writer, fns map[string]any, args any) error
+}

--- a/internal/engine/jet/cache.go
+++ b/internal/engine/jet/cache.go
@@ -1,0 +1,31 @@
+// Copyright 2023 Outreach Corporation. All Rights Reserved.
+
+// Description: This file implements a cache for jet.
+
+package jet
+
+import (
+	"sync"
+
+	"github.com/CloudyKit/jet/v6"
+)
+
+// cache is an in-memory cache for usage with jet. It implements the
+// jet.Cache interface
+type cache struct {
+	m sync.Map
+}
+
+// Get retrieves a jet.Template from the cache
+func (c *cache) Get(templatePath string) *jet.Template {
+	_t, ok := c.m.Load(templatePath)
+	if !ok {
+		return nil
+	}
+	return _t.(*jet.Template)
+}
+
+// Put puts a template into the cache
+func (c *cache) Put(templatePath string, t *jet.Template) {
+	c.m.Store(templatePath, t)
+}

--- a/internal/engine/jet/jet.go
+++ b/internal/engine/jet/jet.go
@@ -1,0 +1,101 @@
+// Copyright 2023 Outreach Corporation. All Rights Reserved.
+
+// Description: This file implements an engine for the jet templating language
+
+// Package jet implements a jet templating language engine
+package jet
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/CloudyKit/jet/v6"
+)
+
+// NewInstance returns a new instance of the jet engine
+func NewInstance(moduleName string) (*Instance, error) {
+	c := &cache{}
+
+	return &Instance{
+		set:   jet.NewSet(jet.NewInMemLoader(), jet.WithCache(c)),
+		cache: c,
+	}, nil
+}
+
+// Instance is an instance of a jet engine
+type Instance struct {
+	// set is the underlying template set for jet
+	set *jet.Set
+
+	// cache is the underlying jet cache
+	cache jet.Cache
+}
+
+// funcsToJetFunc converts a map[string]any into set.AddGlobalFunc
+func (i *Instance) funcsToJetFunc(fns map[string]any) {
+	for name, fn := range fns {
+		i.set.AddGlobalFunc(name, func(a jet.Arguments) reflect.Value {
+			rv := reflect.ValueOf(fn)
+			if rv.Kind() != reflect.Func {
+				panic(fmt.Errorf("global function %q is not a function", name))
+			}
+
+			// convert all arguments into a []reflect.Value
+			args := make([]reflect.Value, a.NumOfArguments())
+			for i := 0; i < a.NumOfArguments(); i++ {
+				args[i] = a.Get(i)
+			}
+
+			rtrn := rv.Call(args)
+			if len(rtrn) > 2 {
+				panic(fmt.Errorf("global function %q returned more than two arguments, halp!?", name))
+			}
+
+			if len(rtrn) == 2 {
+				// if the second argument is an error, panic
+				if rtrn[1].Interface() != nil {
+					a.Panicf("global function %q returned an error: %v", name, rtrn[1].Interface())
+				}
+			}
+
+			// otherwise, return the first return value
+			return rtrn[0]
+		})
+	}
+}
+
+// Parse parses a template and adds it to the current template instance
+func (i *Instance) Parse(name string, r io.Reader, fns map[string]any) error {
+	contents, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	// Ensure the global functions are available
+	i.funcsToJetFunc(fns)
+
+	// TODO(jaredallard): This probably doesn't handle their extend/inherit stuff
+	// correctly. We probably would need to load all templates into memory first
+	// to do that.
+	t, err := i.set.Parse(name, string(contents))
+	if err != nil {
+		return err
+	}
+	i.cache.Put("/"+name, t)
+
+	return err
+}
+
+// Render renders a template into the provide writer
+func (i *Instance) Render(name string, out io.Writer, fns map[string]any, args any) error {
+	t, err := i.set.GetTemplate(name)
+	if err != nil {
+		return err
+	}
+
+	// Update the global functions
+	i.funcsToJetFunc(fns)
+
+	return t.Execute(out, nil, args)
+}

--- a/internal/engine/jet/jet_test.go
+++ b/internal/engine/jet/jet_test.go
@@ -1,0 +1,34 @@
+package jet_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	_ "embed"
+
+	"github.com/Masterminds/sprig/v3"
+	"github.com/getoutreach/stencil/internal/engine/jet"
+	"gotest.tools/v3/assert"
+)
+
+//go:embed testdata/shouldrender.jet
+var shouldRenderData string
+
+func TestShouldRender(t *testing.T) {
+	i, err := jet.NewInstance("test")
+	assert.NilError(t, err, "failed to create engine instance")
+
+	err = i.Parse("test.jet", strings.NewReader(shouldRenderData), sprig.TxtFuncMap())
+	assert.NilError(t, err, "failed to parse template")
+
+	buf := new(bytes.Buffer)
+	err = i.Render("test.jet", buf, sprig.TxtFuncMap(), map[string]interface{}{
+		"Config": map[string]interface{}{
+			"Name": "test",
+		},
+	})
+	assert.NilError(t, err, "failed to render template")
+
+	assert.Equal(t, buf.String(), "test", "expected template to render correctly")
+}

--- a/internal/engine/jet/testdata/shouldrender.jet
+++ b/internal/engine/jet/testdata/shouldrender.jet
@@ -1,0 +1,1 @@
+{{ .Config.Name }}

--- a/internal/engine/texttemplate/texttemplate.go
+++ b/internal/engine/texttemplate/texttemplate.go
@@ -1,0 +1,48 @@
+// Copyright 2023 Outreach Corporation. All Rights Reserved.
+
+// Description: This file implements the text/template go-template renderer
+// as an engine.
+
+// Package texttemplate implements a template engine using the go-template
+// renderer as an engine.
+package texttemplate
+
+import (
+	"io"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+)
+
+// NewInstance returns a new instance of the text/template go-template engine
+func NewInstance(moduleName string) (*Instance, error) {
+	return &Instance{
+		t: template.New(moduleName).Funcs(sprig.TxtFuncMap()),
+	}, nil
+}
+
+// Instance is an instance of a text/template go-template engine
+type Instance struct {
+	// t is the underlying template used by this engine instance
+	t *template.Template
+}
+
+// Parse parses a template and adds it to the current template instance
+func (i *Instance) Parse(name string, r io.Reader, fns map[string]any) error {
+	contents, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
+	_, err = i.t.New(name).Funcs(fns).Parse(string(contents))
+	return err
+}
+
+// Render renders a template into the provide writer
+func (i *Instance) Render(name string, out io.Writer, fns map[string]any, args any) error {
+	tpl := i.t
+	if fns != nil {
+		tpl = tpl.Funcs(fns)
+	}
+	return tpl.ExecuteTemplate(out, name, args)
+}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds the notion of an `engine` into stencil. This allows the usage of multiple different templating engines currently, only `text/template`, `html/template` and [`jet`](https://github.com/CloudyKit/jet) are supported.

Currently, all functionality is supported in `text/template` and `html/template`, but functionality like `inherit`, `import`, and `extends` are not supported due to how the template renderer works today. Future work will enable this functionality.

[`jet`](https://github.com/CloudyKit/jet) is a much stronger templating language that lends itself better to template "programming" like we practice today. Eventually, it'll become the recommended templating language for usage.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
