### PR TITLE
fix: module replace not working

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -59,9 +59,19 @@
       "host": "127.0.0.1",
       "port": 42097
       // <</Stencil::Block>>
-    }
+    },
     // <<Stencil::Block(vscodeLaunchConfigs)>>
-
+    {
+      "name": "Debug stencil run",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "envFile": "${workspaceRoot}/.vscode/private.env",
+      "program": "${workspaceRoot}/cmd/stencil/",
+      "buildFlags": "-tags=or_dev",
+      "args": ["run"],
+      "cwd": "${workspaceRoot}" // replace with directory of the targed service
+    }
     // <</Stencil::Block>>
   ]
 }

--- a/internal/modules/modules.go
+++ b/internal/modules/modules.go
@@ -153,7 +153,7 @@ func work(ctx context.Context, opts *ModuleResolveOptions, item *workItem, wl *w
 
 	// if we're not using a local or in-memory replaced module, resolve the version
 	// (local modules & in-memory modules should be treated as always satisfying constraints)
-	if !uriIsLocal(item.uri) && opts.Replacements[item.importPath] == nil {
+	if !uriIsLocal(item.uri) && wl.replacements[item.importPath] == "" {
 		var err error
 		version, err = wl.getLatestModuleForConstraints(ctx, item, opts.Token)
 		if err != nil {


### PR DESCRIPTION
The `replacements` is not working as expected. The root cause is the replacement configuration is only saved in `workList`.

This PR also add vscode configuration to debug stencil

<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
