### PR TITLE
fix(configuration): annotate omitempty on deprecated prerelease attribute

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -75,7 +75,7 @@ type TemplateRepository struct {
 
 	// Deprecated: Use 'channel' instead, prerelease sets 'channel' to 'rc'.
 	// Prerelease is a boolean indicating whether or not to consider prerelease versions
-	Prerelease bool `yaml:"prerelease"`
+	Prerelease bool `yaml:"prerelease,omitempty"`
 
 	// Deprecated: Use name instead
 	// URL is a full URL for a given module


### PR DESCRIPTION
## What this PR does / why we need it

Hopefully this will cause `prerelease` to only be emitted if it is `true`.