### PR TITLE
feat(lint): annotate manifest lint findings with source line numbers

### DIFF
--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -213,10 +213,14 @@ func runManifestReader(log logrus.FieldLogger, name string, r io.Reader) ([]lint
 }
 
 // logFindings logs each finding via logrus (stderr). Errors log at error level,
-// warnings at warn level, and info findings at info level.
+// warnings at warn level, and info findings at info level. When a finding has a
+// resolved source line (Line > 0), it is attached as a "line" field.
 func logFindings(log logrus.FieldLogger, findings []lint.Finding) {
 	for _, f := range findings {
 		entry := log.WithField("path", f.Path)
+		if f.Line > 0 {
+			entry = entry.WithField("line", f.Line)
+		}
 		switch f.Severity {
 		case lint.SeverityWarning:
 			entry.Warn(f.Message)

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -198,15 +198,15 @@ func resolveManifestReader(path string) (io.Reader, io.Closer, *lint.Finding, er
 }
 
 // runManifestReader loads + validates one manifest from r and returns its
-// findings. It does NOT log; logging is the command's responsibility so
-// findings are emitted exactly once. name is used in messages.
+// findings. It does NOT log the findings themselves; logging is the command's
+// responsibility so findings are emitted exactly once. name is used in messages.
 func runManifestReader(log logrus.FieldLogger, name string, r io.Reader) ([]lint.Finding, error) {
-	mf, strictErr, multiDoc, readErr := lintmanifest.Load(r)
-	if readErr != nil {
-		return nil, errors.Wrapf(readErr, "failed to read manifest %q", name)
+	res, err := lintmanifest.Load(r)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read manifest %q", name)
 	}
-	findings := lintmanifest.Validate(mf, strictErr)
-	if multiDoc {
+	findings := lintmanifest.Validate(res)
+	if res.MultiDoc {
 		log.WithField("path", name).Warn("additional YAML documents after the first are ignored")
 	}
 	return findings, nil

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -97,6 +97,26 @@ func TestLogFindingsRoutesInfoToInfoLevel(t *testing.T) {
 	assert.Assert(t, strings.Contains(out, "deprecated msg"))
 }
 
+func TestLogFindingsIncludesLineWhenSet(t *testing.T) {
+	var buf bytes.Buffer
+	log := logrus.New()
+	log.SetOutput(&buf)
+	log.SetLevel(logrus.InfoLevel)
+
+	logFindings(log, []lint.Finding{
+		{Severity: lint.SeverityWarning, Path: "arguments.x.type", Message: "dep", Line: 4},
+		{Severity: lint.SeverityError, Path: "manifest.yaml", Message: "empty"}, // Line 0
+	})
+
+	out := buf.String()
+	// The finding with a line emits a line field...
+	assert.Assert(t, strings.Contains(out, "line=4"),
+		"expected line field for the lined finding, got: %s", out)
+	// ...and the zero-line finding does not.
+	assert.Assert(t, !strings.Contains(out, "line=0"),
+		"zero-line findings must not emit a line field, got: %s", out)
+}
+
 func TestResolveManifestReaderMissing(t *testing.T) {
 	r, closer, finding, err := resolveManifestReader(filepath.Join(t.TempDir(), "nope.yaml"))
 	assert.NilError(t, err)

--- a/internal/lint/lint.go
+++ b/internal/lint/lint.go
@@ -31,6 +31,9 @@ type Finding struct {
 	Path string
 	// Message is a human-readable description of the problem.
 	Message string
+	// Line is the 1-based source line of the YAML key this finding references,
+	// or 0 when no line is known (whole-document findings, or an unresolved path).
+	Line int
 }
 
 // Findings accumulates Finding values during a lint run. The zero value is

--- a/internal/lint/lint_test.go
+++ b/internal/lint/lint_test.go
@@ -61,3 +61,16 @@ func TestInfofAndCountsIgnoresInfo(t *testing.T) {
 	assert.Equal(t, 0, errs)
 	assert.Equal(t, 0, warns)
 }
+
+func TestFindingLineDefaultsToZero(t *testing.T) {
+	var f lint.Findings
+	f.Errorf("name", "name is required")
+	items := f.Items()
+	assert.Equal(t, 1, len(items))
+	// Findings built via the helpers carry no line (0) by default.
+	assert.Equal(t, 0, items[0].Line)
+
+	// A Finding may carry an explicit line.
+	withLine := lint.Finding{Severity: lint.SeverityWarning, Path: "arguments.x.type", Message: "dep", Line: 4}
+	assert.Equal(t, 4, withLine.Line)
+}

--- a/internal/lint/manifest/manifest.go
+++ b/internal/lint/manifest/manifest.go
@@ -27,54 +27,75 @@ import (
 	"github.com/getoutreach/stencil/pkg/configuration"
 )
 
-// Load reads a manifest from r and decodes it twice: once strictly
-// (rejecting unknown keys) to surface structural problems, and once leniently
-// so the returned manifest is populated for field-level checks even when the
-// strict decode failed.
+// LoadResult holds the outcome of decoding a manifest for linting.
+type LoadResult struct {
+	// Manifest is the leniently-decoded manifest, or nil if the YAML could not
+	// be decoded at all.
+	Manifest *configuration.TemplateRepositoryManifest
+	// Root is the first document's YAML node tree, used to resolve finding
+	// paths to source lines. It is nil if the bytes did not parse as a node.
+	Root *yaml.Node
+	// StrictErr is the strict-decode error (unknown keys / type errors), or nil.
+	// For empty input it is io.EOF.
+	StrictErr error
+	// MultiDoc is true when r contains more than one YAML document.
+	MultiDoc bool
+}
+
+// Load reads a manifest from r and decodes it: once strictly (rejecting unknown
+// keys) to surface structural problems, once leniently so the returned manifest
+// is populated for field-level checks even when the strict decode failed, and
+// once into a yaml.Node tree to retain source positions for line annotation.
 //
-// strictErr is the strict-decode error (if any); for empty input it is io.EOF.
-// mf is nil only when the lenient decode also fails (truly malformed YAML).
-// multiDoc is true when r contains more than one YAML document. readErr is
-// non-nil only when reading from r itself fails.
-func Load(r io.Reader) (mf *configuration.TemplateRepositoryManifest,
-	strictErr error, multiDoc bool, readErr error) {
+// The returned error is non-nil only when reading from r itself fails.
+func Load(r io.Reader) (*LoadResult, error) {
 	raw, err := io.ReadAll(r)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, err
 	}
+
+	res := &LoadResult{}
 
 	// Strict decode into a throwaway manifest to capture unknown-key/type errors.
 	strictDec := yaml.NewDecoder(bytes.NewReader(raw))
 	strictDec.KnownFields(true)
 	var strictManifest configuration.TemplateRepositoryManifest
-	strictErr = strictDec.Decode(&strictManifest)
+	res.StrictErr = strictDec.Decode(&strictManifest)
 
-	// Lenient decode so field checks can run regardless of strictErr. Retain the
+	// Node decode for source positions. A failure here is non-fatal: lint still
+	// runs on the struct path, just without line numbers.
+	var node yaml.Node
+	if err := yaml.Unmarshal(raw, &node); err == nil {
+		res.Root = &node
+	}
+
+	// Lenient decode so field checks can run regardless of StrictErr. Retain the
 	// decoder so we can probe for a second document afterward.
 	lenientDec := yaml.NewDecoder(bytes.NewReader(raw))
 	var lenientManifest configuration.TemplateRepositoryManifest
 	if err := lenientDec.Decode(&lenientManifest); err != nil {
 		// Empty or malformed input: no usable manifest for field checks.
-		return nil, strictErr, false, nil
+		return res, nil
 	}
-	mf = &lenientManifest
+	res.Manifest = &lenientManifest
 
 	// Probe for a second document on the (already-advanced) lenient decoder.
 	var discard any
 	if err := lenientDec.Decode(&discard); err == nil {
-		multiDoc = true
+		res.MultiDoc = true
 	}
 
-	return mf, strictErr, multiDoc, nil
+	return res, nil
 }
 
-// Validate runs the manifest lint checks and returns every finding. It never
-// fails fast. strictErr is the error (if any) returned by the strict YAML
-// decode in Load; mf may be nil if the YAML could not be decoded at all, in
-// which case only the strict-decode finding (check 1) is returned and checks
-// 2-7 are skipped.
-func Validate(mf *configuration.TemplateRepositoryManifest, strictErr error) []lint.Finding {
+// Validate runs the manifest lint checks and returns every finding, each
+// annotated with the source line of the YAML key it references when that line
+// can be resolved. It never fails fast. res.Manifest may be nil if the YAML
+// could not be decoded at all, in which case only the strict-decode finding
+// (check 1) is returned and checks 2-7 are skipped.
+func Validate(res *LoadResult) []lint.Finding {
 	var f lint.Findings
+	mf, strictErr := res.Manifest, res.StrictErr
 
 	// Check 1: strict decode succeeded.
 	if strictErr != nil {
@@ -95,7 +116,16 @@ func Validate(mf *configuration.TemplateRepositoryManifest, strictErr error) []l
 	checkArguments(&f, mf)
 	checkModules(&f, mf)
 
-	return f.Items()
+	// Annotate each finding with its source line where resolvable.
+	findings := f.Items()
+	if res.Root != nil {
+		for i := range findings {
+			if findings[i].Line == 0 {
+				findings[i].Line = resolvePath(res.Root, findings[i].Path)
+			}
+		}
+	}
+	return findings
 }
 
 // checkName implements check 2. A manifest's name is a Go import path

--- a/internal/lint/manifest/manifest_test.go
+++ b/internal/lint/manifest/manifest_test.go
@@ -281,3 +281,75 @@ func hasFindingMsg(findings []lint.Finding, path, substr string) bool {
 	}
 	return false
 }
+
+func TestValidateAnnotatesLines(t *testing.T) {
+	// 1 name: testing
+	// 2 arguments:
+	// 3   x:
+	// 4     type: string
+	// 5     values: [a, b]
+	const in = `name: testing
+arguments:
+  x:
+    type: string
+    values: [a, b]
+`
+	got := validateString(in)
+
+	// Both deprecation warnings carry the line of their key.
+	assert.Equal(t, 4, findingLine(t, got, "arguments.x.type"))
+	assert.Equal(t, 5, findingLine(t, got, "arguments.x.values"))
+}
+
+func TestValidateAnnotatesSchemaErrorLine(t *testing.T) {
+	// 1 name: testing
+	// 2 arguments:
+	// 3   bad:
+	// 4     schema:
+	// 5       type: notarealtype
+	const in = `name: testing
+arguments:
+  bad:
+    schema:
+      type: notarealtype
+`
+	got := validateString(in)
+	assert.Equal(t, 4, findingLine(t, got, "arguments.bad.schema"))
+}
+
+func TestValidateAnnotatesRequiredDefaultLine(t *testing.T) {
+	// 1 name: testing
+	// 2 arguments:
+	// 3   x:
+	// 4     required: true
+	// 5     default: hi
+	const in = `name: testing
+arguments:
+  x:
+    required: true
+    default: hi
+`
+	got := validateString(in)
+	// The required+default finding is anchored on the argument block key (x:).
+	assert.Equal(t, 3, findingLine(t, got, "arguments.x"))
+}
+
+func TestValidateWholeDocumentFindingHasNoLine(t *testing.T) {
+	got := validateString("  \n") // empty manifest → check-1 finding
+	assert.Equal(t, 1, len(got))
+	assert.Equal(t, "manifest.yaml", got[0].Path)
+	assert.Equal(t, 0, got[0].Line) // whole-document: no resolvable line
+}
+
+// findingLine returns the Line of the first finding at path, failing the test
+// if no such finding exists.
+func findingLine(t *testing.T, findings []lint.Finding, path string) int {
+	t.Helper()
+	for _, f := range findings {
+		if f.Path == path {
+			return f.Line
+		}
+	}
+	t.Fatalf("no finding at path %q in %v", path, findings)
+	return 0
+}

--- a/internal/lint/manifest/manifest_test.go
+++ b/internal/lint/manifest/manifest_test.go
@@ -15,53 +15,54 @@ import (
 )
 
 func TestLoadValid(t *testing.T) {
-	mf, strictErr, multiDoc, readErr := lintmanifest.Load(strings.NewReader("name: testing\n"))
+	res, readErr := lintmanifest.Load(strings.NewReader("name: testing\n"))
 	assert.NilError(t, readErr)
-	assert.NilError(t, strictErr)
-	assert.Equal(t, false, multiDoc)
-	assert.Assert(t, mf != nil)
-	assert.Equal(t, "testing", mf.Name)
+	assert.NilError(t, res.StrictErr)
+	assert.Equal(t, false, res.MultiDoc)
+	assert.Assert(t, res.Manifest != nil)
+	assert.Equal(t, "testing", res.Manifest.Name)
+	assert.Assert(t, res.Root != nil)
 }
 
 func TestLoadUnknownKeyStrictFailsButLenientPopulates(t *testing.T) {
 	// 'nme' is an unknown key: strict decode fails, but lenient decode still
 	// populates the rest so field checks can run.
-	mf, strictErr, _, readErr := lintmanifest.Load(strings.NewReader("name: testing\nnme: oops\n"))
+	res, readErr := lintmanifest.Load(strings.NewReader("name: testing\nnme: oops\n"))
 	assert.NilError(t, readErr)
-	assert.Assert(t, strictErr != nil)
-	assert.Assert(t, mf != nil)
-	assert.Equal(t, "testing", mf.Name)
+	assert.Assert(t, res.StrictErr != nil)
+	assert.Assert(t, res.Manifest != nil)
+	assert.Equal(t, "testing", res.Manifest.Name)
 }
 
 func TestLoadNestedUnknownKey(t *testing.T) {
 	// An unknown key inside an argument must also trip strict decoding.
 	in := "name: testing\narguments:\n  foo:\n    scema: {}\n"
-	_, strictErr, _, readErr := lintmanifest.Load(strings.NewReader(in))
+	res, readErr := lintmanifest.Load(strings.NewReader(in))
 	assert.NilError(t, readErr)
-	assert.Assert(t, strictErr != nil)
+	assert.Assert(t, res.StrictErr != nil)
 }
 
 func TestLoadEmptyInput(t *testing.T) {
-	mf, strictErr, _, readErr := lintmanifest.Load(strings.NewReader("   \n# just a comment\n"))
+	res, readErr := lintmanifest.Load(strings.NewReader("   \n# just a comment\n"))
 	assert.NilError(t, readErr)
-	assert.Assert(t, strictErr != nil) // io.EOF
-	assert.Assert(t, mf == nil)
+	assert.Assert(t, res.StrictErr != nil) // io.EOF
+	assert.Assert(t, res.Manifest == nil)
 }
 
 func TestLoadMultiDocument(t *testing.T) {
-	mf, strictErr, multiDoc, readErr := lintmanifest.Load(
+	res, readErr := lintmanifest.Load(
 		strings.NewReader("name: testing\n---\nname: second\n"))
 	assert.NilError(t, readErr)
-	assert.NilError(t, strictErr)
-	assert.Assert(t, mf != nil)
-	assert.Equal(t, "testing", mf.Name) // only doc 1 is read
-	assert.Equal(t, true, multiDoc)
+	assert.NilError(t, res.StrictErr)
+	assert.Assert(t, res.Manifest != nil)
+	assert.Equal(t, "testing", res.Manifest.Name) // only doc 1 is read
+	assert.Equal(t, true, res.MultiDoc)
 }
 
 // validateString is a convenience that runs Load + Validate over a YAML string.
 func validateString(in string) []lint.Finding {
-	mf, strictErr, _, _ := lintmanifest.Load(strings.NewReader(in))
-	return lintmanifest.Validate(mf, strictErr)
+	res, _ := lintmanifest.Load(strings.NewReader(in))
+	return lintmanifest.Validate(res)
 }
 
 // hasFinding reports whether findings contains one with the given severity and path

--- a/internal/lint/manifest/resolve.go
+++ b/internal/lint/manifest/resolve.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Resolves dotted lint finding paths (e.g. "arguments.foo.type")
+// to the 1-based source line of the corresponding YAML key node, for line
+// annotation of manifest lint findings.
+
+package manifest
+
+import (
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// resolvePath returns the 1-based line of the key node identified by a dotted
+// finding path within root, or 0 if root is nil or the path cannot be matched.
+// root is a yaml.v3 DocumentNode; the top mapping is its first content child.
+//
+// Module paths are special-cased because module names are Go import paths that
+// contain dots (e.g. github.com/getoutreach/stencil-base), which a naive split
+// on "." would shred. All other paths are walked as dotted mapping keys.
+//
+// On any failure to match, resolvePath returns 0. It never panics.
+func resolvePath(root *yaml.Node, path string) int {
+	if root == nil || path == "" {
+		return 0
+	}
+	top := deref(root)
+	if top != nil && top.Kind == yaml.DocumentNode {
+		if len(top.Content) == 0 {
+			return 0
+		}
+		top = deref(top.Content[0])
+	}
+	if top == nil || top.Kind != yaml.MappingNode {
+		return 0
+	}
+
+	// Module paths need bespoke parsing (names contain dots).
+	if path == "modules" || strings.HasPrefix(path, "modules.") || strings.HasPrefix(path, "modules[") {
+		return resolveModulePath(top, path)
+	}
+
+	// General dotted mapping walk.
+	cur := top
+	lastKeyLine := 0
+	for _, seg := range strings.Split(path, ".") {
+		if cur == nil || cur.Kind != yaml.MappingNode {
+			return 0
+		}
+		keyNode, valNode := mappingChild(cur, seg)
+		if keyNode == nil {
+			return 0
+		}
+		lastKeyLine = keyNode.Line
+		cur = deref(valNode)
+	}
+	return lastKeyLine
+}
+
+// resolveModulePath resolves "modules[N].field" and "modules.NAME.field" within
+// the top mapping, returning the field key's line (or the matched item's name:
+// line when no field segment is present). NAME may contain dots. Returns 0 on
+// any miss.
+func resolveModulePath(top *yaml.Node, path string) int {
+	rest := strings.TrimPrefix(path, "modules")
+	_, seqVal := mappingChild(top, "modules")
+	seq := deref(seqVal)
+	if seq == nil || seq.Kind != yaml.SequenceNode {
+		return 0
+	}
+
+	// Index form: modules[N].field
+	if strings.HasPrefix(rest, "[") {
+		closeIdx := strings.IndexByte(rest, ']')
+		if closeIdx < 0 {
+			return 0
+		}
+		idx, err := strconv.Atoi(rest[1:closeIdx])
+		if err != nil || idx < 0 || idx >= len(seq.Content) {
+			return 0
+		}
+		field := strings.TrimPrefix(rest[closeIdx+1:], ".")
+		return fieldLineIn(deref(seq.Content[idx]), field)
+	}
+
+	// Name form: modules.NAME.field — the LAST dot separates the (dotted) NAME
+	// from the trailing field.
+	rest = strings.TrimPrefix(rest, ".")
+	lastDot := strings.LastIndexByte(rest, '.')
+	if lastDot < 0 {
+		return 0
+	}
+	name, field := rest[:lastDot], rest[lastDot+1:]
+	item, nameLine := sequenceItemByName(seq, name)
+	if item == nil {
+		return 0
+	}
+	if field == "" {
+		return nameLine
+	}
+	return fieldLineIn(item, field)
+}
+
+// fieldLineIn returns the key line of field within mapping node m, or 0 when
+// field is empty, m is not a mapping, or the key is absent.
+func fieldLineIn(m *yaml.Node, field string) int {
+	if field == "" {
+		return 0
+	}
+	keyNode, _ := mappingChild(m, field)
+	if keyNode == nil {
+		return 0
+	}
+	return keyNode.Line
+}
+
+// deref follows an alias node to its anchored target, returning other nodes
+// unchanged. A nil node returns nil.
+func deref(n *yaml.Node) *yaml.Node {
+	if n != nil && n.Kind == yaml.AliasNode && n.Alias != nil {
+		return n.Alias
+	}
+	return n
+}
+
+// mappingChild finds the key/value pair in a mapping node whose key scalar
+// equals key. Returns (nil, nil) if not found or m is not a mapping.
+func mappingChild(m *yaml.Node, key string) (keyNode, valNode *yaml.Node) {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return nil, nil
+	}
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		k := m.Content[i]
+		if k.Value == key {
+			return k, m.Content[i+1]
+		}
+	}
+	return nil, nil
+}
+
+// sequenceItemByName scans a sequence of mapping nodes for the first item whose
+// name: child value equals name. Returns the item node and the line of its
+// name: key, or (nil, 0) if not found.
+func sequenceItemByName(seq *yaml.Node, name string) (item *yaml.Node, nameLine int) {
+	if seq == nil || seq.Kind != yaml.SequenceNode {
+		return nil, 0
+	}
+	for _, raw := range seq.Content {
+		it := deref(raw)
+		keyNode, valNode := mappingChild(it, "name")
+		if keyNode != nil && valNode != nil && valNode.Value == name {
+			return it, keyNode.Line
+		}
+	}
+	return nil, 0
+}

--- a/internal/lint/manifest/resolve.go
+++ b/internal/lint/manifest/resolve.go
@@ -17,9 +17,10 @@ import (
 // finding path within root, or 0 if root is nil or the path cannot be matched.
 // root is a yaml.v3 DocumentNode; the top mapping is its first content child.
 //
-// Module paths are special-cased because module names are Go import paths that
-// contain dots (e.g. github.com/getoutreach/stencil-base), which a naive split
-// on "." would shred. All other paths are walked as dotted mapping keys.
+// Module and argument paths are special-cased because their names contain dots
+// (module names are Go import paths like github.com/getoutreach/stencil-base;
+// argument names are namespaced like aws.IRSA), which a naive split on "." would
+// shred. All other paths are walked as dotted mapping keys.
 //
 // On any failure to match, resolvePath returns 0. It never panics.
 func resolvePath(root *yaml.Node, path string) int {
@@ -37,9 +38,12 @@ func resolvePath(root *yaml.Node, path string) int {
 		return 0
 	}
 
-	// Module paths need bespoke parsing (names contain dots).
+	// Module and argument paths need bespoke parsing (names contain dots).
 	if path == "modules" || strings.HasPrefix(path, "modules.") || strings.HasPrefix(path, "modules[") {
 		return resolveModulePath(top, path)
+	}
+	if strings.HasPrefix(path, "arguments.") {
+		return resolveArgumentPath(top, path)
 	}
 
 	// General dotted mapping walk.
@@ -57,6 +61,45 @@ func resolvePath(root *yaml.Node, path string) int {
 		cur = deref(valNode)
 	}
 	return lastKeyLine
+}
+
+// argumentFields are the per-argument keys the linter emits finding paths for.
+// They form a closed set, so a finding path "arguments.NAME.FIELD" can be split
+// unambiguously even when NAME itself contains dots: the trailing FIELD is one
+// of these, and everything between "arguments." and it is the (flat) NAME.
+var argumentFields = []string{"type", "values", "schema"}
+
+// resolveArgumentPath resolves "arguments.NAME" and "arguments.NAME.FIELD"
+// within the top mapping, where NAME is a single flat key that may contain dots
+// (e.g. aws.IRSA). FIELD, when present, is one of argumentFields. Returns the
+// FIELD key's line, or the NAME key's line for the bare form, or 0 on any miss.
+func resolveArgumentPath(top *yaml.Node, path string) int {
+	rest := strings.TrimPrefix(path, "arguments.")
+	_, argsVal := mappingChild(top, "arguments")
+	args := deref(argsVal)
+	if args == nil || args.Kind != yaml.MappingNode {
+		return 0
+	}
+
+	// Split off a known trailing field if present; otherwise the whole rest is
+	// the (bare) argument name.
+	name, field := rest, ""
+	for _, fld := range argumentFields {
+		if strings.HasSuffix(rest, "."+fld) {
+			name = strings.TrimSuffix(rest, "."+fld)
+			field = fld
+			break
+		}
+	}
+
+	keyNode, valNode := mappingChild(args, name)
+	if keyNode == nil {
+		return 0
+	}
+	if field == "" {
+		return keyNode.Line
+	}
+	return fieldLineIn(deref(valNode), field)
 }
 
 // resolveModulePath resolves "modules[N].field" and "modules.NAME.field" within

--- a/internal/lint/manifest/resolve_test.go
+++ b/internal/lint/manifest/resolve_test.go
@@ -69,6 +69,8 @@ modules:
 		{"whole-document path misses", "manifest.yaml", 0},
 		{"nonexistent argument misses", "arguments.nope.type", 0},
 		{"out-of-range module index misses", "modules[9].url", 0},
+		{"malformed index brace misses", "modules[0.url", 0},
+		{"non-numeric index misses", "modules[x].url", 0},
 		{"nonexistent module name misses", "modules.no-such-module.url", 0},
 		{"empty path misses", "", 0},
 	}

--- a/internal/lint/manifest/resolve_test.go
+++ b/internal/lint/manifest/resolve_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Tests for resolving dotted lint finding paths to YAML source lines.
+
+package manifest
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+	"gotest.tools/v3/assert"
+)
+
+// parseNode is a test helper: decode YAML text into a *yaml.Node document root.
+func parseNode(t *testing.T, in string) *yaml.Node {
+	t.Helper()
+	var n yaml.Node
+	assert.NilError(t, yaml.Unmarshal([]byte(in), &n))
+	return &n
+}
+
+func TestResolvePath(t *testing.T) {
+	// Line-numbered for reference (1-based):
+	// 1 name: testing
+	// 2 type: templates
+	// 3 stencilVersion: ">=1.0.0"
+	// 4 arguments:
+	// 5   foo:
+	// 6     type: string
+	// 7     values: [a, b]
+	// 8     schema:
+	// 9       type: string
+	// 10 modules:
+	// 11   - name: github.com/getoutreach/stencil-base
+	// 12     url: https://x
+	// 13     prerelease: true
+	const doc = `name: testing
+type: templates
+stencilVersion: ">=1.0.0"
+arguments:
+  foo:
+    type: string
+    values: [a, b]
+    schema:
+      type: string
+modules:
+  - name: github.com/getoutreach/stencil-base
+    url: https://x
+    prerelease: true
+`
+	root := parseNode(t, doc)
+
+	tests := []struct {
+		name string
+		path string
+		want int
+	}{
+		{"top-level name", "name", 1},
+		{"top-level type", "type", 2},
+		{"top-level stencilVersion", "stencilVersion", 3},
+		{"argument block key", "arguments.foo", 5},
+		{"argument type field", "arguments.foo.type", 6},
+		{"argument values field", "arguments.foo.values", 7},
+		{"argument schema field", "arguments.foo.schema", 8},
+		{"module url by name", "modules.github.com/getoutreach/stencil-base.url", 12},
+		{"module prerelease by name", "modules.github.com/getoutreach/stencil-base.prerelease", 13},
+		{"module url by index", "modules[0].url", 12},
+		{"module prerelease by index", "modules[0].prerelease", 13},
+		{"whole-document path misses", "manifest.yaml", 0},
+		{"nonexistent argument misses", "arguments.nope.type", 0},
+		{"out-of-range module index misses", "modules[9].url", 0},
+		{"nonexistent module name misses", "modules.no-such-module.url", 0},
+		{"empty path misses", "", 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, resolvePath(root, test.path))
+		})
+	}
+}
+
+func TestResolvePathNilRoot(t *testing.T) {
+	assert.Equal(t, 0, resolvePath(nil, "name"))
+}
+
+func TestResolvePathFollowsAlias(t *testing.T) {
+	// foo is an alias of the &def anchor; resolving through it must land on the
+	// anchor definition's key line.
+	// 1 defaults: &def
+	// 2   type: string
+	// 3   values: [a, b]
+	// 4 arguments:
+	// 5   foo: *def
+	const doc = `defaults: &def
+  type: string
+  values: [a, b]
+arguments:
+  foo: *def
+`
+	root := parseNode(t, doc)
+	// The aliased mapping's type key is defined on line 2.
+	assert.Equal(t, 2, resolvePath(root, "arguments.foo.type"))
+}
+
+func TestResolvePathDottedArgNameIsKnownLimitation(t *testing.T) {
+	// An argument whose name contains a dot mis-splits; documents the accepted
+	// limitation. "weird.name" splits into "weird"/"name", which won't match.
+	const doc = `arguments:
+  weird.name:
+    type: string
+`
+	root := parseNode(t, doc)
+	assert.Equal(t, 0, resolvePath(root, "arguments.weird.name.type"))
+}

--- a/internal/lint/manifest/resolve_test.go
+++ b/internal/lint/manifest/resolve_test.go
@@ -30,10 +30,15 @@ func TestResolvePath(t *testing.T) {
 	// 7     values: [a, b]
 	// 8     schema:
 	// 9       type: string
-	// 10 modules:
-	// 11   - name: github.com/getoutreach/stencil-base
-	// 12     url: https://x
-	// 13     prerelease: true
+	// 10   aws.IRSA:
+	// 11     type: boolean
+	// 12   terraform.datadog.monitoring.generateSLOs:
+	// 13     type: boolean
+	// 14     default: true
+	// 15 modules:
+	// 16   - name: github.com/getoutreach/stencil-base
+	// 17     url: https://x
+	// 18     prerelease: true
 	const doc = `name: testing
 type: templates
 stencilVersion: ">=1.0.0"
@@ -43,6 +48,11 @@ arguments:
     values: [a, b]
     schema:
       type: string
+  aws.IRSA:
+    type: boolean
+  terraform.datadog.monitoring.generateSLOs:
+    type: boolean
+    default: true
 modules:
   - name: github.com/getoutreach/stencil-base
     url: https://x
@@ -62,10 +72,14 @@ modules:
 		{"argument type field", "arguments.foo.type", 6},
 		{"argument values field", "arguments.foo.values", 7},
 		{"argument schema field", "arguments.foo.schema", 8},
-		{"module url by name", "modules.github.com/getoutreach/stencil-base.url", 12},
-		{"module prerelease by name", "modules.github.com/getoutreach/stencil-base.prerelease", 13},
-		{"module url by index", "modules[0].url", 12},
-		{"module prerelease by index", "modules[0].prerelease", 13},
+		{"dotted argument name, type field", "arguments.aws.IRSA.type", 11},
+		{"dotted argument name, bare", "arguments.aws.IRSA", 10},
+		{"deeply dotted argument name, type field", "arguments.terraform.datadog.monitoring.generateSLOs.type", 13},
+		{"deeply dotted argument name, bare", "arguments.terraform.datadog.monitoring.generateSLOs", 12},
+		{"module url by name", "modules.github.com/getoutreach/stencil-base.url", 17},
+		{"module prerelease by name", "modules.github.com/getoutreach/stencil-base.prerelease", 18},
+		{"module url by index", "modules[0].url", 17},
+		{"module prerelease by index", "modules[0].prerelease", 18},
 		{"whole-document path misses", "manifest.yaml", 0},
 		{"nonexistent argument misses", "arguments.nope.type", 0},
 		{"out-of-range module index misses", "modules[9].url", 0},
@@ -105,13 +119,20 @@ arguments:
 	assert.Equal(t, 2, resolvePath(root, "arguments.foo.type"))
 }
 
-func TestResolvePathDottedArgNameIsKnownLimitation(t *testing.T) {
-	// An argument whose name contains a dot mis-splits; documents the accepted
-	// limitation. "weird.name" splits into "weird"/"name", which won't match.
+func TestResolvePathDottedArgName(t *testing.T) {
+	// Argument names commonly contain dots for namespacing (e.g. "aws.IRSA",
+	// "dependencies.optional"). The resolver must treat the segment between the
+	// "arguments." prefix and a known trailing field as a single flat key.
+	// 1 arguments:
+	// 2   weird.name:
+	// 3     type: string
 	const doc = `arguments:
   weird.name:
     type: string
 `
 	root := parseNode(t, doc)
-	assert.Equal(t, 0, resolvePath(root, "arguments.weird.name.type"))
+	// Field form resolves to the field key line; bare form resolves to the
+	// argument's own key line.
+	assert.Equal(t, 3, resolvePath(root, "arguments.weird.name.type"))
+	assert.Equal(t, 2, resolvePath(root, "arguments.weird.name"))
 }


### PR DESCRIPTION
## What this PR does / why we need it

`stencil lint module-manifest` findings identify the offending field by a dotted path (e.g. `arguments.foo.type`) but not where it lives, which is tedious to locate in a large `manifest.yaml`. This adds the source line of the referenced YAML key as a `line` field on the finding's log output, so a deprecation warning now reads `... line=4 path=arguments.foo.type`.

The line is best-effort and additive: every finding that maps to a YAML key gets one, while whole-document findings (empty manifest, missing file) and any unresolvable path omit it. Existing `path`/`msg` output is unchanged.

## Notes for your reviewers

- **The load-bearing logic is dotted-name handling in `resolvePath`.** Both module and argument names routinely contain dots (module names are Go import paths; argument names are namespaced), yet finding paths are dot-joined — so a naive split on `.` shreds the name and resolves no line. The resolver anchors on the known prefix (`modules`/`arguments`) and a known trailing field, treating the span between as the flat name. This was verified against a production manifest; without it, the common case of dotted argument names gets no line at all.
- **`Load` now returns a `LoadResult` struct** (carrying the YAML node tree) and `Validate` takes it, replacing their previous multi-value signatures. The change is contained to `internal/lint/manifest` and its single production caller; no external API is affected.
- **The lint check functions are untouched.** All positional logic lives in the new resolver plus a one-pass annotation step in `Validate`, so the existing checks keep emitting the same dotted paths.
- The only unresolved case is the pathological one where an argument is literally *named* with a trailing field-name segment; it doesn't occur in practice and is documented as out of scope.