### PR TITLE
fix(git): use git CLI for DefaultBranch

### DIFF
--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -196,7 +196,7 @@ func (s *Stencil) Render(ctx context.Context, log logrus.FieldLogger) ([]*Templa
 	}
 
 	log.Debug("Creating values for template")
-	vals := NewValues(ctx, s.m, s.modules)
+	vals := NewValues(ctx, s.m, s.modules, log)
 	log.Debug("Finished creating values")
 
 	// Add the templates to their modules template to allow them to be able to access

--- a/internal/codegen/values.go
+++ b/internal/codegen/values.go
@@ -15,6 +15,7 @@ import (
 	"github.com/getoutreach/stencil/internal/modules"
 	"github.com/getoutreach/stencil/pkg/configuration"
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/sirupsen/logrus"
 )
 
 // runtime contains information about the current state
@@ -145,7 +146,7 @@ func (v *Values) WithTemplate(name string) *Values {
 
 // NewValues returns a fully initialized Values
 // based on the current runtime environment.
-func NewValues(ctx context.Context, sm *configuration.ServiceManifest, mods []*modules.Module) *Values {
+func NewValues(ctx context.Context, sm *configuration.ServiceManifest, mods []*modules.Module, log logrus.FieldLogger) *Values {
 	vals := &Values{
 		Git: git{},
 		Runtime: runtime{
@@ -178,6 +179,7 @@ func NewValues(ctx context.Context, sm *configuration.ServiceManifest, mods []*m
 	if r, err := gogit.PlainOpen(""); err == nil {
 		db, err := stencilgit.GetDefaultBranch(ctx, "")
 		if err != nil {
+			log.Warnf("Failed to get default branch, defaulting to 'main': %v", err)
 			db = "main"
 		}
 		vals.Git.DefaultBranch = db

--- a/internal/codegen/values_test.go
+++ b/internal/codegen/values_test.go
@@ -67,7 +67,7 @@ func TestValues(t *testing.T) {
 			Name:    "testing",
 			Version: "1.2.3",
 		},
-	})
+	}, logrus.New())
 	assert.DeepEqual(t, &Values{
 		Git: git{
 			Ref:           plumbing.NewBranchReferenceName("main").String(),


### PR DESCRIPTION
## What this PR does / why we need it

There was a regression in #430 where it didn't take into account authenticated repositories, and it wasn't clear that there was an issue because the values generation code ate the error but defaulted to `main`, so it wasn't until legacy private repos were restenciled made it obvious there was a problem.

1. Revert `go-git` implementation with a (fixed `LC_ALL=C`) `git` CLI implementation
2. Add a warning log when the default branch logic returns an error