### PR TITLE
chore: Promote unstable to rc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.16.0
+  shared: getoutreach/shared@2.18.0
   queue: eddiewebb/queue@1.8.4
 
 parameters:

--- a/stencil.lock
+++ b/stencil.lock
@@ -2,7 +2,7 @@ version: v1.36.0
 modules:
     - name: github.com/getoutreach/devbase
       url: https://github.com/getoutreach/devbase
-      version: v2.16.0
+      version: v2.18.0
     - name: github.com/getoutreach/stencil-actions
       url: https://github.com/getoutreach/stencil-actions
       version: v0.3.0


### PR DESCRIPTION
Promote unstable to rc, created by `dt release promote`

**DO NOT MERGE**