### PR TITLE
fix: only print debug log when debug log level is specified

### DIFF
--- a/internal/modules/module.go
+++ b/internal/modules/module.go
@@ -183,7 +183,7 @@ func (m *Module) GetFS(ctx context.Context) (billy.Filesystem, error) {
 	}
 
 	cacheDir := filepath.Join(StencilCacheDir(), "module_fs", ModuleCacheDirectory(m.URI, m.Version))
-	logrus.Println("cacheDir", cacheDir)
+	logrus.Debug("cacheDir", cacheDir)
 
 	if useModuleCache(cacheDir) {
 		m.fs = osfs.New(cacheDir)


### PR DESCRIPTION
## What this PR does / why we need it

Regression from #411