### PR TITLE
fix: avoid default branch errors when using non-English for LC_ALL

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ workflows:
       - shared/test:
           <<: *test
           ## <<Stencil::Block(circleSharedTestExtra)>>
-
+          pre_setup_script: ./scripts/test-pre-setup.sh
           ## <</Stencil::Block>>
       - shared/publish_docs:
           context: *contexts

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -7,6 +7,7 @@ package git
 
 import (
 	"context"
+	"os"
 	"os/exec"
 	"regexp"
 
@@ -32,6 +33,9 @@ var (
 func GetDefaultBranch(ctx context.Context, path string) (string, error) {
 	cmd := exec.CommandContext(ctx, "git", "remote", "show", "origin")
 	cmd.Dir = path
+	env := os.Environ()
+	env = append(env, "LC_ALL=C")
+	cmd.Env = env
 	out, err := cmd.Output()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get head branch from remote origin")

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025 Outreach Corporation. All Rights Reserved.
+
+// Description: Unit tests for the git package.
+
+package git_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	stgit "github.com/getoutreach/stencil/internal/git"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"gotest.tools/v3/assert"
+)
+
+// Makes sure that GetDefaultBranch works correctly even when the system language is not set to English.
+func TestGetDefaultBranchDifferentOSLanguage(t *testing.T) {
+	ctx := context.Background()
+
+	remoteRepoDir := t.TempDir()
+	remoteRepo, err := git.PlainInitWithOptions(remoteRepoDir, &git.PlainInitOptions{
+		InitOptions: git.InitOptions{DefaultBranch: "refs/heads/main"},
+		Bare:        false,
+	})
+	assert.NilError(t, err)
+	wt, err := remoteRepo.Worktree()
+	assert.NilError(t, err)
+	assert.NilError(t, os.WriteFile(filepath.Join(remoteRepoDir, "test.txt"), []byte("hello world"), 0o644))
+	_, err = wt.Add("test.txt")
+	assert.NilError(t, err)
+	_, err = wt.Commit("Initial commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test Author",
+			Email: "test@example.com",
+		},
+	})
+	assert.NilError(t, err)
+
+	repoDir := t.TempDir()
+	_, err = git.PlainCloneContext(ctx, repoDir, false, &git.CloneOptions{
+		URL: remoteRepoDir,
+	})
+	assert.NilError(t, err)
+
+	t.Setenv("LC_ALL", "fr_FR.UTF-8")
+	defaultBranch, err := stgit.GetDefaultBranch(ctx, repoDir)
+	assert.NilError(t, err)
+	assert.Equal(t, defaultBranch, "main", "Expected default branch to be 'main'")
+}

--- a/scripts/test-pre-setup.sh
+++ b/scripts/test-pre-setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#
+# Custom script to set up the environment before running tests.
+
+# This is needed to ensure that the French locale is available for tests.
+sudo apt-get install --yes language-pack-fr

--- a/scripts/test-pre-setup.sh
+++ b/scripts/test-pre-setup.sh
@@ -3,4 +3,5 @@
 # Custom script to set up the environment before running tests.
 
 # This is needed to ensure that the French locale is available for tests.
+sudo apt-get update
 sudo apt-get install --yes language-pack-fr


### PR DESCRIPTION
## What this PR does / why we need it

If a user sets their `LC_ALL` to a non-English value, and that language has a translation file for `git`, `git.DefaultBranch` will fail since it's [searching using the English output](https://github.com/getoutreach/stencil/blob/c801ba2cdc1f3a5e92e5010ee4799c709388ba7b/internal/git/git.go#L27).

Instead of setting `LC_ALL=C` when calling `git`, I have elected to convert it to use `go-git`, to avoid this whole mess entirely.

The test was written to fail with the current behavior, and passes with the changes (and also passes if we set `LC_ALL=C`).

## Jira ID

[DT-4814]

[DT-4814]: https://outreach-io.atlassian.net/browse/DT-4814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ