### PR TITLE
fix: strip leading v when parsing stencil version as semver

### DIFF
--- a/internal/cmd/stencil/stencil.go
+++ b/internal/cmd/stencil/stencil.go
@@ -99,7 +99,8 @@ func NewCommand(log logrus.FieldLogger, s *configuration.ServiceManifest, dryRun
 // validateStencilVersion ensures that the running Stencil version is
 // compatible with the given Stencil modules.
 func (c *Command) validateStencilVersion(ctx context.Context, mods []*modules.Module, stencilVersion string) error {
-	sgv, err := msemver.StrictNewVersion(stencilVersion)
+	// Strip the leading 'v' if it exists
+	sgv, err := msemver.StrictNewVersion(strings.TrimPrefix(stencilVersion, "v"))
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/stencil/stencil_test.go
+++ b/internal/cmd/stencil/stencil_test.go
@@ -193,7 +193,7 @@ func TestValidateStencilVersionBadConstraint(t *testing.T) {
 	mods := []*modules.Module{
 		modules.NewWithFS(ctx, "example.com/stencil-test", osfs.New("testdata/stencil-version-bad-constraint")),
 	}
-	err := c.validateStencilVersion(ctx, mods, "1.10.0")
+	err := c.validateStencilVersion(ctx, mods, "v1.10.0")
 	assert.Error(t, err, "improper constraint: invalid")
 }
 
@@ -205,8 +205,8 @@ func TestValidateStencilVersionConstraintValidationFailure(t *testing.T) {
 	mods := []*modules.Module{
 		modules.NewWithFS(ctx, "example.com/stencil-test", osfs.New("testdata/stencil-version-failure")),
 	}
-	err := c.validateStencilVersion(ctx, mods, "1.10.0")
-	assert.ErrorContains(t, err, "stencil version 1.10.0 does not match the version constraint (^2.0.0) for example.com/stencil-test")
+	err := c.validateStencilVersion(ctx, mods, "v1.10.0")
+	assert.ErrorContains(t, err, "stencil version v1.10.0 does not match the version constraint (^2.0.0) for example.com/stencil-test")
 }
 
 func TestValidateStencilVersionConstraintValidationSuccess(t *testing.T) {
@@ -217,5 +217,5 @@ func TestValidateStencilVersionConstraintValidationSuccess(t *testing.T) {
 	mods := []*modules.Module{
 		modules.NewWithFS(ctx, "example.com/stencil-test", osfs.New("testdata/stencil-version-success")),
 	}
-	assert.NilError(t, c.validateStencilVersion(ctx, mods, "1.10.0"))
+	assert.NilError(t, c.validateStencilVersion(ctx, mods, "v1.10.0"))
 }


### PR DESCRIPTION
## What this PR does / why we need it

Regression from #426, the upstream Stencil doesn't prefix versions with `v` but gobox-based versions do (and the semver library doesn't parse it), so strip it from the beginning of the version string before parsing.