### PR TITLE
fix: panic on GetModuleHook that doesnt exist

### DIFF
--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -36,19 +36,19 @@ type TplStencil struct {
 // This is incredibly useful for allowing other modules to write
 // to files that your module owns. Think of them as extension points
 // for your module. The value returned by this function is always a
-// []interface{}, aka a list.
+// []any, aka a list.
 //
-//	{{- /* This returns a []interface{} */}}
+//	{{- /* This returns a []any */}}
 //	{{ $hook := stencil.GetModuleHook "myModuleHook" }}
 //	{{- range $hook }}
 //	  {{ . }}
 //	{{- end }}
-func (s *TplStencil) GetModuleHook(name string) []interface{} {
+func (s *TplStencil) GetModuleHook(name string) []any {
 	k := s.s.sharedData.key(s.t.Module.Name, name)
 	v := s.s.sharedData.moduleHooks[k]
 	if v == nil {
 		// No data, return nothing
-		return nil
+		return []any{}
 	}
 
 	s.log.WithField("template", s.t.ImportPath()).WithField("path", k).

--- a/internal/codegen/tpl_stencil.go
+++ b/internal/codegen/tpl_stencil.go
@@ -46,6 +46,10 @@ type TplStencil struct {
 func (s *TplStencil) GetModuleHook(name string) []interface{} {
 	k := s.s.sharedData.key(s.t.Module.Name, name)
 	v := s.s.sharedData.moduleHooks[k]
+	if v == nil {
+		// No data, return nothing
+		return nil
+	}
 
 	s.log.WithField("template", s.t.ImportPath()).WithField("path", k).
 		WithField("data", spew.Sdump(v)).Debug("getting module hook")

--- a/service.yaml
+++ b/service.yaml
@@ -2,8 +2,6 @@ name: stencil
 arguments:
   commands:
     - stencil
-  coverage:
-    provider: codecov
   description: microservice lifecycle manager
   lintroller: platinum
   metrics: datadog


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR fixes a panic on a module hook that has no data.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
