### PR TITLE
fix(modules): properly resolve branches as versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,11 +29,13 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
-require github.com/hashicorp/go-multierror v1.1.1
+require (
+	github.com/Masterminds/semver/v3 v3.2.0
+	github.com/hashicorp/go-multierror v1.1.1
+)
 
 require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect

--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -292,7 +292,7 @@ func (s *TplStencil) ReadBlocks(fpath string) (map[string]string, error) {
 
 // Debug logs the provided arguments under the DEBUG log level (must run stencil with --debug).
 //
-//  {{- $_ := stencil.Debug "I'm a log!" }}
+//	{{- $_ := stencil.Debug "I'm a log!" }}
 func (s *TplStencil) Debug(args ...interface{}) error {
 	s.log.WithField("path", s.t.Path).Debug(args...)
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR fixes the documented using branches in `version` field for modules. This wasn't working, despite being documented due to the contrainst work done awhile ago. To enable this, when we can't parse a valid constraint out of `version`, we assume we're using a branch. `channel` is essentially a glorified branch system (with support for pre-release versions), so we alias `Version` to `Channel` when this is supplied.

Longer term we should remove channels and only support constraint or branch.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3366]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3366]: https://outreach-io.atlassian.net/browse/DT-3366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ