### PR TITLE
ci(gh-pages): upgrade runner from Ubuntu 20.04 to 24.04, migrate job from asdf to mise

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -10,18 +10,13 @@ jobs:
   deploy:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup asdf
-        uses: asdf-vm/actions/install@v1
-      - name: Install hugo
-        working-directory: ./docs
-        run: |-
-          # We run this here because of sub directory limitations
-          asdf plugin add hugo
-          asdf install
-
+      - uses: jdx/mise-action@v2
+        with:
+          install_args: hugo
+          working_directory: ./docs
       - name: Build
         working-directory: ./docs
         run: hugo --minify

--- a/docs/.tool-versions
+++ b/docs/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.22.0
+golang 1.23.4
 hugo 0.108.0


### PR DESCRIPTION
## What this PR does / why we need it

The Ubuntu 20.04 runner is being removed ([ref](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/)).

Also replaces `asdf` in the runner with `mise`.
