### PR TITLE
feat: parallel resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/urfave/cli/v2 v2.27.1
+	golang.org/x/sync v0.6.0
 	golang.org/x/term v0.20.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.1

--- a/internal/modules/modules.go
+++ b/internal/modules/modules.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/getoutreach/gobox/pkg/cfg"
@@ -19,6 +20,7 @@ import (
 	"github.com/getoutreach/stencil/pkg/configuration"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
 )
 
 // resolvedModule is used to keep track of a module during the resolution
@@ -96,16 +98,214 @@ type ModuleResolveOptions struct {
 //
 //nolint:funlen // Why: Will be refactored in the future
 func GetModulesForService(ctx context.Context, opts *ModuleResolveOptions) ([]*Module, error) {
-	// start resolving the top-level modules
-	modulesToResolve := make([]resolveModule, 0)
+	wl := buildWorkLists(opts)
 
-	// strReplacements are replacements that replace the URL for a module's
+	log := opts.Log
+
+	concurentResolutions := 5
+	g := errgroup.Group{}
+	g.SetLimit(concurentResolutions)
+
+	for len(wl.tasks) > 0 {
+		for {
+			// get an item
+			item := wl.pop()
+			if item == nil {
+				break
+			}
+			// if it's marked "dont resolve", skip it
+			if item.inProgressResolution.dontResolve {
+				continue
+			}
+
+			// resolve the module in a goroutine
+			g.Go(func() error { return work(ctx, opts, item, &wl, log) })
+		}
+		// wait for all the goroutines to finish
+		err := g.Wait()
+		if err != nil {
+			return nil, err
+		}
+		// check if we have any more modules to resolve
+	}
+
+	// convert the resolved modules to a list of modules
+	modules := make([]*Module, 0, len(wl.resolved))
+	for _, m := range wl.resolved {
+		modules = append(modules, m.Module)
+	}
+	return modules, nil
+}
+
+// work does the actual work of resolving a module
+func work(ctx context.Context, opts *ModuleResolveOptions, item *workItem, wl *workList,
+	log logrus.FieldLogger) error {
+	var m *Module
+	var version *resolver.Version
+
+	// if we're not using a local or in-memory replaced module, resolve the version
+	// (local modules & in-memory modules should be treated as always satisfying constraints)
+	if !uriIsLocal(item.uri) && opts.Replacements[item.importPath] == nil {
+		var err error
+		version, err = wl.getLatestModuleForConstraints(ctx, item, opts.Token)
+		if err != nil {
+			return err
+		}
+	} else {
+		// for local + in-memory modules we don't have a version so just stub it
+		version = &resolver.Version{
+			Mutable: true,
+		}
+
+		// if uri is local, represent it as "local" instead of the full path
+		if uriIsLocal(item.uri) {
+			version.Tag = "local"
+		} else {
+			// otherwise assume in-memory
+			version.Tag = "in-memory"
+		}
+		version.Branch = version.Tag
+
+		// don't attempt to resolve this module again
+		item.inProgressResolution.dontResolve = true
+	}
+
+	// if we have a replacement for the module in-memory, use that instead
+	// of creating a new module that's to be resolved
+	if _, ok := opts.Replacements[item.importPath]; ok {
+		m = opts.Replacements[item.importPath]
+	} else {
+		var err error
+		m, err = New(ctx, item.uri, &configuration.TemplateRepository{
+			Name:    item.importPath,
+			Channel: item.spec.conf.Channel,
+			Version: version.GitRef(),
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	mf, err := m.Manifest(ctx)
+	if err != nil {
+		return err
+	}
+
+	// add the dependencies of this module to the stack to be resolved
+	for i := range mf.Modules {
+		wl.push(&resolveModule{
+			conf:   mf.Modules[i],
+			parent: item.importPath + "@" + version.String(),
+		})
+	}
+
+	// set the module on our resolved module
+	item.inProgressResolution.Module = m
+	item.inProgressResolution.version = version
+
+	log.WithFields(logrus.Fields{
+		"module":  item.importPath,
+		"version": version.GitRef(),
+	}).Debug("resolved module")
+	return nil
+}
+
+// workList is a list of modules to resolve
+type workList struct {
+	tasks []resolveModule
+	// replacements replace the URL for a module's
 	// provided import path.
-	strReplacements := make(map[string]string)
+	replacements map[string]string
 
 	// resolved contains the current modules that have been selected and is used
 	// to track previous resolutions/constraints for re-resolving modules.
-	resolved := make(map[string]*resolvedModule)
+	resolved map[string]*resolvedModule
+
+	// mu protects all the collections in this struct
+	mu  sync.Mutex
+	log logrus.FieldLogger
+}
+
+// workItem is a single item in the work list
+type workItem struct {
+	importPath           string
+	inProgressResolution *resolvedModule
+	spec                 resolveModule
+	uri                  string
+}
+
+// pop removes and returns the first item in the work list
+func (list *workList) pop() *workItem {
+	list.mu.Lock()
+	defer list.mu.Unlock()
+
+	if len(list.tasks) == 0 {
+		return nil
+	}
+	resolv := list.tasks[0]
+	list.tasks = list.tasks[1:]
+
+	if resolv.conf.Version != "" {
+		if _, err := semver.NewConstraint(resolv.conf.Version); err != nil {
+			// Attempt to resolve as a branch, which essentially is a channel.
+			// This is a bit of a hack, ideally we'll consolidate this logic when
+			// channels are ripped out of stencil later.
+			resolv.conf.Channel = resolv.conf.Version
+			resolv.conf.Version = ""
+		}
+	}
+
+	// check if it has already been resolved
+	importPath := resolv.conf.Name
+	if _, ok := list.resolved[importPath]; !ok {
+		list.resolved[importPath] = &resolvedModule{Module: &Module{}}
+	}
+	rm := list.resolved[importPath]
+
+	// if the module has already been resolved and is marked as
+	// "dontResolve", then re-use it.
+	if rm.dontResolve {
+		// this module has already been resolved and should always be used
+		list.log.WithFields(logrus.Fields{
+			"module": importPath,
+		}).Debug("Using in-memory module")
+		return &workItem{importPath: importPath, inProgressResolution: rm, spec: resolv}
+	}
+
+	// log the resolution attempt
+	rm.history = append(rm.history, resolution{
+		constraint:   resolv.conf.Version,
+		channel:      resolv.conf.Channel,
+		parentModule: resolv.parent,
+	})
+	list.log.WithFields(logrus.Fields{
+		"module": importPath,
+		"parent": resolv.parent,
+	}).Debug("resolving module")
+
+	uri := "https://" + importPath
+	// use a different url for the module if it's been replaced
+	if _, ok := list.replacements[importPath]; ok {
+		uri = list.replacements[importPath]
+	}
+
+	return &workItem{importPath: importPath, inProgressResolution: rm, spec: resolv, uri: uri}
+}
+
+// push adds a module to the work list
+func (list *workList) push(task *resolveModule) {
+	list.mu.Lock()
+	defer list.mu.Unlock()
+
+	list.tasks = append(list.tasks, *task)
+}
+
+// buildWorkLists constructs a list of modules to resolve and a map of string replacements
+func buildWorkLists(opts *ModuleResolveOptions) workList {
+	// start resolving the top-level modules
+	modulesToResolve := make([]resolveModule, 0)
+
+	strReplacements := make(map[string]string)
 
 	if opts.ServiceManifest != nil {
 		sm := opts.ServiceManifest
@@ -139,154 +339,33 @@ func GetModulesForService(ctx context.Context, opts *ModuleResolveOptions) ([]*M
 			parent: opts.Module.Name + " (top-level)",
 		})
 	}
-
-	log := opts.Log
-
-	// resolve all versions, adding more to the stack as we go
-	for {
-		// done resolving the modules
-		if len(modulesToResolve) == 0 {
-			break
-		}
-
-		resolv := modulesToResolve[0]
-		importPath := resolv.conf.Name
-		if _, ok := resolved[importPath]; !ok {
-			resolved[importPath] = &resolvedModule{Module: &Module{}}
-		}
-		rm := resolved[importPath]
-
-		if resolv.conf.Version != "" {
-			if _, err := semver.NewConstraint(resolv.conf.Version); err != nil {
-				// Attempt to resolve as a branch, which essentially is a channel.
-				// This is a bit of a hack, ideally we'll consolidate this logic when
-				// channels are ripped out of stencil later.
-				resolv.conf.Channel = resolv.conf.Version
-				resolv.conf.Version = ""
-			}
-		}
-
-		// if the module has already been resolved and is marked as
-		// "dontResolve", then re-use it.
-		if rm.dontResolve {
-			// this module has already been resolved and should always be used
-			log.WithFields(logrus.Fields{
-				"module": importPath,
-			}).Debug("Using in-memory module")
-			modulesToResolve = modulesToResolve[1:]
-			continue
-		}
-
-		// log the resolution attempt
-		rm.history = append(rm.history, resolution{
-			constraint:   resolv.conf.Version,
-			channel:      resolv.conf.Channel,
-			parentModule: resolv.parent,
-		})
-		log.WithFields(logrus.Fields{
-			"module": importPath,
-			"parent": resolv.parent,
-		}).Debug("resolving module")
-
-		uri := "https://" + importPath
-		var version *resolver.Version
-
-		var m *Module
-
-		// use a different url for the module if it's been replaced
-		if _, ok := strReplacements[importPath]; ok {
-			uri = strReplacements[importPath]
-		}
-
-		// if we're not using a local or in-memory replaced module, resolve the version
-		// (local modules & in-memory modules should be treated as always satisfying constraints)
-		if !uriIsLocal(uri) && opts.Replacements[importPath] == nil {
-			var err error
-			version, err = getLatestModuleForConstraints(ctx, uri, opts.Token, &resolv, resolved)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			// for local + in-memory modules we don't have a version so just stub it
-			version = &resolver.Version{
-				Mutable: true,
-			}
-
-			// if uri is local, represent it as "local" instead of the full path
-			if uriIsLocal(uri) {
-				version.Tag = "local"
-			} else {
-				// otherwise assume in-memory
-				version.Tag = "in-memory"
-			}
-			version.Branch = version.Tag
-
-			// don't attempt to resolve this module again
-			rm.dontResolve = true
-		}
-
-		// if we have a replacement for the module in-memory, use that instead
-		// of creating a new module that's to be resolved
-		if _, ok := opts.Replacements[importPath]; ok {
-			m = opts.Replacements[importPath]
-		} else {
-			var err error
-			m, err = New(ctx, uri, &configuration.TemplateRepository{
-				Name:    importPath,
-				Channel: resolv.conf.Channel,
-				Version: version.GitRef(),
-			})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		mf, err := m.Manifest(ctx)
-		if err != nil {
-			return nil, err
-		}
-
-		// add the dependencies of this module to the stack to be resolved
-		for i := range mf.Modules {
-			modulesToResolve = append(modulesToResolve, resolveModule{
-				conf:   mf.Modules[i],
-				parent: importPath + "@" + version.String(),
-			})
-		}
-
-		// set the module on our resolved module
-		rm.Module = m
-		rm.version = version
-
-		log.WithFields(logrus.Fields{
-			"module":  importPath,
-			"version": version.GitRef(),
-		}).Debug("resolved module")
-
-		// resolve the next module
-		modulesToResolve = modulesToResolve[1:]
+	return workList{
+		tasks:        modulesToResolve,
+		replacements: strReplacements,
+		log:          opts.Log,
+		resolved:     make(map[string]*resolvedModule),
 	}
-
-	// convert the resolved modules to a list of modules
-	modules := make([]*Module, 0, len(resolved))
-	for _, m := range resolved {
-		modules = append(modules, m.Module)
-	}
-	return modules, nil
 }
 
 // getLatestModuleForConstraints returns the latest module that satisfies the provided constraints
-func getLatestModuleForConstraints(ctx context.Context, uri string, token cfg.SecretData,
-	m *resolveModule, resolved map[string]*resolvedModule) (*resolver.Version, error) {
+func (list *workList) getLatestModuleForConstraints(ctx context.Context, item *workItem, token cfg.SecretData) (*resolver.Version, error) {
 	constraints := make([]string, 0)
-	for _, r := range resolved[m.conf.Name].history {
+	m := item.spec
+
+	list.mu.Lock()
+	// todo(AWinterman): Did i fuckover some modify by reference by lifting this up
+	module, ok := list.resolved[m.conf.Name]
+	// todo(AWinterman): this looks the same as item.inProgressResolution, is it?
+	list.mu.Unlock()
+
+	for _, r := range module.history {
 		if r.constraint != "" {
 			constraints = append(constraints, r.constraint)
 		}
 	}
 
 	channel := m.conf.Channel
-	for _, r := range resolved[m.conf.Name].history {
+	for _, r := range module.history {
 		// if we don't have a channel, or the channel is stable, check to see if
 		// the channel we last resolved with doesn't match the current channel requested.
 		//
@@ -304,23 +383,23 @@ func getLatestModuleForConstraints(ctx context.Context, uri string, token cfg.Se
 
 	// If the last version we resolved is mutable, it's impossible for us
 	// to compare the two, so we have to use it.
-	if rm, ok := resolved[m.conf.Name]; ok {
-		if rm.version != nil && rm.version.Mutable {
+	if ok {
+		if module.version != nil && module.version.Mutable {
 			// IDEA(jaredallard): We should log this as it's non-deterministic when we
 			// have a good interface for doing so.
-			return rm.version, nil
+			return module.version, nil
 		}
 	}
 
 	v, err := resolver.Resolve(ctx, token, &resolver.Criteria{
-		URL:           uri,
+		URL:           item.uri,
 		Channel:       channel,
 		Constraints:   constraints,
 		AllowBranches: true,
 	})
 	if err != nil {
 		errorString := ""
-		history := resolved[m.conf.Name].history
+		history := module.history
 		for i := range history {
 			h := &history[i]
 			errorString += strings.Repeat(" ", i*2) + "└─ "


### PR DESCRIPTION
Stencil spends a little while just doing network requests to gather its
dependencies.

Anecdotally, this is like several seconds per module, which makes
resolution take a long time.

This change set adds a smidge of parallelism to that resolution. The
strategy is to launch a fixed number of worker routines, use them to
resolve the work list, and then on completion, check whether items were
added to the work list that no worker picked up, due to a race condition
between when workers check for more work and when work can get added.

Existing tests covered this changeset completely, including revealing
situations where we'd leave items in the work set, so I didn't feel the
need to add additional coverage.
