### PR TITLE
fix: Use OrbVersion for correct shared orb version

### DIFF
--- a/internal/codegen/values.go
+++ b/internal/codegen/values.go
@@ -79,6 +79,9 @@ type module struct {
 
 	// Version is the version of the current module
 	Version string
+
+	// OrbVersion is the shared orb version for current module
+	OrbVersion string
 }
 
 // stencilTemplate contains information about the current template
@@ -163,8 +166,9 @@ func NewValues(ctx context.Context, sm *configuration.ServiceManifest, mods []*m
 
 	for _, m := range mods {
 		vals.Runtime.Modules = append(vals.Runtime.Modules, module{
-			Name:    m.Name,
-			Version: m.Version,
+			Name:       m.Name,
+			Version:    m.Version,
+			OrbVersion: m.OrbVersion,
 		})
 	}
 

--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -50,6 +50,9 @@ type Module struct {
 	// Version is the version of this module
 	Version string
 
+	// OrbVersion is the shared orb version for this module
+	OrbVersion string
+
 	// fs is a cached filesystem
 	fs billy.Filesystem
 }
@@ -78,7 +81,6 @@ func New(ctx context.Context, uri string, tr *configuration.TemplateRepository) 
 		if _, err := os.Stat(osPath); err != nil {
 			return nil, errors.Wrapf(err, "failed to find module %s at path %q", tr.Name, osPath)
 		}
-
 		// translate the path into a file:// URI
 		uri = "file://" + osPath
 		tr.Version = localModuleVersion
@@ -87,7 +89,7 @@ func New(ctx context.Context, uri string, tr *configuration.TemplateRepository) 
 		return nil, fmt.Errorf("version must be specified for module %q", tr.Name)
 	}
 
-	return &Module{template.New(tr.Name).Funcs(sprig.TxtFuncMap()), tr.Name, uri, tr.Version, nil}, nil
+	return &Module{template.New(tr.Name).Funcs(sprig.TxtFuncMap()), tr.Name, uri, tr.Version, tr.OrbVersion, nil}, nil
 }
 
 // NewWithFS creates a module with the specified file system. This is

--- a/internal/modules/module_test.go
+++ b/internal/modules/module_test.go
@@ -59,6 +59,29 @@ func TestReplacementLocalModule(t *testing.T) {
 		"expected module to use replacement URI")
 }
 
+func TestReplacementModuleUseOrbversion(t *testing.T) {
+	sm := &configuration.ServiceManifest{
+		Name: "testing-service",
+		Modules: []*configuration.TemplateRepository{
+			{
+				Name:       "github.com/getoutreach/stencil-base",
+				OrbVersion: "stable",
+			},
+		},
+		Replacements: map[string]string{
+			"github.com/getoutreach/stencil-base": "file://testdata",
+		},
+	}
+
+	mods, err := modules.GetModulesForService(context.Background(), &modules.ModuleResolveOptions{ServiceManifest: sm, Log: newLogger()})
+	assert.NilError(t, err, "expected GetModulesForService() to not error")
+	assert.Equal(t, len(mods), 1, "expected exactly one module to be returned")
+	t.Log("mod version ", mods[0].OrbVersion, mods[0].Version)
+	assert.Equal(t, mods[0].Version, "local", "expected module Version is local")
+	assert.Assert(t, len(mods[0].OrbVersion) > 1, "expected module orbVersion is not empty")
+	assert.Assert(t, mods[0].OrbVersion != "local", "expected module orbVersion is not local")
+}
+
 func TestCanGetLatestVersion(t *testing.T) {
 	ctx := context.Background()
 	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -91,6 +91,10 @@ type TemplateRepository struct {
 	// Version can also be a constraint as supported by the underlying resolver:
 	// https://pkg.go.dev/github.com/getoutreach/gobox/pkg/cli/updater/resolver#Resolve
 	Version string `yaml:"version,omitempty"`
+
+	// OrbVersion is the version of shared orb for CI. It is only used to override the orb version
+	// for devbase module local replacement
+	OrbVersion string `yaml:"orbVersion,omitempty"`
 }
 
 // TemplateRepositoryManifest is a manifest of a template repository


### PR DESCRIPTION
…b version

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Add OrbVersion to get the shared orb version and pass to stencil-circleCI. This is used to fix the problem that stencil-circleci changed the shared orb to `devbase:local` in devbase repo.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3834]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers
The OrbVersion is only applied when it is set in the manifest. 

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
