### PR TITLE
feat(module-hooks): sort module hook data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,20 +4,20 @@ go 1.19
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
+	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bradleyjkemp/cupaloy v2.3.0+incompatible
 	github.com/charmbracelet/glamour v0.6.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/getoutreach/gobox v1.57.1
-
-	// This version has util.Walk
-	// https://github.com/go-git/go-billy/commit/7ab80d7c013de28ffbb1ca64b9bbf8dd1cbd81c5
 	github.com/go-git/go-billy/v5 v5.4.1
 	github.com/go-git/go-git/v5 v5.6.0
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-hclog v1.4.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-plugin v1.4.9
+	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/santhosh-tekuri/jsonschema/v5 v5.2.0
 	github.com/sirupsen/logrus v1.9.0
@@ -27,11 +27,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.4.0
 	sigs.k8s.io/yaml v1.3.0
-)
-
-require (
-	github.com/Masterminds/semver/v3 v3.2.0
-	github.com/hashicorp/go-multierror v1.1.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -463,6 +463,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
+github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=

--- a/internal/codegen/tpl_stencil_test.go
+++ b/internal/codegen/tpl_stencil_test.go
@@ -127,7 +127,7 @@ func TestTplStencil_GetModuleHook(t *testing.T) {
 					),
 				),
 				s: &Stencil{sharedData: &sharedData{
-					moduleHooks: make(map[string][]interface{}),
+					moduleHooks: make(map[string]*moduleHook),
 					globals:     make(map[string]global),
 				}},
 				log: logrus.New(),
@@ -142,6 +142,10 @@ func TestTplStencil_GetModuleHook(t *testing.T) {
 				}
 			}
 			s.s.isFirstPass = false
+
+			// Sort the module hooks, which should be called by stencil before
+			// the second pass
+			s.s.sortModuleHooks()
 
 			if got := s.GetModuleHook(tt.args.name); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("TplStencil.GetModuleHook() = %v, want %v", got, tt.want)

--- a/internal/codegen/tpl_stencil_test.go
+++ b/internal/codegen/tpl_stencil_test.go
@@ -8,8 +8,12 @@ package codegen
 import (
 	"reflect"
 	"testing"
+	"time"
 
+	"github.com/getoutreach/stencil/internal/modules/modulestest"
+	"github.com/getoutreach/stencil/pkg/configuration"
 	"github.com/go-git/go-billy/v5"
+	"github.com/sirupsen/logrus"
 )
 
 func TestTplStencil_ReadBlocks(t *testing.T) {
@@ -62,6 +66,85 @@ func TestTplStencil_ReadBlocks(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("TplStencil.ReadBlocks() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func TestTplStencil_GetModuleHook(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name    string
+		inserts []interface{}
+		args    args
+		want    []interface{}
+	}{
+		{
+			inserts: []interface{}{
+				[]string{"abc"},
+				[]string{"def"},
+				[]interface{}{map[string]interface{}{
+					"abc": "def",
+				}},
+				[]string{"abc"},
+			},
+			args: args{
+				name: "name",
+			},
+			want: []interface{}{
+				// This is what the hashing resulted in
+				map[string]interface{}{
+					"abc": "def",
+				},
+				"def",
+				"abc",
+				"abc",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &TplStencil{
+				t: must(
+					NewTemplate(
+						must(modulestest.NewModuleFromTemplates(&configuration.TemplateRepositoryManifest{
+							Name: "test",
+						})),
+						"not-a-real-template.tpl",
+						0o755,
+						time.Now(),
+						[]byte(""),
+						logrus.New(),
+					),
+				),
+				s: &Stencil{sharedData: &sharedData{
+					moduleHooks: make(map[string][]interface{}),
+					globals:     make(map[string]global),
+				}},
+				log: logrus.New(),
+			}
+
+			s.s.isFirstPass = true
+			for _, insert := range tt.inserts {
+				err1, err2 := s.AddToModuleHook(s.t.Module.Name, tt.args.name, insert)
+				if err1 != nil || err2 != nil {
+					t.Errorf("TplStencil.GetModuleHook() error = %v, %v", err1, err2)
+					return
+				}
+			}
+			s.s.isFirstPass = false
+
+			if got := s.GetModuleHook(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TplStencil.GetModuleHook() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds sorting to module hooks by using `hashstructure`, falling back to `fmt.Sprintf("%v")`. This makes re-runs of stencil more reproducible, since module hook insertion order is not guaranteed because file execution order is not.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3484]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3484]: https://outreach-io.atlassian.net/browse/DT-3484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ