### PR TITLE
feat(configuration): per-argument deprecation for stencil manifests

### DIFF
--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -213,7 +213,7 @@ func runManifestReader(log logrus.FieldLogger, name string, r io.Reader) ([]lint
 }
 
 // logFindings logs each finding via logrus (stderr). Errors log at error level,
-// warnings at warn level.
+// warnings at warn level, and info findings at info level.
 func logFindings(log logrus.FieldLogger, findings []lint.Finding) {
 	for _, f := range findings {
 		entry := log.WithField("path", f.Path)

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -222,6 +222,8 @@ func logFindings(log logrus.FieldLogger, findings []lint.Finding) {
 			entry.Warn(f.Message)
 		case lint.SeverityError:
 			entry.Error(f.Message)
+		case lint.SeverityInfo:
+			entry.Info(f.Message)
 		default:
 			// Defensive: surface any unexpected severity as an error so it is
 			// never silently dropped.

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -50,6 +51,31 @@ func TestFailIfFindingsPolicy(t *testing.T) {
 		"manifest validation failed: 1 error(s), 0 warning(s)")
 	assert.Error(t, failIfFindings(errOnly, false),
 		"manifest validation failed: 1 error(s), 0 warning(s)")
+}
+
+func TestFailIfFindingsInfoOnlyPasses(t *testing.T) {
+	infoOnly := []lint.Finding{{Severity: lint.SeverityInfo, Path: "arguments.x", Message: "i"}}
+	// Info never fails, regardless of warnings-as-errors.
+	assert.NilError(t, failIfFindings(infoOnly, true))
+	assert.NilError(t, failIfFindings(infoOnly, false))
+}
+
+func TestLogFindingsRoutesInfoToInfoLevel(t *testing.T) {
+	var buf bytes.Buffer
+	log := logrus.New()
+	log.SetOutput(&buf)
+	log.SetLevel(logrus.InfoLevel)
+
+	logFindings(log, []lint.Finding{
+		{Severity: lint.SeverityInfo, Path: "arguments.x", Message: "deprecated msg"},
+	})
+
+	out := buf.String()
+	// logrus default text formatter writes level=info for Info(); it would be
+	// level=error if the info case were missing (the defensive default).
+	assert.Assert(t, strings.Contains(out, "level=info"),
+		"expected info-level log, got: %s", out)
+	assert.Assert(t, strings.Contains(out, "deprecated msg"))
 }
 
 func TestResolveManifestReaderMissing(t *testing.T) {

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -60,6 +60,25 @@ func TestFailIfFindingsInfoOnlyPasses(t *testing.T) {
 	assert.NilError(t, failIfFindings(infoOnly, false))
 }
 
+func TestFailManifestInfoOnlyLogsBareValidLine(t *testing.T) {
+	var buf bytes.Buffer
+	log := logrus.New()
+	log.SetOutput(&buf)
+	log.SetLevel(logrus.InfoLevel)
+
+	// An info-only finding set must pass and log the bare "is valid" success
+	// line: info findings are not counted as warnings, so the "(N warning(s))"
+	// form must not appear.
+	infoOnly := []lint.Finding{{Severity: lint.SeverityInfo, Path: "arguments.x", Message: "deprecated msg"}}
+	err := failManifest(log, "manifest.yaml", infoOnly, true)
+	assert.NilError(t, err)
+
+	out := buf.String()
+	assert.Assert(t, strings.Contains(out, "is valid"), "expected success line, got: %s", out)
+	assert.Assert(t, !strings.Contains(out, "warning(s)"),
+		"info-only findings must not log the warning-count form, got: %s", out)
+}
+
 func TestLogFindingsRoutesInfoToInfoLevel(t *testing.T) {
 	var buf bytes.Buffer
 	log := logrus.New()

--- a/docs/content/en/reference/template-module.md
+++ b/docs/content/en/reference/template-module.md
@@ -56,6 +56,7 @@ The important keys that a module has are listed below, but an exhaustive list ca
   - `required` - whether or not the argument is required to be set
   - `default` - a default value for the argument, cannot be set when required is true
   - `from` - aliases this argument to another module's argument. Only supports one-level deep.
+  - `deprecated` - a string migration message. When non-empty, the argument is deprecated: a consuming repo that sets it in `service.yaml` gets a render-time warning, and `stencil lint module-manifest` reports it informationally. Empty or absent means not deprecated. Must be a string (e.g. `deprecated: "Use newArg instead."`); the bool form `deprecated: true` is not supported.
 
 #### Writing a JSON Schema
 

--- a/internal/codegen/stencil.go
+++ b/internal/codegen/stencil.go
@@ -5,6 +5,7 @@ package codegen
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -199,6 +200,14 @@ func (s *Stencil) Render(ctx context.Context, log logrus.FieldLogger) ([]*Templa
 	vals := NewValues(ctx, s.m, s.modules, log)
 	log.Debug("Finished creating values")
 
+	warnings, err := s.deprecatedArgumentWarnings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, w := range warnings {
+		log.Warn(w)
+	}
+
 	// Add the templates to their modules template to allow them to be able to access
 	// functions declared in the same module
 	for _, t := range tplfiles {
@@ -235,6 +244,42 @@ func (s *Stencil) Render(ctx context.Context, log logrus.FieldLogger) ([]*Templa
 	}
 
 	return tpls, nil
+}
+
+// deprecatedArgumentWarnings returns one warning message per (module, argument)
+// where the module's manifest marks the argument deprecated (a non-empty
+// Deprecated string) AND the service manifest sets a value for it. Messages are
+// returned in deterministic order: module slice order, arguments sorted by name.
+// from: re-export entries are skipped — the owning module carries the message.
+func (s *Stencil) deprecatedArgumentWarnings(ctx context.Context) ([]string, error) {
+	var warnings []string
+	for _, m := range s.modules {
+		mf, err := m.Manifest(ctx)
+		if err != nil {
+			return nil, err
+		}
+		names := make([]string, 0, len(mf.Arguments))
+		for name := range mf.Arguments {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			arg := mf.Arguments[name]
+			if arg.From != "" {
+				continue
+			}
+			if arg.Deprecated == "" {
+				continue
+			}
+			if _, set := s.m.Arguments[name]; !set {
+				continue
+			}
+			warnings = append(warnings, fmt.Sprintf(
+				"module %q argument %q is deprecated: %s",
+				m.Name, name, arg.Deprecated))
+		}
+	}
+	return warnings, nil
 }
 
 // PostRun runs all post run commands specified in the modules that

--- a/internal/codegen/stencil_arg_deprecation_test.go
+++ b/internal/codegen/stencil_arg_deprecation_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Outreach Corporation. All Rights Reserved.
+
+// Description: Tests for render-time deprecated-argument warnings.
+
+package codegen
+
+import (
+	"context"
+	"testing"
+
+	"github.com/getoutreach/stencil/pkg/configuration"
+	"gotest.tools/v3/assert"
+)
+
+func TestDeprecatedArgumentWarnings(t *testing.T) {
+	t.Run("warns when a deprecated arg is set in service.yaml", func(t *testing.T) {
+		tt := fakeTemplate(t,
+			map[string]interface{}{"oldArg": "x"}, // service.yaml sets it
+			map[string]configuration.Argument{
+				"oldArg": {Deprecated: "use newArg instead"},
+			})
+		got, err := tt.s.deprecatedArgumentWarnings(context.Background())
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got, []string{
+			`module "test" argument "oldArg" is deprecated: use newArg instead`,
+		})
+	})
+
+	t.Run("no warning when the deprecated arg is not set", func(t *testing.T) {
+		tt := fakeTemplate(t,
+			map[string]interface{}{}, // service.yaml does NOT set it
+			map[string]configuration.Argument{
+				"oldArg": {Deprecated: "use newArg instead"},
+			})
+		got, err := tt.s.deprecatedArgumentWarnings(context.Background())
+		assert.NilError(t, err)
+		assert.Equal(t, len(got), 0)
+	})
+
+	t.Run("no warning for a non-deprecated arg that is set", func(t *testing.T) {
+		tt := fakeTemplate(t,
+			map[string]interface{}{"normalArg": "x"},
+			map[string]configuration.Argument{
+				"normalArg": {},
+			})
+		got, err := tt.s.deprecatedArgumentWarnings(context.Background())
+		assert.NilError(t, err)
+		assert.Equal(t, len(got), 0)
+	})
+
+	t.Run("deterministic sorted order for multiple deprecated args", func(t *testing.T) {
+		tt := fakeTemplate(t,
+			map[string]interface{}{"bArg": "x", "aArg": "y"},
+			map[string]configuration.Argument{
+				"bArg": {Deprecated: "msg b"},
+				"aArg": {Deprecated: "msg a"},
+			})
+		got, err := tt.s.deprecatedArgumentWarnings(context.Background())
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got, []string{
+			`module "test" argument "aArg" is deprecated: msg a`,
+			`module "test" argument "bArg" is deprecated: msg b`,
+		})
+	})
+
+	t.Run("from: re-export is skipped", func(t *testing.T) {
+		// test-0 re-exports "shared" from test-1 via from:; test-1 owns the
+		// deprecation. The from: entry must NOT warn.
+		tt := fakeTemplateMultipleModules(t,
+			map[string]interface{}{"shared": "x"},
+			// test-0 (the importer)
+			map[string]configuration.Argument{
+				"shared": {From: "test-1", Deprecated: "ignored on from"},
+			},
+			// test-1 (the owner) — note: owner is imported, so it warns
+			map[string]configuration.Argument{
+				"shared": {Deprecated: "use the new shared"},
+			},
+		)
+		got, err := tt.s.deprecatedArgumentWarnings(context.Background())
+		assert.NilError(t, err)
+		// Only the owning module (test-1) warns; the from: entry in test-0 is skipped.
+		assert.DeepEqual(t, got, []string{
+			`module "test-1" argument "shared" is deprecated: use the new shared`,
+		})
+	})
+}

--- a/internal/codegen/stencil_arg_deprecation_test.go
+++ b/internal/codegen/stencil_arg_deprecation_test.go
@@ -26,6 +26,19 @@ func TestDeprecatedArgumentWarnings(t *testing.T) {
 		})
 	})
 
+	t.Run("warns when a deprecated arg is present with an empty value", func(t *testing.T) {
+		tt := fakeTemplate(t,
+			map[string]interface{}{"oldArg": ""}, // present in service.yaml, empty value
+			map[string]configuration.Argument{
+				"oldArg": {Deprecated: "use newArg instead"},
+			})
+		got, err := tt.s.deprecatedArgumentWarnings(context.Background())
+		assert.NilError(t, err)
+		assert.DeepEqual(t, got, []string{
+			`module "test" argument "oldArg" is deprecated: use newArg instead`,
+		})
+	})
+
 	t.Run("no warning when the deprecated arg is not set", func(t *testing.T) {
 		tt := fakeTemplate(t,
 			map[string]interface{}{}, // service.yaml does NOT set it

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -19,6 +19,8 @@ const (
 	// SeverityWarning marks a finding that fails only when warnings are
 	// treated as errors.
 	SeverityWarning Severity = "warning"
+	// SeverityInfo marks an informational finding that never fails a lint run.
+	SeverityInfo Severity = "info"
 )
 
 // Finding is a single problem discovered while linting.
@@ -55,6 +57,15 @@ func (f *Findings) Warnf(path, format string, a ...any) {
 	})
 }
 
+// Infof appends a SeverityInfo finding at path with a formatted message.
+func (f *Findings) Infof(path, format string, a ...any) {
+	f.items = append(f.items, Finding{
+		Severity: SeverityInfo,
+		Path:     path,
+		Message:  fmt.Sprintf(format, a...),
+	})
+}
+
 // Add appends a pre-built Finding.
 func (f *Findings) Add(find Finding) {
 	f.items = append(f.items, find)
@@ -78,6 +89,9 @@ func Counts(findings []Finding) (errors, warnings int) {
 			errors++
 		case SeverityWarning:
 			warnings++
+		case SeverityInfo:
+			// Info findings are intentionally not counted: they never fail a
+			// lint run, so they must not affect the error/warning tally.
 		}
 	}
 	return errors, warnings

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -45,3 +45,19 @@ func TestCountsEmpty(t *testing.T) {
 	assert.Equal(t, 0, errs)
 	assert.Equal(t, 0, warns)
 }
+
+func TestInfofAndCountsIgnoresInfo(t *testing.T) {
+	var f lint.Findings
+	f.Infof("arguments.x", "argument %q is deprecated: %s", "x", "use y")
+
+	items := f.Items()
+	assert.Equal(t, 1, len(items))
+	assert.Equal(t, lint.SeverityInfo, items[0].Severity)
+	assert.Equal(t, "arguments.x", items[0].Path)
+	assert.Equal(t, `argument "x" is deprecated: use y`, items[0].Message)
+
+	// Counts must ignore info: it tallies only errors and warnings.
+	errs, warns := f.Counts()
+	assert.Equal(t, 0, errs)
+	assert.Equal(t, 0, warns)
+}

--- a/internal/lint/manifest/manifest.go
+++ b/internal/lint/manifest/manifest.go
@@ -133,6 +133,8 @@ func checkStencilVersion(f *lint.Findings, mf *configuration.TemplateRepositoryM
 
 // checkArguments implements checks 4, 6, and 7 (argument deprecations) in
 // sorted key order, skipping arguments that reference another module via from:.
+// Also emits an informational finding for each argument that sets the
+// deprecated property.
 func checkArguments(f *lint.Findings, mf *configuration.TemplateRepositoryManifest) {
 	names := make([]string, 0, len(mf.Arguments))
 	for name := range mf.Arguments {

--- a/internal/lint/manifest/manifest.go
+++ b/internal/lint/manifest/manifest.go
@@ -163,6 +163,9 @@ func checkArguments(f *lint.Findings, mf *configuration.TemplateRepositoryManife
 		if len(arg.Values) > 0 {
 			f.Warnf("arguments."+name+".values", "argument field 'values' is deprecated; use 'schema'")
 		}
+		if arg.Deprecated != "" {
+			f.Infof("arguments."+name, "argument %q is deprecated: %s", name, arg.Deprecated)
+		}
 	}
 }
 

--- a/internal/lint/manifest/manifest_test.go
+++ b/internal/lint/manifest/manifest_test.go
@@ -199,6 +199,29 @@ func TestValidate(t *testing.T) {
 				"    type: string\n    schema:\n      type: notarealtype\n",
 			none: true,
 		},
+		{
+			name: "deprecated argument emits info finding",
+			in:   "name: testing\narguments:\n  oldArg:\n    deprecated: use newArg instead\n",
+			want: []lint.Finding{
+				{Severity: lint.SeverityInfo, Path: "arguments.oldArg"},
+			},
+			wantMsg: map[string]string{
+				"arguments.oldArg": "argument \"oldArg\" is deprecated: use newArg instead",
+			},
+		},
+		{
+			name: "deprecated bool form is a strict-decode error",
+			in:   "name: testing\narguments:\n  oldArg:\n    deprecated: true\n",
+			want: []lint.Finding{
+				{Severity: lint.SeverityError, Path: "manifest.yaml"},
+			},
+		},
+		{
+			name: "from: arg with deprecated produces no info finding",
+			in: "name: testing\nmodules:\n  - name: github.com/getoutreach/stencil-base\n" +
+				"arguments:\n  shared:\n    from: github.com/getoutreach/stencil-base\n    deprecated: ignored\n",
+			none: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -150,7 +150,7 @@ func (d *DeprecationMessage) UnmarshalYAML(value *yaml.Node) error {
 		*d = DeprecationMessage(value.Value)
 		return nil
 	default:
-		return fmt.Errorf("argument \"deprecated\" must be a string message, got %s (%q); "+
+		return fmt.Errorf("deprecation message must be a string, got %s (%q); "+
 			"the bool form is not supported — supply a migration message", value.Tag, value.Value)
 	}
 }

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -130,6 +130,31 @@ type PostRunCommandSpec struct {
 	Command string `yaml:"command"`
 }
 
+// DeprecationMessage is an argument's deprecation message. It is a string:
+// non-empty means the argument is deprecated and this is the migration message
+// shown to consumers; empty means not deprecated. Its custom UnmarshalYAML
+// rejects non-string YAML scalars (e.g. the legacy `deprecated: true` bool
+// form) so authors must supply a message string rather than a bare bool.
+type DeprecationMessage string
+
+// UnmarshalYAML accepts only a YAML string (!!str) or null (!!null); any other
+// node — bool, int, float, sequence, or mapping — is an error. This is
+// required because yaml.v3 otherwise coerces any scalar into a string
+// silently, which would let `deprecated: true` decode to the message "true".
+func (d *DeprecationMessage) UnmarshalYAML(value *yaml.Node) error {
+	switch value.Tag {
+	case "!!null":
+		*d = ""
+		return nil
+	case "!!str":
+		*d = DeprecationMessage(value.Value)
+		return nil
+	default:
+		return fmt.Errorf("argument \"deprecated\" must be a string message, got %s (%q); "+
+			"the bool form is not supported — supply a migration message", value.Tag, value.Value)
+	}
+}
+
 // Argument is a user-input argument that can be passed to
 // templates
 type Argument struct {
@@ -145,6 +170,15 @@ type Argument struct {
 
 	// Schema is a JSON schema, in YAML, for the argument.
 	Schema map[string]interface{} `yaml:"schema"`
+
+	// When non-empty, this marks the argument as deprecated and is the
+	// human-readable migration message shown to consumers. An empty or absent
+	// value means the argument is not deprecated.
+	//
+	// In YAML this must be a string, e.g. `deprecated: "Use newArg instead."`.
+	// The bool form (`deprecated: true`) is rejected by
+	// DeprecationMessage.UnmarshalYAML; authors must supply a message string.
+	Deprecated DeprecationMessage `yaml:"deprecated,omitempty"`
 
 	// Deprecated fields below.
 

--- a/pkg/configuration/configuration_test.go
+++ b/pkg/configuration/configuration_test.go
@@ -6,6 +6,10 @@ package configuration_test
 
 import (
 	"fmt"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+	"gotest.tools/v3/assert"
 
 	"github.com/getoutreach/stencil/pkg/configuration"
 )
@@ -38,4 +42,41 @@ func ExampleNewServiceManifest() {
 	// Output:
 	// testing
 	// map[hello:world]
+}
+
+func TestArgumentDeprecatedDecode(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string // YAML for a single Argument
+		want    string // expected Deprecated value (when no error)
+		wantErr bool
+	}{
+		{name: "absent", in: "description: hi\n", want: ""},
+		{name: "empty string", in: "deprecated: \"\"\n", want: ""},
+		{name: "null", in: "deprecated:\n", want: ""},
+		{name: "tilde null", in: "deprecated: ~\n", want: ""},
+		{name: "message", in: "deprecated: use newArg instead\n", want: "use newArg instead"},
+		{name: "quoted message", in: "deprecated: \"Use newArg instead.\"\n", want: "Use newArg instead."},
+		{name: "yes is a string not a bool", in: "deprecated: yes\n", want: "yes"},
+		{name: "bool true rejected", in: "deprecated: true\n", wantErr: true},
+		{name: "bool false rejected", in: "deprecated: false\n", wantErr: true},
+		{name: "int rejected", in: "deprecated: 42\n", wantErr: true},
+		{name: "float rejected", in: "deprecated: 3.14\n", wantErr: true},
+		{name: "list rejected", in: "deprecated: [a, b]\n", wantErr: true},
+		{name: "map rejected", in: "deprecated: {x: 1}\n", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var arg configuration.Argument
+			err := yaml.Unmarshal([]byte(tt.in), &arg)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "expected decode error, got nil (value=%q)", arg.Deprecated)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tt.want, string(arg.Deprecated))
+			// "deprecated" is defined as a non-empty value.
+			assert.Equal(t, tt.want != "", arg.Deprecated != "")
+		})
+	}
 }


### PR DESCRIPTION
## What this PR does / why we need it

Lets a module author mark a manifest `argument` as deprecated and hand consumers a migration message, via a new `deprecated` string field on `configuration.Argument`. Previously there was no first-class way to deprecate an argument; the only signal was a note in the module's documentation.

Once an argument is deprecated, a consuming repo that sets it in `service.yaml` gets a render-time warning, and `stencil lint manifest` surfaces it as an informational finding (which never fails a lint). The reference docs gain a `deprecated` bullet.

## Jira ID

[DT-5388]

## Notes for your reviewers

- **Stacked on #485** and should merge after it; the informational finding reuses the `internal/lint` finding model introduced there.
- **The original bool form is intentionally rejected, which is a breaking change (_except that it wasn't codified, so not really_).** `deprecated` is string-only, so `deprecated: true` now fails to decode (a custom `UnmarshalYAML` is required because YAML would otherwise silently coerce `true` to the string `"true"`). stencil-golang is the only repo in the corpus using the bool form, so getoutreach/stencil-golang#710 migrates it and **must merge before the next stencil release** to avoid breaking that module's manifest decode.

[DT-5388]: https://outreach-io.atlassian.net/browse/DT-5388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ