### PR TITLE
chore: maintenance mode announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 <!-- <</Stencil::Block>> -->
 
+> [!WARNING]
+> This version of Stencil is in maintenance mode. That is, there is not enough time to maintain this aside from bug fixes and Outreach-specific features. The next-generation of this tool is currently located at [`rgst-io/stencil`](https://github.com/rgst-io/stencil).
+
 microservice lifecycle manager
 
 ## Contributing


### PR DESCRIPTION
## What this PR does / why we need it

This is for three reasons:

1. Note that a community version exists
2. Make it clear that we don't have the time to handle community requests
3. Allow the community version to use the Homebrew package identifier instead ([ref](https://github.com/orgs/Homebrew/discussions/5587))