### PR TITLE
fix: stencil create module depend on stencil-circleci and stencil-base

### DIFF
--- a/cmd/stencil/create_module.go
+++ b/cmd/stencil/create_module.go
@@ -82,6 +82,10 @@ func NewCreateModule() *cli.Command {
 				Name: path.Base(c.Args().Get(0)),
 				Modules: []*configuration.TemplateRepository{{
 					Name: "github.com/getoutreach/stencil-template-base",
+				}, {
+					Name: "github.com/getoutreach/stencil-base",
+				}, {
+					Name: "github.com/getoutreach/stencil-circleci",
 				}},
 				Arguments: map[string]interface{}{
 					"reportingTeam": reportingTeam,

--- a/docs/content/en/getting-started/module-quick-start.md
+++ b/docs/content/en/getting-started/module-quick-start.md
@@ -20,7 +20,7 @@ This quick start assumes you're familiar with stencil usage already. If you aren
 
 ## Step 1: Create a module
 
-Using the [`stencil create`]() command we're able to quickly create a module, let's start with a simple hello world module.
+Using the [`stencil create`]() command we're able to quickly create a module, let's start with a simple hello world module. 
 
 {{< code file="create-module.sh" >}}
 mkdir helloworld; cd helloworld

--- a/docs/content/en/getting-started/module-quick-start.md
+++ b/docs/content/en/getting-started/module-quick-start.md
@@ -27,7 +27,7 @@ mkdir helloworld; cd helloworld
 stencil create module github.com/yourorg/helloworld
 {{< /code >}}
 
-You'll notice that when running that command, stencil itself was ran. This is because `stencil create` uses the [`stencil-template-base`](https://github.com/getoutreach/stencil-template-base) module by default. This brings automatic CI and testing support to your module.
+You'll notice that when running that command, stencil itself was ran. This is because `stencil create` uses the [`stencil-template-base`](https://github.com/getoutreach/stencil-template-base), the [`stencil-base`](https://github.com/getoutreach/stencil-base), and the [`stencil-circleci`](https://github.com/getoutreach/stencil-circleci) modules by default. This brings automatic CI and testing support to your module.
 
 Let's briefly look at what it's created:
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Adds the dependency for stencil-circleci and stencil-base here since both were removed from stencil-template-base.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3579]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3579]: https://outreach-io.atlassian.net/browse/DT-3579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ