### PR TITLE
feat: add `stencilVersion` constraint to template repository manifest

### DIFF
--- a/internal/cmd/stencil/stencil.go
+++ b/internal/cmd/stencil/stencil.go
@@ -9,14 +9,17 @@ package stencil
 
 import (
 	"context"
+	gerrors "errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/blang/semver/v4"
+	msemver "github.com/Masterminds/semver/v3"
+	bsemver "github.com/blang/semver/v4"
 	"github.com/charmbracelet/glamour"
+	"github.com/getoutreach/gobox/pkg/app"
 	"github.com/getoutreach/gobox/pkg/cfg"
 	"github.com/getoutreach/gobox/pkg/cli/github"
 	"github.com/getoutreach/stencil/internal/codegen"
@@ -93,6 +96,37 @@ func NewCommand(log logrus.FieldLogger, s *configuration.ServiceManifest, dryRun
 	}
 }
 
+// validateStencilVersion ensures that the running Stencil version is
+// compatible with the given Stencil modules.
+func (c *Command) validateStencilVersion(ctx context.Context, mods []*modules.Module, stencilVersion string) error {
+	sgv, err := msemver.StrictNewVersion(stencilVersion)
+	if err != nil {
+		return err
+	}
+
+	for _, m := range mods {
+		c.log.Infof(" -> %s %s", m.Name, m.Version)
+
+		manifest, err := m.Manifest(ctx)
+		if err != nil {
+			return errors.Wrap(err, "could not get module manifest")
+		}
+
+		if manifest.StencilVersion != "" {
+			versionConstraint, err := msemver.NewConstraint(manifest.StencilVersion)
+			if err != nil {
+				return err
+			}
+			if validated, errs := versionConstraint.Validate(sgv); !validated {
+				return fmt.Errorf("stencil version %s does not match the version constraint (%s) for %s: %w",
+					stencilVersion, manifest.StencilVersion, m.Name, gerrors.Join(errs...))
+			}
+		}
+	}
+
+	return nil
+}
+
 // Run fetches dependencies of the root modules and builds the layered filesystem,
 // after that GenerateFiles is called to actually walk the filesystem and render
 // the templates. This step also does minimal post-processing of the dependencies
@@ -119,8 +153,8 @@ func (c *Command) Run(ctx context.Context) error {
 		return errors.Wrap(err, "failed to handle major version upgrade")
 	}
 
-	for _, m := range mods {
-		c.log.Infof(" -> %s %s", m.Name, m.Version)
+	if err := c.validateStencilVersion(ctx, mods, app.Version); err != nil {
+		return err
 	}
 
 	st := codegen.NewStencil(c.manifest, mods, c.log)
@@ -171,7 +205,7 @@ func (c *Command) useModulesFromLock() error {
 	outOfSync := false
 	outOfSyncReasons := make([]string, 0)
 
-	// iterate over all of the modules that are desired, if
+	// Iterate over all of the modules that are desired, if
 	// they are not in the lockfile, then the user is unable
 	// to use a frozen lockfile.
 	for _, m := range c.manifest.Modules {
@@ -248,12 +282,12 @@ func (c *Command) checkForMajorVersions(ctx context.Context, mods []*modules.Mod
 			continue
 		}
 
-		lastV, err := semver.ParseTolerant(lastm.Version)
+		lastV, err := bsemver.ParseTolerant(lastm.Version)
 		if err != nil {
 			continue
 		}
 
-		newV, err := semver.ParseTolerant(m.Version)
+		newV, err := bsemver.ParseTolerant(m.Version)
 		if err != nil {
 			continue
 		}

--- a/internal/cmd/stencil/testdata/stencil-version-bad-constraint/manifest.yaml
+++ b/internal/cmd/stencil/testdata/stencil-version-bad-constraint/manifest.yaml
@@ -1,0 +1,2 @@
+name: example.com/stencil-test
+stencilVersion: invalid

--- a/internal/cmd/stencil/testdata/stencil-version-failure/manifest.yaml
+++ b/internal/cmd/stencil/testdata/stencil-version-failure/manifest.yaml
@@ -1,0 +1,2 @@
+name: example.com/stencil-test
+stencilVersion: ^2.0.0

--- a/internal/cmd/stencil/testdata/stencil-version-success/manifest.yaml
+++ b/internal/cmd/stencil/testdata/stencil-version-success/manifest.yaml
@@ -1,0 +1,2 @@
+name: example.com/stencil-test
+stencilVersion: ^1.0.0

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -102,6 +102,11 @@ type TemplateRepositoryManifest struct {
 	// Modules are template repositories that this manifest requires
 	Modules []*TemplateRepository `yaml:"modules"`
 
+	// StencilVersion is the version constraint which describes what
+	// versions of Stencil can render this module. It conforms to the
+	// constraint syntax as supported by github.com/Masterminds/semver/v3.
+	StencilVersion string `yaml:"stencilVersion,omitempty"`
+
 	// Type stores a comma-separated list of template repository types served by the current module.
 	// Use the TemplateRepositoryTypes.Contains method to check.
 	Type TemplateRepositoryTypes `yaml:"type,omitempty"`


### PR DESCRIPTION
## What this PR does / why we need it

This is a backport from `rgst-io` (the new upstream) - I want to use to make sure that current Outreach stencil templates can't be used with 2.x with a better error message.