### PR TITLE
feat(lint): add `stencil lint templates --fix` and unify aggregate `--fix`

### DIFF
--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -3,17 +3,11 @@
 // Description: This file contains the stencil lint command, which statically
 // validates a Stencil module without resolving dependencies.
 //
-// gosec G304 note: every os.Open/os.ReadFile/os.WriteFile call in this file
-// takes a path that is either a CLI argument the invoking user typed directly,
-// or derived from one (e.g. joining a user-named directory with
-// "manifest.yaml"). Each path-accepting function runs it through
-// filepath.Clean before using it, resolving any "." or ".." elements
-// lexically. This is not a security boundary -- stencil lint's whole purpose
-// is to read/write files the local user already has filesystem access to,
-// the same trust model as `cat`/`grep`/`eslint <path>`, so there is no
-// privilege boundary here for a path to cross, and Clean does not (and is not
-// meant to) prevent the user from naming a path outside any particular
-// directory. It normalizes the path representation before use.
+// Every file path here is a CLI argument the user typed, or derived from one.
+// Each path-accepting function runs it through filepath.Clean before use, but
+// that's normalization, not a security boundary: there's no privilege
+// boundary for a path to cross in a local CLI tool operating on paths the
+// invoking user already has filesystem access to.
 
 package main
 
@@ -217,9 +211,8 @@ func lintTemplateFiles(log logrus.FieldLogger, files []string) ([]lint.Finding, 
 	return all, nil
 }
 
-// fixTemplateFiles fixes each path in files in place (writing only when bytes
-// change; see writeFixedFile) and returns the concatenated findings from
-// re-linting the (possibly fixed) content. A non-nil error is an I/O failure.
+// fixTemplateFiles fixes each path in files (see fixTemplateFile) and returns
+// the concatenated findings. A non-nil error is an I/O failure.
 func fixTemplateFiles(log logrus.FieldLogger, files []string) ([]lint.Finding, error) {
 	var all []lint.Finding
 	for _, path := range files {
@@ -272,9 +265,9 @@ func templateOpenErrorFinding(path string, err error) lint.Finding {
 	}
 }
 
-// logAppliedTemplates logs one info line per template-syntax fix the fixer
-// applied, additionally attaching the source line since (unlike
-// manifest.Applied) linttemplates.Applied carries one.
+// logAppliedTemplates logs one info line per template-syntax fix, including
+// the source line (linttemplates.Applied carries one; manifest.Applied does
+// not).
 func logAppliedTemplates(log logrus.FieldLogger, applied []linttemplates.Applied) {
 	for _, a := range applied {
 		logFixed(log, a.Path, a.Message, logrus.Fields{"line": a.Line})
@@ -652,11 +645,8 @@ func logFixed(log logrus.FieldLogger, path, message string, fields logrus.Fields
 
 // writeFixedFile returns a writer that overwrites path with the fixed bytes,
 // but only when they differ from original -- the bytes the caller already
-// read from path before fixing -- so a no-op fix does not dirty the file or
-// bump its mtime, and path is not read from disk a second time (avoiding a
-// second I/O round trip, and a TOCTOU window against a concurrent writer to
-// path between the caller's read and this write). The existing file mode is
-// preserved.
+// read from path -- so a no-op fix doesn't dirty the file, bump its mtime, or
+// re-read path from disk. The existing file mode is preserved.
 func writeFixedFile(path string, original []byte) func([]byte) error {
 	path = filepath.Clean(path)
 	return func(fixed []byte) error {

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -222,23 +222,12 @@ func fixTemplateFiles(log logrus.FieldLogger, files []string) ([]lint.Finding, e
 func fixTemplateFile(log logrus.FieldLogger, path string) ([]lint.Finding, error) {
 	log.WithField("path", path).Debug("fixing template")
 	raw, err := os.ReadFile(path) //nolint:gosec // Why: path is a user-provided lint target.
-	if os.IsNotExist(err) {
-		return []lint.Finding{{
-			Severity: lint.SeverityError,
-			Path:     path,
-			Message:  fmt.Sprintf("template file not found: %s", path),
-		}}, nil
-	}
 	if err != nil {
-		return []lint.Finding{{
-			Severity: lint.SeverityError,
-			Path:     path,
-			Message:  fmt.Sprintf("failed to open template %s: %v", path, err),
-		}}, nil
+		return []lint.Finding{templateOpenErrorFinding(path, err)}, nil
 	}
 
 	fixed, applied := linttemplates.FixBytes(path, raw)
-	if writeErr := writeFixedFile(path)(fixed); writeErr != nil {
+	if writeErr := writeFixedFile(path, raw)(fixed); writeErr != nil {
 		return nil, errors.Wrapf(writeErr, "failed to write fixed template %q", path)
 	}
 	logAppliedTemplates(log, applied)
@@ -246,12 +235,31 @@ func fixTemplateFile(log logrus.FieldLogger, path string) ([]lint.Finding, error
 	return linttemplates.LintReader(path, bytes.NewReader(fixed))
 }
 
+// templateOpenErrorFinding builds the "not found"/"failed to open" finding
+// for a template path that couldn't be read, shared by runTemplateFile and
+// fixTemplateFile so their wording for the same class of failure can never
+// diverge.
+func templateOpenErrorFinding(path string, err error) lint.Finding {
+	if os.IsNotExist(err) {
+		return lint.Finding{
+			Severity: lint.SeverityError,
+			Path:     path,
+			Message:  fmt.Sprintf("template file not found: %s", path),
+		}
+	}
+	return lint.Finding{
+		Severity: lint.SeverityError,
+		Path:     path,
+		Message:  fmt.Sprintf("failed to open template %s: %v", path, err),
+	}
+}
+
 // logAppliedTemplates logs one info line per template-syntax fix the fixer
-// applied. Mirrors logApplied, additionally attaching the source line since
-// (unlike manifest.Applied) linttemplates.Applied carries one.
+// applied, additionally attaching the source line since (unlike
+// manifest.Applied) linttemplates.Applied carries one.
 func logAppliedTemplates(log logrus.FieldLogger, applied []linttemplates.Applied) {
 	for _, a := range applied {
-		log.WithField("path", a.Path).WithField("line", a.Line).Infof("fixed: %s", a.Message)
+		logFixed(log, a.Path, a.Message, logrus.Fields{"line": a.Line})
 	}
 }
 
@@ -309,19 +317,8 @@ func collectTemplateFiles(log logrus.FieldLogger, dir string) ([]string, error) 
 func runTemplateFile(log logrus.FieldLogger, path string) ([]lint.Finding, error) {
 	log.WithField("path", path).Debug("linting template")
 	fh, err := os.Open(path) //nolint:gosec // Why: path is a user-provided lint target.
-	if os.IsNotExist(err) {
-		return []lint.Finding{{
-			Severity: lint.SeverityError,
-			Path:     path,
-			Message:  fmt.Sprintf("template file not found: %s", path),
-		}}, nil
-	}
 	if err != nil {
-		return []lint.Finding{{
-			Severity: lint.SeverityError,
-			Path:     path,
-			Message:  fmt.Sprintf("failed to open template %s: %v", path, err),
-		}}, nil
+		return []lint.Finding{templateOpenErrorFinding(path, err)}, nil
 	}
 	defer fh.Close()
 	return linttemplates.LintReader(path, fh)
@@ -350,6 +347,20 @@ func runLintAggregate(_ context.Context, c *cli.Command) error {
 
 	log := newLintLogger(c)
 
+	// Checked before the --fix branch too, so a non-directory path gets the
+	// same friendly finding either way, instead of --fix falling through to a
+	// raw "failed to stat ...manifest.yaml: not a directory" error from
+	// resolveManifestPath.
+	if info, statErr := os.Stat(dir); statErr == nil && !info.IsDir() {
+		finding := lint.Finding{
+			Severity: lint.SeverityError,
+			Path:     dir,
+			Message:  fmt.Sprintf("%q is not a directory; stencil lint expects a module directory", dir),
+		}
+		logFindings(log, []lint.Finding{finding})
+		return failIfFindings([]lint.Finding{finding}, c.Bool("warnings-as-errors"))
+	}
+
 	if c.Bool("fix") {
 		var all []lint.Finding
 
@@ -362,7 +373,7 @@ func runLintAggregate(_ context.Context, c *cli.Command) error {
 			if readErr != nil {
 				return errors.Wrapf(readErr, "failed to read %q", fixPath)
 			}
-			findings, fixErr := fixManifestBytes(log, fixPath, raw, writeFixedFile(fixPath))
+			findings, fixErr := fixManifestBytes(log, fixPath, raw, writeFixedFile(fixPath, raw))
 			if fixErr != nil {
 				return errors.Wrap(fixErr, "lint failed")
 			}
@@ -383,17 +394,7 @@ func runLintAggregate(_ context.Context, c *cli.Command) error {
 		all = append(all, findings...)
 
 		logFindings(log, all)
-		return failIfFindings(all, c.Bool("warnings-as-errors"))
-	}
-
-	if info, statErr := os.Stat(dir); statErr == nil && !info.IsDir() {
-		finding := lint.Finding{
-			Severity: lint.SeverityError,
-			Path:     dir,
-			Message:  fmt.Sprintf("%q is not a directory; stencil lint expects a module directory", dir),
-		}
-		logFindings(log, []lint.Finding{finding})
-		return failIfFindings([]lint.Finding{finding}, c.Bool("warnings-as-errors"))
+		return failLint(log, fmt.Sprintf("module %q is", dir), all, c.Bool("warnings-as-errors"))
 	}
 
 	runners := []runner{
@@ -465,7 +466,7 @@ func runLintModuleManifest(_ context.Context, c *cli.Command) error {
 		if readErr != nil {
 			return errors.Wrapf(readErr, "failed to read %q", fixPath)
 		}
-		return fixAndRelint(c, log, fixPath, raw, writeFixedFile(fixPath))
+		return fixAndRelint(c, log, fixPath, raw, writeFixedFile(fixPath, raw))
 	}
 
 	r, closer, finding, err := resolveManifestReader(path)
@@ -612,17 +613,32 @@ func failManifest(log logrus.FieldLogger, name string, findings []lint.Finding, 
 // logApplied logs one info line per fix the fixer applied.
 func logApplied(log logrus.FieldLogger, applied []lintmanifest.Applied) {
 	for _, a := range applied {
-		log.WithField("path", a.Path).Infof("fixed: %s", a.Message)
+		logFixed(log, a.Path, a.Message, nil)
 	}
 }
 
+// logFixed logs one info line for a single applied fix, in the shared
+// "fixed: <message>" format every fixer uses. fields attaches any additional
+// structured context beyond "path" (e.g. templates' source line); pass nil
+// for none.
+func logFixed(log logrus.FieldLogger, path, message string, fields logrus.Fields) {
+	entry := log.WithField("path", path)
+	if len(fields) > 0 {
+		entry = entry.WithFields(fields)
+	}
+	entry.Infof("fixed: %s", message)
+}
+
 // writeFixedFile returns a writer that overwrites path with the fixed bytes,
-// but only when they differ from the current contents (so a no-op fix does not
-// dirty the file or bump its mtime). The existing file mode is preserved.
-func writeFixedFile(path string) func([]byte) error {
+// but only when they differ from original -- the bytes the caller already
+// read from path before fixing -- so a no-op fix does not dirty the file or
+// bump its mtime, and path is not read from disk a second time (avoiding a
+// second I/O round trip, and a TOCTOU window against a concurrent writer to
+// path between the caller's read and this write). The existing file mode is
+// preserved.
+func writeFixedFile(path string, original []byte) func([]byte) error {
 	return func(fixed []byte) error {
-		current, err := os.ReadFile(path) //nolint:gosec // Why: user-provided lint target.
-		if err == nil && bytes.Equal(current, fixed) {
+		if bytes.Equal(original, fixed) {
 			return nil // no change: leave the file untouched
 		}
 		mode := os.FileMode(0o644)

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -2,6 +2,16 @@
 
 // Description: This file contains the stencil lint command, which statically
 // validates a Stencil module without resolving dependencies.
+//
+// gosec G304 note: every os.Open/os.ReadFile/os.WriteFile call in this file
+// takes a path that is either a CLI argument the invoking user typed directly,
+// or derived from one (e.g. joining a user-named directory with
+// "manifest.yaml"). stencil lint's whole purpose is to read/write files the
+// local user already has filesystem access to -- the same trust model as
+// `cat`/`grep`/`eslint <path>`. There is no privilege or trust boundary here
+// for a path to cross (the invoking user and the process share the same
+// filesystem permissions), so path canonicalization/allow-listing would not
+// add real protection; each call site is marked #nosec G304 on that basis.
 
 package main
 
@@ -221,7 +231,7 @@ func fixTemplateFiles(log logrus.FieldLogger, files []string) ([]lint.Finding, e
 // reported as a finding (not an error), mirroring runTemplateFile.
 func fixTemplateFile(log logrus.FieldLogger, path string) ([]lint.Finding, error) {
 	log.WithField("path", path).Debug("fixing template")
-	raw, err := os.ReadFile(path) //nolint:gosec // Why: path is a user-provided lint target.
+	raw, err := os.ReadFile(path) //nolint:gosec // Why: path is a user-provided lint target; #nosec G304 for the same reason.
 	if err != nil {
 		return []lint.Finding{templateOpenErrorFinding(path, err)}, nil
 	}
@@ -316,7 +326,7 @@ func collectTemplateFiles(log logrus.FieldLogger, dir string) ([]string, error) 
 // an error finding (not an error), mirroring resolveManifestReader.
 func runTemplateFile(log logrus.FieldLogger, path string) ([]lint.Finding, error) {
 	log.WithField("path", path).Debug("linting template")
-	fh, err := os.Open(path) //nolint:gosec // Why: path is a user-provided lint target.
+	fh, err := os.Open(path) //nolint:gosec // Why: path is a user-provided lint target; #nosec G304 for the same reason.
 	if err != nil {
 		return []lint.Finding{templateOpenErrorFinding(path, err)}, nil
 	}
@@ -369,7 +379,7 @@ func runLintAggregate(_ context.Context, c *cli.Command) error {
 			return errors.Wrap(err, "lint failed")
 		}
 		if finding == nil {
-			raw, readErr := os.ReadFile(fixPath) //nolint:gosec // Why: user-provided lint target.
+			raw, readErr := os.ReadFile(fixPath) //nolint:gosec // Why: user-provided lint target; #nosec G304 for the same reason.
 			if readErr != nil {
 				return errors.Wrapf(readErr, "failed to read %q", fixPath)
 			}
@@ -462,7 +472,7 @@ func runLintModuleManifest(_ context.Context, c *cli.Command) error {
 			return failManifest(log, fixPath, []lint.Finding{*finding},
 				c.Bool("warnings-as-errors"))
 		}
-		raw, readErr := os.ReadFile(fixPath) //nolint:gosec // Why: user-provided lint target.
+		raw, readErr := os.ReadFile(fixPath) //nolint:gosec // Why: user-provided lint target; #nosec G304 for the same reason.
 		if readErr != nil {
 			return errors.Wrapf(readErr, "failed to read %q", fixPath)
 		}
@@ -558,7 +568,7 @@ func resolveManifestReader(path string) (io.Reader, io.Closer, *lint.Finding, er
 		return nil, nil, nil, errors.Wrapf(err, "failed to stat %q", path)
 	}
 
-	fh, err := os.Open(path) //nolint:gosec // Why: path is a user-provided lint target.
+	fh, err := os.Open(path) //nolint:gosec // Why: path is a user-provided lint target; #nosec G304 for the same reason.
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "failed to open %q", path)
 	}

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -6,12 +6,14 @@
 // gosec G304 note: every os.Open/os.ReadFile/os.WriteFile call in this file
 // takes a path that is either a CLI argument the invoking user typed directly,
 // or derived from one (e.g. joining a user-named directory with
-// "manifest.yaml"). stencil lint's whole purpose is to read/write files the
-// local user already has filesystem access to -- the same trust model as
-// `cat`/`grep`/`eslint <path>`. There is no privilege or trust boundary here
-// for a path to cross (the invoking user and the process share the same
-// filesystem permissions), so path canonicalization/allow-listing would not
-// add real protection; each call site is marked #nosec G304 on that basis.
+// "manifest.yaml"). Each path-accepting function runs it through
+// filepath.Clean before using it, resolving any "." or ".." elements
+// lexically. This is not a security boundary -- stencil lint's whole purpose
+// is to read/write files the local user already has filesystem access to,
+// the same trust model as `cat`/`grep`/`eslint <path>`, so there is no
+// privilege boundary here for a path to cross, and Clean does not (and is not
+// meant to) prevent the user from naming a path outside any particular
+// directory. It normalizes the path representation before use.
 
 package main
 
@@ -230,8 +232,9 @@ func fixTemplateFiles(log logrus.FieldLogger, files []string) ([]lint.Finding, e
 // findings from re-linting the fixed content. A missing/unreadable file is
 // reported as a finding (not an error), mirroring runTemplateFile.
 func fixTemplateFile(log logrus.FieldLogger, path string) ([]lint.Finding, error) {
+	path = filepath.Clean(path)
 	log.WithField("path", path).Debug("fixing template")
-	raw, err := os.ReadFile(path) //nolint:gosec // Why: path is a user-provided lint target; #nosec G304 for the same reason.
+	raw, err := os.ReadFile(path) //nolint:gosec // Why: path is a user-provided lint target; cleaned above.
 	if err != nil {
 		return []lint.Finding{templateOpenErrorFinding(path, err)}, nil
 	}
@@ -325,8 +328,9 @@ func collectTemplateFiles(log logrus.FieldLogger, dir string) ([]string, error) 
 // runTemplateFile lints a single template path. A missing file is reported as
 // an error finding (not an error), mirroring resolveManifestReader.
 func runTemplateFile(log logrus.FieldLogger, path string) ([]lint.Finding, error) {
+	path = filepath.Clean(path)
 	log.WithField("path", path).Debug("linting template")
-	fh, err := os.Open(path) //nolint:gosec // Why: path is a user-provided lint target; #nosec G304 for the same reason.
+	fh, err := os.Open(path) //nolint:gosec // Why: path is a user-provided lint target; cleaned above.
 	if err != nil {
 		return []lint.Finding{templateOpenErrorFinding(path, err)}, nil
 	}
@@ -379,7 +383,7 @@ func runLintAggregate(_ context.Context, c *cli.Command) error {
 			return errors.Wrap(err, "lint failed")
 		}
 		if finding == nil {
-			raw, readErr := os.ReadFile(fixPath) //nolint:gosec // Why: user-provided lint target; #nosec G304 for the same reason.
+			raw, readErr := os.ReadFile(fixPath) //nolint:gosec // Why: path is a user-provided lint target, cleaned via resolveManifestPath.
 			if readErr != nil {
 				return errors.Wrapf(readErr, "failed to read %q", fixPath)
 			}
@@ -472,7 +476,7 @@ func runLintModuleManifest(_ context.Context, c *cli.Command) error {
 			return failManifest(log, fixPath, []lint.Finding{*finding},
 				c.Bool("warnings-as-errors"))
 		}
-		raw, readErr := os.ReadFile(fixPath) //nolint:gosec // Why: user-provided lint target; #nosec G304 for the same reason.
+		raw, readErr := os.ReadFile(fixPath) //nolint:gosec // Why: path is a user-provided lint target, cleaned via resolveManifestPath.
 		if readErr != nil {
 			return errors.Wrapf(readErr, "failed to read %q", fixPath)
 		}
@@ -528,6 +532,7 @@ func manifestRunner(path string) runner {
 // file not found" finding (not an error), mirroring resolveManifestReader so the
 // --fix and non-fix paths agree on target location and absence reporting.
 func resolveManifestPath(path string) (resolved string, finding *lint.Finding, err error) {
+	path = filepath.Clean(path)
 	info, statErr := os.Stat(path)
 	if statErr == nil && info.IsDir() {
 		path = filepath.Join(path, "manifest.yaml")
@@ -551,6 +556,7 @@ func resolveManifestPath(path string) (resolved string, finding *lint.Finding, e
 // finding (not an error). The returned io.Closer (when non-nil) must be closed
 // by the caller. A non-nil error is an unexpected I/O failure.
 func resolveManifestReader(path string) (io.Reader, io.Closer, *lint.Finding, error) {
+	path = filepath.Clean(path)
 	info, err := os.Stat(path)
 	if err == nil && info.IsDir() {
 		// A directory: lint its manifest.yaml (mirrors `lint [dir]`).
@@ -568,7 +574,7 @@ func resolveManifestReader(path string) (io.Reader, io.Closer, *lint.Finding, er
 		return nil, nil, nil, errors.Wrapf(err, "failed to stat %q", path)
 	}
 
-	fh, err := os.Open(path) //nolint:gosec // Why: path is a user-provided lint target; #nosec G304 for the same reason.
+	fh, err := os.Open(path) //nolint:gosec // Why: path is a user-provided lint target; cleaned above.
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "failed to open %q", path)
 	}
@@ -647,6 +653,7 @@ func logFixed(log logrus.FieldLogger, path, message string, fields logrus.Fields
 // path between the caller's read and this write). The existing file mode is
 // preserved.
 func writeFixedFile(path string, original []byte) func([]byte) error {
+	path = filepath.Clean(path)
 	return func(fixed []byte) error {
 		if bytes.Equal(original, fixed) {
 			return nil // no change: leave the file untouched
@@ -655,7 +662,7 @@ func writeFixedFile(path string, original []byte) func([]byte) error {
 		if info, statErr := os.Stat(path); statErr == nil {
 			mode = info.Mode().Perm()
 		}
-		return os.WriteFile(path, fixed, mode)
+		return os.WriteFile(path, fixed, mode) //nolint:gosec // Why: path is a user-provided lint target, cleaned above.
 	}
 }
 

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -234,7 +234,7 @@ func fixTemplateFiles(log logrus.FieldLogger, files []string) ([]lint.Finding, e
 func fixTemplateFile(log logrus.FieldLogger, path string) ([]lint.Finding, error) {
 	path = filepath.Clean(path)
 	log.WithField("path", path).Debug("fixing template")
-	raw, err := os.ReadFile(path) //nolint:gosec // Why: path is a user-provided lint target; cleaned above.
+	raw, err := os.ReadFile(path) // path was cleaned above.
 	if err != nil {
 		return []lint.Finding{templateOpenErrorFinding(path, err)}, nil
 	}
@@ -330,7 +330,7 @@ func collectTemplateFiles(log logrus.FieldLogger, dir string) ([]string, error) 
 func runTemplateFile(log logrus.FieldLogger, path string) ([]lint.Finding, error) {
 	path = filepath.Clean(path)
 	log.WithField("path", path).Debug("linting template")
-	fh, err := os.Open(path) //nolint:gosec // Why: path is a user-provided lint target; cleaned above.
+	fh, err := os.Open(path) // path was cleaned above.
 	if err != nil {
 		return []lint.Finding{templateOpenErrorFinding(path, err)}, nil
 	}
@@ -383,7 +383,7 @@ func runLintAggregate(_ context.Context, c *cli.Command) error {
 			return errors.Wrap(err, "lint failed")
 		}
 		if finding == nil {
-			raw, readErr := os.ReadFile(fixPath) //nolint:gosec // Why: path is a user-provided lint target, cleaned via resolveManifestPath.
+			raw, readErr := os.ReadFile(fixPath) // path was cleaned inside resolveManifestPath.
 			if readErr != nil {
 				return errors.Wrapf(readErr, "failed to read %q", fixPath)
 			}
@@ -476,7 +476,7 @@ func runLintModuleManifest(_ context.Context, c *cli.Command) error {
 			return failManifest(log, fixPath, []lint.Finding{*finding},
 				c.Bool("warnings-as-errors"))
 		}
-		raw, readErr := os.ReadFile(fixPath) //nolint:gosec // Why: path is a user-provided lint target, cleaned via resolveManifestPath.
+		raw, readErr := os.ReadFile(fixPath) // path was cleaned inside resolveManifestPath.
 		if readErr != nil {
 			return errors.Wrapf(readErr, "failed to read %q", fixPath)
 		}
@@ -574,7 +574,7 @@ func resolveManifestReader(path string) (io.Reader, io.Closer, *lint.Finding, er
 		return nil, nil, nil, errors.Wrapf(err, "failed to stat %q", path)
 	}
 
-	fh, err := os.Open(path) //nolint:gosec // Why: path is a user-provided lint target; cleaned above.
+	fh, err := os.Open(path) // path was cleaned above.
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "failed to open %q", path)
 	}
@@ -662,7 +662,7 @@ func writeFixedFile(path string, original []byte) func([]byte) error {
 		if info, statErr := os.Stat(path); statErr == nil {
 			mode = info.Mode().Perm()
 		}
-		return os.WriteFile(path, fixed, mode) //nolint:gosec // Why: path is a user-provided lint target, cleaned above.
+		return os.WriteFile(path, fixed, mode) // path was cleaned above.
 	}
 }
 

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -39,6 +39,11 @@ import (
 // templatesDir is the conventional subdirectory holding a module's *.tpl files.
 const templatesDir = "templates"
 
+// stdinName is the placeholder name/path used for stdin ('-') input across
+// both the manifest and templates lint/fix paths, so a finding, log line, or
+// Applied entry sourced from stdin always reads the same way.
+const stdinName = "<stdin>"
+
 // NewLintCommand returns the `lint` command group: an aggregate `lint [dir]`
 // plus `lint module-manifest [path]` and `lint templates [files...]`
 // subcommands. Validation is local-only.
@@ -130,20 +135,20 @@ func runLintTemplates(_ context.Context, c *cli.Command) error {
 			}
 			// Fixed template goes to stdout; diagnostics go to the logger
 			// (stderr), mirroring `lint module-manifest - --fix`.
-			fixed, applied := linttemplates.FixBytes("<stdin>", raw)
+			fixed, applied := linttemplates.FixBytes(stdinName, raw)
 			if _, werr := c.Writer.Write(fixed); werr != nil {
 				return errors.Wrap(werr, "failed to write fixed template")
 			}
 			logAppliedTemplates(log, applied)
-			findings, err := linttemplates.LintReader("<stdin>", bytes.NewReader(fixed))
+			findings, err := linttemplates.LintReader(stdinName, bytes.NewReader(fixed))
 			if err != nil {
 				return errors.Wrap(err, "lint failed")
 			}
 			logFindings(log, findings)
 			return failTemplates(log, findings, c.Bool("warnings-as-errors"))
 		}
-		log.WithField("path", "<stdin>").Debug("linting template")
-		findings, err := linttemplates.LintReader("<stdin>", c.Reader)
+		log.WithField("path", stdinName).Debug("linting template")
+		findings, err := linttemplates.LintReader(stdinName, c.Reader)
 		if err != nil {
 			return errors.Wrap(err, "lint failed")
 		}
@@ -234,7 +239,7 @@ func fixTemplateFiles(log logrus.FieldLogger, files []string) ([]lint.Finding, e
 func fixTemplateFile(log logrus.FieldLogger, path string) ([]lint.Finding, error) {
 	path = filepath.Clean(path)
 	log.WithField("path", path).Debug("fixing template")
-	raw, err := os.ReadFile(path) // path was cleaned above.
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		return []lint.Finding{templateOpenErrorFinding(path, err)}, nil
 	}
@@ -330,7 +335,7 @@ func collectTemplateFiles(log logrus.FieldLogger, dir string) ([]string, error) 
 func runTemplateFile(log logrus.FieldLogger, path string) ([]lint.Finding, error) {
 	path = filepath.Clean(path)
 	log.WithField("path", path).Debug("linting template")
-	fh, err := os.Open(path) // path was cleaned above.
+	fh, err := os.Open(path)
 	if err != nil {
 		return []lint.Finding{templateOpenErrorFinding(path, err)}, nil
 	}
@@ -447,17 +452,17 @@ func runLintModuleManifest(_ context.Context, c *cli.Command) error {
 		}
 		if c.Bool("fix") {
 			// Fixed YAML goes to stdout; diagnostics go to the logger (stderr).
-			return fixAndRelint(c, log, "<stdin>", raw, func(fixed []byte) error {
+			return fixAndRelint(c, log, stdinName, raw, func(fixed []byte) error {
 				_, werr := c.Writer.Write(fixed)
 				return werr
 			})
 		}
-		findings, err := runManifestReader(log, "<stdin>", bytes.NewReader(raw))
+		findings, err := runManifestReader(log, stdinName, bytes.NewReader(raw))
 		if err != nil {
 			return errors.Wrap(err, "lint failed")
 		}
 		logFindings(log, findings)
-		return failManifest(log, "<stdin>", findings, c.Bool("warnings-as-errors"))
+		return failManifest(log, stdinName, findings, c.Bool("warnings-as-errors"))
 	}
 
 	path := "./manifest.yaml"
@@ -574,7 +579,7 @@ func resolveManifestReader(path string) (io.Reader, io.Closer, *lint.Finding, er
 		return nil, nil, nil, errors.Wrapf(err, "failed to stat %q", path)
 	}
 
-	fh, err := os.Open(path) // path was cleaned above.
+	fh, err := os.Open(path)
 	if err != nil {
 		return nil, nil, nil, errors.Wrapf(err, "failed to open %q", path)
 	}
@@ -662,7 +667,7 @@ func writeFixedFile(path string, original []byte) func([]byte) error {
 		if info, statErr := os.Stat(path); statErr == nil {
 			mode = info.Mode().Perm()
 		}
-		return os.WriteFile(path, fixed, mode) // path was cleaned above.
+		return os.WriteFile(path, fixed, mode)
 	}
 }
 

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -28,13 +28,14 @@ import (
 const templatesDir = "templates"
 
 // NewLintCommand returns the `lint` command group: an aggregate `lint [dir]`
-// plus a `lint module-manifest [path]` subcommand. Validation is local-only.
+// plus `lint module-manifest [path]` and `lint templates [files...]`
+// subcommands. Validation is local-only.
 func NewLintCommand() *cli.Command {
 	return &cli.Command{
 		Name:        "lint",
 		Usage:       "Validate a Stencil module without resolving dependencies",
 		ArgsUsage:   "[dir]",
-		Description: "Validate a Stencil module's manifest without resolving dependencies (template linting follows in DT-4828)",
+		Description: "Validate a Stencil module's manifest and templates without resolving dependencies",
 		Flags:       []cli.Flag{warningsAsErrorsFlag(), fixFlag()},
 		Commands:    []*cli.Command{newLintModuleManifestCommand(), newLintTemplatesCommand()},
 		Action:      runLintAggregate,
@@ -51,13 +52,14 @@ func warningsAsErrorsFlag() cli.Flag {
 	}
 }
 
-// fixFlag is declared on both the lint group and the module-manifest
-// subcommand, since urfave/cli/v3 does not inherit parent flags. It is opt-in.
+// fixFlag is declared on the lint group and both the module-manifest and
+// templates subcommands, since urfave/cli/v3 does not inherit parent flags.
+// It is opt-in.
 func fixFlag() cli.Flag {
 	return &cli.BoolFlag{
 		Name: "fix",
-		Usage: "automatically fix safe deprecations in place, re-encoding the " +
-			"manifest at 2-space indent when a fix is applied (re-lints after fixing)",
+		Usage: "automatically fix safe deprecations in place (a manifest is " +
+			"re-encoded at 2-space indent when fixed; re-lints after fixing)",
 		Value: false,
 	}
 }
@@ -72,8 +74,7 @@ func newLintLogger(c *cli.Command) *logrus.Logger {
 }
 
 // runner lints one input and returns its findings. A non-nil error is an I/O
-// failure (not a lint finding). DT-4828 adds a template runner alongside the
-// manifest runner.
+// failure (not a lint finding).
 type runner func(log logrus.FieldLogger) ([]lint.Finding, error)
 
 // newLintModuleManifestCommand builds the `lint module-manifest [path]` subcommand.
@@ -95,7 +96,7 @@ func newLintTemplatesCommand() *cli.Command {
 		Usage:       "Validate Stencil templates' block correctness without rendering",
 		ArgsUsage:   "[files...]",
 		Description: "Validate template files (defaults to ./templates/**/*.tpl). Use '-' to read a single template from stdin.",
-		Flags:       []cli.Flag{warningsAsErrorsFlag()},
+		Flags:       []cli.Flag{warningsAsErrorsFlag(), fixFlag()},
 		Action:      runLintTemplates,
 	}
 }
@@ -103,11 +104,31 @@ func newLintTemplatesCommand() *cli.Command {
 // runLintTemplates is the `stencil lint templates [files...]` action.
 func runLintTemplates(_ context.Context, c *cli.Command) error {
 	log := newLintLogger(c)
+	fix := c.Bool("fix")
 
 	// stdin mode: a single '-' reads one template from stdin.
 	if c.Args().Len() == 1 && c.Args().First() == "-" {
 		if readerIsTTY(c.Reader) {
 			return errors.New("'-' expects piped input, not an interactive terminal")
+		}
+		if fix {
+			raw, err := io.ReadAll(c.Reader)
+			if err != nil {
+				return errors.Wrap(err, "failed to read stdin")
+			}
+			// Fixed template goes to stdout; diagnostics go to the logger
+			// (stderr), mirroring `lint module-manifest - --fix`.
+			fixed, applied := linttemplates.FixBytes("<stdin>", raw)
+			if _, werr := c.Writer.Write(fixed); werr != nil {
+				return errors.Wrap(werr, "failed to write fixed template")
+			}
+			logAppliedTemplates(log, applied)
+			findings, err := linttemplates.LintReader("<stdin>", bytes.NewReader(fixed))
+			if err != nil {
+				return errors.Wrap(err, "lint failed")
+			}
+			logFindings(log, findings)
+			return failTemplates(log, findings, c.Bool("warnings-as-errors"))
 		}
 		log.WithField("path", "<stdin>").Debug("linting template")
 		findings, err := linttemplates.LintReader("<stdin>", c.Reader)
@@ -150,7 +171,14 @@ func runLintTemplates(_ context.Context, c *cli.Command) error {
 	// args can be interleaved with dir-collected files above; sort the merged
 	// slice for deterministic output.
 	sort.Strings(files)
-	all, err := lintTemplateFiles(log, files)
+
+	var all []lint.Finding
+	var err error
+	if fix {
+		all, err = fixTemplateFiles(log, files)
+	} else {
+		all, err = lintTemplateFiles(log, files)
+	}
 	if err != nil {
 		return errors.Wrap(err, "lint failed")
 	}
@@ -170,6 +198,61 @@ func lintTemplateFiles(log logrus.FieldLogger, files []string) ([]lint.Finding, 
 		all = append(all, findings...)
 	}
 	return all, nil
+}
+
+// fixTemplateFiles fixes each path in files in place (writing only when bytes
+// change; see writeFixedFile) and returns the concatenated findings from
+// re-linting the (possibly fixed) content. A non-nil error is an I/O failure.
+func fixTemplateFiles(log logrus.FieldLogger, files []string) ([]lint.Finding, error) {
+	var all []lint.Finding
+	for _, path := range files {
+		findings, err := fixTemplateFile(log, path)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, findings...)
+	}
+	return all, nil
+}
+
+// fixTemplateFile migrates legacy block syntax in the template at path to v2
+// syntax, writes it back in place only when bytes changed, and returns the
+// findings from re-linting the fixed content. A missing/unreadable file is
+// reported as a finding (not an error), mirroring runTemplateFile.
+func fixTemplateFile(log logrus.FieldLogger, path string) ([]lint.Finding, error) {
+	log.WithField("path", path).Debug("fixing template")
+	raw, err := os.ReadFile(path) //nolint:gosec // Why: path is a user-provided lint target.
+	if os.IsNotExist(err) {
+		return []lint.Finding{{
+			Severity: lint.SeverityError,
+			Path:     path,
+			Message:  fmt.Sprintf("template file not found: %s", path),
+		}}, nil
+	}
+	if err != nil {
+		return []lint.Finding{{
+			Severity: lint.SeverityError,
+			Path:     path,
+			Message:  fmt.Sprintf("failed to open template %s: %v", path, err),
+		}}, nil
+	}
+
+	fixed, applied := linttemplates.FixBytes(path, raw)
+	if writeErr := writeFixedFile(path)(fixed); writeErr != nil {
+		return nil, errors.Wrapf(writeErr, "failed to write fixed template %q", path)
+	}
+	logAppliedTemplates(log, applied)
+
+	return linttemplates.LintReader(path, bytes.NewReader(fixed))
+}
+
+// logAppliedTemplates logs one info line per template-syntax fix the fixer
+// applied. Mirrors logApplied, additionally attaching the source line since
+// (unlike manifest.Applied) linttemplates.Applied carries one.
+func logAppliedTemplates(log logrus.FieldLogger, applied []linttemplates.Applied) {
+	for _, a := range applied {
+		log.WithField("path", a.Path).WithField("line", a.Line).Infof("fixed: %s", a.Message)
+	}
 }
 
 // templateRunner returns a runner that lints every *.tpl under dir. A missing
@@ -268,30 +351,39 @@ func runLintAggregate(_ context.Context, c *cli.Command) error {
 	log := newLintLogger(c)
 
 	if c.Bool("fix") {
-		// Aggregate --fix covers the manifest only (templates: future DT-4828).
+		var all []lint.Finding
+
 		fixPath, finding, err := resolveManifestPath(filepath.Join(dir, "manifest.yaml"))
 		if err != nil {
 			return errors.Wrap(err, "lint failed")
 		}
-		if finding != nil {
-			// Missing manifest: nothing to fix. Aggregate lint treats a missing
-			// manifest as "nothing to lint" (a module may be templates-only), so do
-			// not fail.
-			//
-			// NOTE: Intentional divergence — `lint --fix dir` lints NO templates,
-			// unlike `lint dir`. Template rule-1/rule-3 errors caught by the
-			// non-fix run are skipped here. Template fixing in aggregate --fix is
-			// deferred to a follow-up (DT-4828). Do not add template linting to
-			// the --fix path without also implementing template fixing.
-			return nil
+		if finding == nil {
+			raw, readErr := os.ReadFile(fixPath) //nolint:gosec // Why: user-provided lint target.
+			if readErr != nil {
+				return errors.Wrapf(readErr, "failed to read %q", fixPath)
+			}
+			findings, fixErr := fixManifestBytes(log, fixPath, raw, writeFixedFile(fixPath))
+			if fixErr != nil {
+				return errors.Wrap(fixErr, "lint failed")
+			}
+			all = append(all, findings...)
 		}
-		raw, readErr := os.ReadFile(fixPath) //nolint:gosec // Why: user-provided lint target.
-		if readErr != nil {
-			return errors.Wrapf(readErr, "failed to read %q", fixPath)
+		// A missing manifest is skipped, not fixed: aggregate lint treats it as
+		// "nothing to lint" (a module may be templates-only), matching the
+		// non-fix aggregate path and manifestRunner.
+
+		files, err := collectTemplateFiles(log, filepath.Join(dir, templatesDir))
+		if err != nil {
+			return errors.Wrap(err, "lint failed")
 		}
-		// NOTE: Even with a manifest present, --fix returns here and never lints
-		// templates (see divergence note above). Deferred to a follow-up (DT-4828).
-		return fixAndRelint(c, log, fixPath, raw, writeFixedFile(fixPath))
+		findings, err := fixTemplateFiles(log, files)
+		if err != nil {
+			return errors.Wrap(err, "lint failed")
+		}
+		all = append(all, findings...)
+
+		logFindings(log, all)
+		return failIfFindings(all, c.Bool("warnings-as-errors"))
 	}
 
 	if info, statErr := os.Stat(dir); statErr == nil && !info.IsDir() {
@@ -548,28 +640,35 @@ func writeFixedFile(path string) func([]byte) error {
 // normal lint runs so the decode error is reported.
 func fixAndRelint(c *cli.Command, log logrus.FieldLogger, name string, raw []byte,
 	writeFixed func([]byte) error) error {
-	fixed, applied, ok := lintmanifest.FixBytes(raw)
-	if !ok {
-		// Unparseable: fall back to a normal lint of the original bytes.
-		findings, err := runManifestReader(log, name, bytes.NewReader(raw))
-		if err != nil {
-			return errors.Wrap(err, "lint failed")
-		}
-		logFindings(log, findings)
-		return failManifest(log, name, findings, c.Bool("warnings-as-errors"))
-	}
-
-	if err := writeFixed(fixed); err != nil {
-		return errors.Wrap(err, "failed to write fixed manifest")
-	}
-	logApplied(log, applied)
-
-	findings, err := runManifestReader(log, name, bytes.NewReader(fixed))
+	findings, err := fixManifestBytes(log, name, raw, writeFixed)
 	if err != nil {
 		return errors.Wrap(err, "lint failed")
 	}
 	logFindings(log, findings)
 	return failManifest(log, name, findings, c.Bool("warnings-as-errors"))
+}
+
+// fixManifestBytes applies safe deprecation fixes to raw, writes the fixed
+// bytes via writeFixed (in-place for a file, or to stdout for '-'), logs each
+// applied fix, and returns the findings from re-linting the fixed content
+// (unlogged and policy-undecided, so callers can aggregate them with other
+// targets' findings before logging/deciding once). If raw cannot be parsed as
+// YAML, fixing is skipped and the original bytes are linted instead, so the
+// decode error surfaces as a normal finding.
+func fixManifestBytes(log logrus.FieldLogger, name string, raw []byte,
+	writeFixed func([]byte) error) ([]lint.Finding, error) {
+	fixed, applied, ok := lintmanifest.FixBytes(raw)
+	if !ok {
+		// Unparseable: fall back to a normal lint of the original bytes.
+		return runManifestReader(log, name, bytes.NewReader(raw))
+	}
+
+	if err := writeFixed(fixed); err != nil {
+		return nil, errors.Wrap(err, "failed to write fixed manifest")
+	}
+	logApplied(log, applied)
+
+	return runManifestReader(log, name, bytes.NewReader(fixed))
 }
 
 // failLint applies the warnings-as-errors policy and, on success, logs a

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -26,6 +26,28 @@ func discardLogger() *logrus.Logger {
 	return l
 }
 
+// captureStderr redirects the process's os.Stderr for the duration of run and
+// returns everything written to it. The lint command actions build their own
+// logrus.Logger via newLintLogger, which defaults to os.Stderr and isn't
+// otherwise injectable from a test driving the command through
+// (*cli.Command).Run, so this is the only way to assert on their log output
+// end to end.
+func captureStderr(t *testing.T, run func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	assert.NilError(t, err)
+	orig := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	run()
+
+	assert.NilError(t, w.Close())
+	out, err := io.ReadAll(r)
+	assert.NilError(t, err)
+	return string(out)
+}
+
 func TestRunManifestReaderValid(t *testing.T) {
 	findings, err := runManifestReader(discardLogger(), "<test>", strings.NewReader("name: testing\n"))
 	assert.NilError(t, err)
@@ -283,6 +305,54 @@ func TestRunLintModuleManifestFixNoOpDoesNotRewrite(t *testing.T) {
 	assert.Equal(t, string(clean), string(out)) // unchanged bytes
 	info2, _ := os.Stat(path)
 	assert.Equal(t, info1.ModTime(), info2.ModTime()) // not rewritten
+}
+
+// TestWriteFixedFileComparesAgainstPassedBytesNotDisk proves writeFixedFile's
+// no-op check uses the original bytes passed in by the caller, not a fresh
+// read of path, by pointing original at content that differs from what's
+// actually on disk: since fixed matches original (not the on-disk content),
+// the write must be skipped even though a re-read would have seen a
+// difference.
+func TestWriteFixedFileComparesAgainstPassedBytesNotDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	onDisk := []byte("on-disk content")
+	original := []byte("stale in-memory content")
+	assert.NilError(t, os.WriteFile(path, onDisk, 0o600))
+
+	info1, err := os.Stat(path)
+	assert.NilError(t, err)
+	err = writeFixedFile(path, original)(original) // fixed == original: a no-op by the caller's view
+	assert.NilError(t, err)
+
+	out, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	assert.Equal(t, string(onDisk), string(out), "on-disk content must be untouched by a caller-side no-op")
+	info2, err := os.Stat(path)
+	assert.NilError(t, err)
+	assert.Equal(t, info1.ModTime(), info2.ModTime())
+}
+
+// TestWriteFixedFileDoesNotReReadPath proves writeFixedFile no longer needs
+// path to still exist with its original content once original has been
+// captured: deleting the file between the caller's read and the write must
+// not prevent the write (mode falls back to the 0644 default, matching the
+// existing missing-file behavior of the mode lookup).
+func TestWriteFixedFileDoesNotReReadPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	original := []byte("original")
+	assert.NilError(t, os.WriteFile(path, original, 0o600))
+
+	assert.NilError(t, os.Remove(path)) // simulate a concurrent delete
+
+	fixed := []byte("fixed")
+	err := writeFixedFile(path, original)(fixed)
+	assert.NilError(t, err)
+
+	out, err := os.ReadFile(path)
+	assert.NilError(t, err)
+	assert.Equal(t, string(fixed), string(out))
 }
 
 func TestRunLintModuleManifestFixStdin(t *testing.T) {
@@ -655,6 +725,51 @@ func TestRunLintAggregateFixTemplatesOnlyModule(t *testing.T) {
 
 	tplOut, _ := os.ReadFile(filepath.Join(tdir, "a.tpl"))
 	assert.Equal(t, "## <<Stencil::Block(x)>>\n{{ file.Block \"x\" }}\n## <</Stencil::Block>>\n", string(tplOut))
+}
+
+// TestRunLintAggregateFixLogsSuccessLine pins that a clean aggregate --fix
+// run prints a success confirmation line, matching what the pre-unification
+// aggregate --fix (which delegated straight to the manifest subcommand's
+// fixAndRelint/failManifest) used to print, and what `lint module-manifest
+// --fix`/`lint templates --fix` still print today. Regression: the initial
+// unification replaced this with a bare failIfFindings, which is silent on
+// success.
+func TestRunLintAggregateFixLogsSuccessLine(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "manifest.yaml"),
+		[]byte("name: m\nmodules:\n  - name: dep\n    prerelease: true\n"), 0o600))
+
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	var err error
+	out := captureStderr(t, func() {
+		err = root.Run(context.Background(), []string{"lint", "--fix", dir})
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(out, "is valid"),
+		"expected a success confirmation line, got:\n%s", out)
+}
+
+// TestRunLintAggregateFixNonDirectoryYieldsFriendlyFinding proves `lint --fix
+// <non-directory>` gives the same clean "is not a directory" finding the
+// non-fix aggregate path gives for the identical input, instead of a raw,
+// path-leaking stat error from resolveManifestPath trying to join
+// "manifest.yaml" onto a file path.
+func TestRunLintAggregateFixNonDirectoryYieldsFriendlyFinding(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notadir.txt")
+	assert.NilError(t, os.WriteFile(path, []byte("hello"), 0o600))
+
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	var err error
+	out := captureStderr(t, func() {
+		err = root.Run(context.Background(), []string{"lint", "--fix", path})
+	})
+	assert.Assert(t, err != nil)
+	assert.Assert(t, strings.Contains(out, "is not a directory; stencil lint expects a module directory"),
+		"expected the friendly not-a-directory finding, got:\n%s", out)
+	assert.Assert(t, !strings.Contains(out, "failed to stat"),
+		"must not leak the raw resolveManifestPath stat error, got:\n%s", out)
 }
 
 // TestRunLintAggregateFixTemplatesUnfixableFails proves the unified aggregate

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -165,11 +165,8 @@ func TestResolveManifestReaderDirAppendsManifest(t *testing.T) {
 }
 
 // TestResolveManifestReaderCleansRedundantPathSegments pins that a path with
-// redundant "." / ".." segments (as gosec/Wiz-style path-validation scanners
-// look for evidence of, ahead of a file read) still resolves correctly:
-// filepath.Clean normalizes the representation before resolveManifestReader's
-// os.Stat/os.Open calls, though it does not (and is not meant to) restrict
-// which file gets opened.
+// redundant "." / ".." segments still resolves, since resolveManifestReader
+// runs it through filepath.Clean before use.
 func TestResolveManifestReaderCleansRedundantPathSegments(t *testing.T) {
 	dir := t.TempDir()
 	assert.NilError(t, os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte("name: testing\n"), 0o600))
@@ -348,12 +345,10 @@ func TestRunLintModuleManifestFixNoOpDoesNotRewrite(t *testing.T) {
 	assert.Equal(t, info1.ModTime(), info2.ModTime()) // not rewritten
 }
 
-// TestWriteFixedFileComparesAgainstPassedBytesNotDisk proves writeFixedFile's
-// no-op check uses the original bytes passed in by the caller, not a fresh
-// read of path, by pointing original at content that differs from what's
-// actually on disk: since fixed matches original (not the on-disk content),
-// the write must be skipped even though a re-read would have seen a
-// difference.
+// TestWriteFixedFileComparesAgainstPassedBytesNotDisk proves the no-op check
+// compares against the original bytes the caller passed in, not a fresh read
+// of path: original deliberately differs from the on-disk content, so a
+// re-read would have seen a change that the passed-in bytes don't.
 func TestWriteFixedFileComparesAgainstPassedBytesNotDisk(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "f.txt")
@@ -769,12 +764,8 @@ func TestRunLintAggregateFixTemplatesOnlyModule(t *testing.T) {
 }
 
 // TestRunLintAggregateFixLogsSuccessLine pins that a clean aggregate --fix
-// run prints a success confirmation line, matching what the pre-unification
-// aggregate --fix (which delegated straight to the manifest subcommand's
-// fixAndRelint/failManifest) used to print, and what `lint module-manifest
-// --fix`/`lint templates --fix` still print today. Regression: the initial
-// unification replaced this with a bare failIfFindings, which is silent on
-// success.
+// run prints a success confirmation line, matching `lint module-manifest
+// --fix`/`lint templates --fix`.
 func TestRunLintAggregateFixLogsSuccessLine(t *testing.T) {
 	dir := t.TempDir()
 	assert.NilError(t, os.WriteFile(filepath.Join(dir, "manifest.yaml"),
@@ -792,10 +783,8 @@ func TestRunLintAggregateFixLogsSuccessLine(t *testing.T) {
 }
 
 // TestRunLintAggregateFixNonDirectoryYieldsFriendlyFinding proves `lint --fix
-// <non-directory>` gives the same clean "is not a directory" finding the
-// non-fix aggregate path gives for the identical input, instead of a raw,
-// path-leaking stat error from resolveManifestPath trying to join
-// "manifest.yaml" onto a file path.
+// <non-directory>` gives the same "is not a directory" finding the non-fix
+// path gives, instead of a raw stat error from resolveManifestPath.
 func TestRunLintAggregateFixNonDirectoryYieldsFriendlyFinding(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "notadir.txt")
 	assert.NilError(t, os.WriteFile(path, []byte("hello"), 0o600))

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -523,3 +523,156 @@ func TestAggregateTemplatesOnlyModuleStillLintsTemplates(t *testing.T) {
 	assert.Assert(t, strings.Contains(err.Error(), "lint failed"),
 		"expected a lint failure, got: %v", err)
 }
+
+func TestNewLintCommandTemplatesHasFixFlag(t *testing.T) {
+	sub := findSubcommand(NewLintCommand(), "templates")
+	assert.Assert(t, sub != nil)
+	assert.Assert(t, flagPresent(sub.Flags, "fix"))
+}
+
+func TestRunLintTemplatesFixInPlace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.tpl")
+	legacy := "###Block(x)\n{{ file.Block \"x\" }}\n###EndBlock(x)\n"
+	assert.NilError(t, os.WriteFile(path, []byte(legacy), 0o600))
+
+	cmd := NewLintCommand()
+	sub := findSubcommand(cmd, "templates")
+	sub.Writer = io.Discard
+	err := cmd.Run(context.Background(), []string{"lint", "templates", "--fix", path})
+	assert.NilError(t, err) // the only finding was the fixable legacy warning → exit 0
+
+	out, readErr := os.ReadFile(path)
+	assert.NilError(t, readErr)
+	assert.Equal(t, "## <<Stencil::Block(x)>>\n{{ file.Block \"x\" }}\n## <</Stencil::Block>>\n", string(out))
+}
+
+// TestRunLintTemplatesFixLeavesUnfixable proves a legacy block missing
+// file.Block is still migrated to v2 syntax, but the rule-1 error (a
+// structural problem --fix never touches) survives re-lint and fails the run.
+func TestRunLintTemplatesFixLeavesUnfixable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.tpl")
+	legacy := "###Block(x)\n###EndBlock(x)\n"
+	assert.NilError(t, os.WriteFile(path, []byte(legacy), 0o600))
+
+	cmd := NewLintCommand()
+	sub := findSubcommand(cmd, "templates")
+	sub.Writer = io.Discard
+	err := cmd.Run(context.Background(), []string{"lint", "templates", "--fix", path})
+	assert.Assert(t, err != nil, "remaining rule-1 error must fail the run")
+	assert.Assert(t, strings.Contains(err.Error(), "lint failed"))
+
+	out, readErr := os.ReadFile(path)
+	assert.NilError(t, readErr)
+	assert.Equal(t, "## <<Stencil::Block(x)>>\n## <</Stencil::Block>>\n", string(out),
+		"the syntax fix should still have been applied and written")
+}
+
+func TestRunLintTemplatesFixNoOpDoesNotRewrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "a.tpl")
+	clean := []byte("## <<Stencil::Block(x)>>\n{{ file.Block \"x\" }}\n## <</Stencil::Block>>\n")
+	assert.NilError(t, os.WriteFile(path, clean, 0o600))
+
+	info1, _ := os.Stat(path)
+	cmd := NewLintCommand()
+	sub := findSubcommand(cmd, "templates")
+	sub.Writer = io.Discard
+	err := cmd.Run(context.Background(), []string{"lint", "templates", "--fix", path})
+	assert.NilError(t, err)
+
+	out, _ := os.ReadFile(path)
+	assert.Equal(t, string(clean), string(out)) // unchanged bytes
+	info2, _ := os.Stat(path)
+	assert.Equal(t, info1.ModTime(), info2.ModTime()) // not rewritten
+}
+
+func TestRunLintTemplatesFixStdin(t *testing.T) {
+	legacy := "###Block(x)\n{{ file.Block \"x\" }}\n###EndBlock(x)\n"
+	var stdout bytes.Buffer
+	cmd := NewLintCommand()
+	sub := findSubcommand(cmd, "templates")
+	sub.Reader = strings.NewReader(legacy)
+	sub.Writer = &stdout
+	err := cmd.Run(context.Background(), []string{"lint", "templates", "--fix", "-"})
+	assert.NilError(t, err)
+	assert.Equal(t, "## <<Stencil::Block(x)>>\n{{ file.Block \"x\" }}\n## <</Stencil::Block>>\n", stdout.String())
+}
+
+// TestFixTemplateFileMissingFileFinding mirrors
+// TestRunTemplateFileMissingFileFinding for the --fix code path: a missing
+// file is a reported finding, not an I/O error.
+func TestFixTemplateFileMissingFileFinding(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.tpl")
+	findings, err := fixTemplateFile(discardLogger(), path)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, lint.SeverityError, findings[0].Severity)
+	assert.Assert(t, strings.Contains(findings[0].Message, "template file not found:"))
+}
+
+// TestRunLintAggregateFixCoversTemplates proves the unified aggregate --fix
+// fixes the manifest AND fixes+re-lints templates in one pass, combining
+// their findings for the exit-code policy.
+func TestRunLintAggregateFixCoversTemplates(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "manifest.yaml"),
+		[]byte("name: m\nmodules:\n  - name: dep\n    prerelease: true\n"), 0o600))
+	tdir := filepath.Join(dir, "templates")
+	assert.NilError(t, os.MkdirAll(tdir, 0o750))
+	legacy := "###Block(x)\n{{ file.Block \"x\" }}\n###EndBlock(x)\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(tdir, "a.tpl"), []byte(legacy), 0o600))
+
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	err := root.Run(context.Background(), []string{"lint", "--fix", dir})
+	assert.NilError(t, err) // both fixes applied, nothing unfixable remains → exit 0
+
+	manifestOut, _ := os.ReadFile(filepath.Join(dir, "manifest.yaml"))
+	assert.Assert(t, strings.Contains(string(manifestOut), "channel: rc"),
+		"aggregate --fix should still migrate the manifest, got:\n%s", string(manifestOut))
+
+	tplOut, _ := os.ReadFile(filepath.Join(tdir, "a.tpl"))
+	assert.Equal(t, "## <<Stencil::Block(x)>>\n{{ file.Block \"x\" }}\n## <</Stencil::Block>>\n", string(tplOut),
+		"aggregate --fix should migrate legacy template syntax")
+}
+
+// TestRunLintAggregateFixTemplatesOnlyModule proves aggregate --fix still
+// fixes templates when there is no manifest.yaml at all (missing manifest is
+// skipped, not an error, matching the non-fix aggregate path).
+func TestRunLintAggregateFixTemplatesOnlyModule(t *testing.T) {
+	dir := t.TempDir()
+	tdir := filepath.Join(dir, "templates")
+	assert.NilError(t, os.MkdirAll(tdir, 0o750))
+	legacy := "###Block(x)\n{{ file.Block \"x\" }}\n###EndBlock(x)\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(tdir, "a.tpl"), []byte(legacy), 0o600))
+
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	err := root.Run(context.Background(), []string{"lint", "--fix", dir})
+	assert.NilError(t, err)
+
+	tplOut, _ := os.ReadFile(filepath.Join(tdir, "a.tpl"))
+	assert.Equal(t, "## <<Stencil::Block(x)>>\n{{ file.Block \"x\" }}\n## <</Stencil::Block>>\n", string(tplOut))
+}
+
+// TestRunLintAggregateFixTemplatesUnfixableFails proves the unified aggregate
+// --fix still fails when a template's structural error survives the fix, even
+// though the manifest fix on its own would have succeeded.
+func TestRunLintAggregateFixTemplatesUnfixableFails(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte("name: m\n"), 0o600))
+	tdir := filepath.Join(dir, "templates")
+	assert.NilError(t, os.MkdirAll(tdir, 0o750))
+	// Legacy syntax gets fixed, but the block still has no file.Block -> the
+	// rule-1 error survives re-lint.
+	legacy := "###Block(x)\n###EndBlock(x)\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(tdir, "a.tpl"), []byte(legacy), 0o600))
+
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	err := root.Run(context.Background(), []string{"lint", "--fix", dir})
+	assert.Assert(t, err != nil, "the surviving rule-1 error must fail the aggregate --fix run")
+	assert.Assert(t, strings.Contains(err.Error(), "lint failed"))
+}

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -164,6 +164,47 @@ func TestResolveManifestReaderDirAppendsManifest(t *testing.T) {
 	assert.Assert(t, strings.Contains(string(b), "name: testing"))
 }
 
+// TestResolveManifestReaderCleansRedundantPathSegments pins that a path with
+// redundant "." / ".." segments (as gosec/Wiz-style path-validation scanners
+// look for evidence of, ahead of a file read) still resolves correctly:
+// filepath.Clean normalizes the representation before resolveManifestReader's
+// os.Stat/os.Open calls, though it does not (and is not meant to) restrict
+// which file gets opened.
+func TestResolveManifestReaderCleansRedundantPathSegments(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte("name: testing\n"), 0o600))
+
+	// filepath.Join cleans its result internally, so building the redundant
+	// "sub/../." segments this way (rather than via Join) keeps the input
+	// genuinely uncleaned, exercising resolveManifestReader's own Clean call.
+	messy := dir + "/sub/../manifest.yaml"
+	r, closer, finding, err := resolveManifestReader(messy)
+	assert.NilError(t, err)
+	assert.Assert(t, finding == nil)
+	assert.Assert(t, r != nil)
+	if closer != nil {
+		defer closer.Close()
+	}
+	b, _ := io.ReadAll(r)
+	assert.Assert(t, strings.Contains(string(b), "name: testing"))
+}
+
+// TestResolveManifestPathCleansRedundantPathSegments mirrors
+// TestResolveManifestReaderCleansRedundantPathSegments for resolveManifestPath,
+// which feeds the --fix code paths.
+func TestResolveManifestPathCleansRedundantPathSegments(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte("name: testing\n"), 0o600))
+
+	// Not built via filepath.Join, which would clean it before
+	// resolveManifestPath ever saw it (see the sibling test above).
+	messy := dir + "/sub/.."
+	resolved, finding, err := resolveManifestPath(messy)
+	assert.NilError(t, err)
+	assert.Assert(t, finding == nil)
+	assert.Equal(t, filepath.Join(dir, "manifest.yaml"), resolved)
+}
+
 func TestManifestRunnerValid(t *testing.T) {
 	dir := t.TempDir()
 	assert.NilError(t, os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte("name: testing\n"), 0o600))

--- a/docs/content/en/commands/stencil_lint.md
+++ b/docs/content/en/commands/stencil_lint.md
@@ -1,7 +1,7 @@
 ---
 title: stencil lint
 linktitle: stencil lint
-description: Validate a Stencil module's manifest without resolving dependencies (template linting follows in DT-4828)
+description: Validate a Stencil module's manifest and templates without resolving dependencies
 categories: [commands]
 menu:
   docs:
@@ -18,7 +18,7 @@ USAGE:
    stencil lint [command [command options]] [dir]
 
 DESCRIPTION:
-   Validate a Stencil module's manifest without resolving dependencies (template linting follows in DT-4828)
+   Validate a Stencil module's manifest and templates without resolving dependencies
 
 COMMANDS:
    module-manifest  Validate a module's manifest.yaml without resolving dependencies
@@ -26,7 +26,7 @@ COMMANDS:
 
 OPTIONS:
    --warnings-as-errors  treat warnings as errors (fail on any finding)
-   --fix                 automatically fix safe deprecations in place, re-encoding the manifest at 2-space indent when a fix is applied (re-lints after fixing)
+   --fix                 automatically fix safe deprecations in place (a manifest is re-encoded at 2-space indent when fixed; re-lints after fixing)
    --help, -h            show help
 
 ```

--- a/docs/content/en/commands/stencil_lint_module-manifest.md
+++ b/docs/content/en/commands/stencil_lint_module-manifest.md
@@ -22,7 +22,7 @@ DESCRIPTION:
 
 OPTIONS:
    --warnings-as-errors  treat warnings as errors (fail on any finding)
-   --fix                 automatically fix safe deprecations in place, re-encoding the manifest at 2-space indent when a fix is applied (re-lints after fixing)
+   --fix                 automatically fix safe deprecations in place (a manifest is re-encoded at 2-space indent when fixed; re-lints after fixing)
    --help, -h            show help
 
 GLOBAL OPTIONS:

--- a/docs/content/en/commands/stencil_lint_templates.md
+++ b/docs/content/en/commands/stencil_lint_templates.md
@@ -22,6 +22,7 @@ DESCRIPTION:
 
 OPTIONS:
    --warnings-as-errors  treat warnings as errors (fail on any finding)
+   --fix                 automatically fix safe deprecations in place (a manifest is re-encoded at 2-space indent when fixed; re-lints after fixing)
    --help, -h            show help
 
 GLOBAL OPTIONS:

--- a/internal/codegen/blocks.go
+++ b/internal/codegen/blocks.go
@@ -14,6 +14,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// StartStatement is a constant for the start of a statement.
+const StartStatement = "Block"
+
 // EndStatement is a constant for the end of a statement
 const EndStatement = "EndBlock"
 
@@ -104,7 +107,7 @@ func parseBlocks(filePath string) (map[string]string, error) {
 			isCommand = true
 
 			switch cmd {
-			case "Block":
+			case StartStatement:
 				blockName := matches[3]
 				if curBlockName != "" {
 					return nil, fmt.Errorf("invalid Block when already inside of a block, at %s:%d", filePath, i+1)

--- a/internal/codegen/blocks_test.go
+++ b/internal/codegen/blocks_test.go
@@ -44,12 +44,9 @@ func TestWrongEndBlock(t *testing.T) {
 }
 
 // TestWrongEndBlockAfterV2Start pins that parseBlocks rejects a mismatched
-// legacy EndBlock name even when the matching Block start already uses v2
-// syntax -- the exact shape internal/lint/templates.FixBytes produces for a
-// legacy pair with mismatched names (it migrates the start, which is never at
-// risk, but deliberately leaves a mismatched EndBlock in legacy form so this
-// render-time check keeps firing rather than being silently defeated by
-// migrating the EndBlock to v2's nameless close tag).
+// legacy EndBlock name even when the Block start is already v2 syntax -- the
+// shape internal/lint/templates.FixBytes produces for a mismatched pair,
+// which it deliberately leaves the EndBlock unmigrated to keep triggering.
 func TestWrongEndBlockAfterV2Start(t *testing.T) {
 	_, err := parseBlocks("testdata/wrongendblock-v2start-test.txt")
 	assert.Error(t, err,

--- a/internal/codegen/blocks_test.go
+++ b/internal/codegen/blocks_test.go
@@ -43,6 +43,20 @@ func TestWrongEndBlock(t *testing.T) {
 		"expected parseBlocks() to fail")
 }
 
+// TestWrongEndBlockAfterV2Start pins that parseBlocks rejects a mismatched
+// legacy EndBlock name even when the matching Block start already uses v2
+// syntax -- the exact shape internal/lint/templates.FixBytes produces for a
+// legacy pair with mismatched names (it migrates the start, which is never at
+// risk, but deliberately leaves a mismatched EndBlock in legacy form so this
+// render-time check keeps firing rather than being silently defeated by
+// migrating the EndBlock to v2's nameless close tag).
+func TestWrongEndBlockAfterV2Start(t *testing.T) {
+	_, err := parseBlocks("testdata/wrongendblock-v2start-test.txt")
+	assert.Error(t, err,
+		"invalid EndBlock, found EndBlock with name \"wrongend\" while inside of block with name \"helloWorld\", at testdata/wrongendblock-v2start-test.txt:3", //nolint:lll
+		"expected parseBlocks() to fail")
+}
+
 func TestParseV2Blocks(t *testing.T) {
 	blocks, err := parseBlocks("testdata/v2blocks-test.txt")
 	assert.NilError(t, err, "expected parseBlocks() not to fail")

--- a/internal/codegen/testdata/wrongendblock-v2start-test.txt
+++ b/internal/codegen/testdata/wrongendblock-v2start-test.txt
@@ -1,0 +1,3 @@
+## <<Stencil::Block(helloWorld)>>
+Hello, world!
+###EndBlock(wrongend)

--- a/internal/lint/templates/.snapshots/TestFixBytes-CRLF_line_endings_are_preserved
+++ b/internal/lint/templates/.snapshots/TestFixBytes-CRLF_line_endings_are_preserved
@@ -1,0 +1,8 @@
+--- fixed ---
+## <<Stencil::Block(x)>>
+{{ file.Block "x" }}
+## <</Stencil::Block>>
+--- applied ---
+t.tpl:1  migrated deprecated block syntax to <<Stencil::Block(x)>>
+t.tpl:3  migrated deprecated block syntax to <</Stencil::Block>>
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-a_block_name_with_spaces_is_preserved_verbatim
+++ b/internal/lint/templates/.snapshots/TestFixBytes-a_block_name_with_spaces_is_preserved_verbatim
@@ -1,0 +1,8 @@
+--- fixed ---
+## <<Stencil::Block(my name)>>
+{{ file.Block "my name" }}
+## <</Stencil::Block>>
+--- applied ---
+t.tpl:1  migrated deprecated block syntax to <<Stencil::Block(my name)>>
+t.tpl:3  migrated deprecated block syntax to <</Stencil::Block>>
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-already-v2_block_is_a_byte-identical_no-op
+++ b/internal/lint/templates/.snapshots/TestFixBytes-already-v2_block_is_a_byte-identical_no-op
@@ -1,0 +1,7 @@
+--- fixed ---
+## <<Stencil::Block(customMise)>>
+{{ file.Block "customMise" }}
+## <</Stencil::Block>>
+--- applied ---
+(no fixes applied)
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-bare_legacy_EndBlock_is_migrated_even_though_unpaired
+++ b/internal/lint/templates/.snapshots/TestFixBytes-bare_legacy_EndBlock_is_migrated_even_though_unpaired
@@ -1,0 +1,5 @@
+--- fixed ---
+## <</Stencil::Block>>
+--- applied ---
+t.tpl:1  migrated deprecated block syntax to <</Stencil::Block>>
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-dynamic-name_legacy_block_is_left_untouched
+++ b/internal/lint/templates/.snapshots/TestFixBytes-dynamic-name_legacy_block_is_left_untouched
@@ -1,0 +1,7 @@
+--- fixed ---
+###Block({{ $b }})
+{{ file.Block $b }}
+###EndBlock({{ $b }})
+--- applied ---
+(no fixes applied)
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-extra_whitespace_between_prefix_and_command_is_normalized_to_one_space
+++ b/internal/lint/templates/.snapshots/TestFixBytes-extra_whitespace_between_prefix_and_command_is_normalized_to_one_space
@@ -1,0 +1,8 @@
+--- fixed ---
+## <<Stencil::Block(x)>>
+{{ file.Block "x" }}
+## <</Stencil::Block>>
+--- applied ---
+t.tpl:1  migrated deprecated block syntax to <<Stencil::Block(x)>>
+t.tpl:3  migrated deprecated block syntax to <</Stencil::Block>>
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-indentation_before_the_prefix_is_preserved
+++ b/internal/lint/templates/.snapshots/TestFixBytes-indentation_before_the_prefix_is_preserved
@@ -1,0 +1,8 @@
+--- fixed ---
+    ## <<Stencil::Block(x)>>
+    {{ file.Block "x" }}
+    ## <</Stencil::Block>>
+--- applied ---
+t.tpl:1  migrated deprecated block syntax to <<Stencil::Block(x)>>
+t.tpl:3  migrated deprecated block syntax to <</Stencil::Block>>
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-legacy_HTML-comment_block_preserves_the_trailing_comment_closer
+++ b/internal/lint/templates/.snapshots/TestFixBytes-legacy_HTML-comment_block_preserves_the_trailing_comment_closer
@@ -1,0 +1,10 @@
+--- fixed ---
+<!-- <<Stencil::Block(overview)>> -->
+
+hello, world!
+
+<!-- <</Stencil::Block>> -->
+--- applied ---
+t.tpl:1  migrated deprecated block syntax to <<Stencil::Block(overview)>>
+t.tpl:5  migrated deprecated block syntax to <</Stencil::Block>>
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-legacy_block_missing_file.Block_is_migrated_but_stays_incomplete
+++ b/internal/lint/templates/.snapshots/TestFixBytes-legacy_block_missing_file.Block_is_migrated_but_stays_incomplete
@@ -1,0 +1,7 @@
+--- fixed ---
+## <<Stencil::Block(x)>>
+## <</Stencil::Block>>
+--- applied ---
+t.tpl:1  migrated deprecated block syntax to <<Stencil::Block(x)>>
+t.tpl:2  migrated deprecated block syntax to <</Stencil::Block>>
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-legacy_hash-comment_block_is_migrated
+++ b/internal/lint/templates/.snapshots/TestFixBytes-legacy_hash-comment_block_is_migrated
@@ -1,0 +1,8 @@
+--- fixed ---
+## <<Stencil::Block(x)>>
+{{ file.Block "x" }}
+## <</Stencil::Block>>
+--- applied ---
+t.tpl:1  migrated deprecated block syntax to <<Stencil::Block(x)>>
+t.tpl:3  migrated deprecated block syntax to <</Stencil::Block>>
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-legacy_slash-comment_block_is_migrated
+++ b/internal/lint/templates/.snapshots/TestFixBytes-legacy_slash-comment_block_is_migrated
@@ -1,0 +1,8 @@
+--- fixed ---
+// <<Stencil::Block(x)>>
+{{ file.Block "x" }}
+// <</Stencil::Block>>
+--- applied ---
+t.tpl:1  migrated deprecated block syntax to <<Stencil::Block(x)>>
+t.tpl:3  migrated deprecated block syntax to <</Stencil::Block>>
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-matching_legacy_EndBlock_name_still_migrates
+++ b/internal/lint/templates/.snapshots/TestFixBytes-matching_legacy_EndBlock_name_still_migrates
@@ -1,0 +1,8 @@
+--- fixed ---
+## <<Stencil::Block(a)>>
+{{ file.Block "a" }}
+## <</Stencil::Block>>
+--- applied ---
+t.tpl:1  migrated deprecated block syntax to <<Stencil::Block(a)>>
+t.tpl:3  migrated deprecated block syntax to <</Stencil::Block>>
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-mismatched_legacy_EndBlock_after_a_v2_start_is_left_unmigrated
+++ b/internal/lint/templates/.snapshots/TestFixBytes-mismatched_legacy_EndBlock_after_a_v2_start_is_left_unmigrated
@@ -1,0 +1,7 @@
+--- fixed ---
+## <<Stencil::Block(a)>>
+{{ file.Block "a" }}
+###EndBlock(b)
+--- applied ---
+(no fixes applied)
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-mismatched_legacy_EndBlock_name_is_left_unmigrated_to_preserve_the_render-time_error
+++ b/internal/lint/templates/.snapshots/TestFixBytes-mismatched_legacy_EndBlock_name_is_left_unmigrated_to_preserve_the_render-time_error
@@ -1,0 +1,7 @@
+--- fixed ---
+## <<Stencil::Block(a)>>
+{{ file.Block "a" }}
+###EndBlock(b)
+--- applied ---
+t.tpl:1  migrated deprecated block syntax to <<Stencil::Block(a)>>
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-mixed_legacy_and_v2_blocks:_only_the_legacy_one_changes
+++ b/internal/lint/templates/.snapshots/TestFixBytes-mixed_legacy_and_v2_blocks:_only_the_legacy_one_changes
@@ -1,0 +1,11 @@
+--- fixed ---
+## <<Stencil::Block(a)>>
+{{ file.Block "a" }}
+## <</Stencil::Block>>
+## <<Stencil::Block(b)>>
+{{ file.Block "b" }}
+## <</Stencil::Block>>
+--- applied ---
+t.tpl:4  migrated deprecated block syntax to <<Stencil::Block(b)>>
+t.tpl:6  migrated deprecated block syntax to <</Stencil::Block>>
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-no_blocks_at_all_is_unchanged
+++ b/internal/lint/templates/.snapshots/TestFixBytes-no_blocks_at_all_is_unchanged
@@ -1,0 +1,6 @@
+--- fixed ---
+just some text
+no blocks here
+--- applied ---
+(no fixes applied)
+

--- a/internal/lint/templates/.snapshots/TestFixBytes-no_trailing_newline_on_the_final_line_is_preserved
+++ b/internal/lint/templates/.snapshots/TestFixBytes-no_trailing_newline_on_the_final_line_is_preserved
@@ -1,0 +1,7 @@
+--- fixed ---
+## <<Stencil::Block(x)>>
+{{ file.Block "x" }}
+## <</Stencil::Block>>--- applied ---
+t.tpl:1  migrated deprecated block syntax to <<Stencil::Block(x)>>
+t.tpl:3  migrated deprecated block syntax to <</Stencil::Block>>
+

--- a/internal/lint/templates/fix.go
+++ b/internal/lint/templates/fix.go
@@ -61,7 +61,7 @@ func matchLegacyTag(line string) (tag legacyTag, ok bool) {
 		return legacyTag{}, false
 	}
 	command := line[idx[4]:idx[5]]
-	if command != "Block" && command != codegen.EndStatement {
+	if command != codegen.StartStatement && command != codegen.EndStatement {
 		// Every other command word is inert to codegen/classify too.
 		return legacyTag{}, false
 	}
@@ -120,7 +120,7 @@ func fixLine(line string, hasOpen bool, openName string) (fixed, message string)
 	}
 
 	switch tag.command {
-	case "Block":
+	case codegen.StartStatement:
 		return tag.indent + v2Prefix + " <<Stencil::Block(" + tag.name + ")>>" + tag.suffix,
 			fmt.Sprintf("migrated deprecated block syntax to <<Stencil::Block(%s)>>", tag.name)
 	case codegen.EndStatement:

--- a/internal/lint/templates/fix.go
+++ b/internal/lint/templates/fix.go
@@ -10,7 +10,8 @@ package templates
 import (
 	"bytes"
 	"fmt"
-	"regexp"
+
+	"github.com/getoutreach/stencil/internal/codegen"
 )
 
 // Applied records one fix the fixer made to a template, for logging. Path is
@@ -22,67 +23,114 @@ type Applied struct {
 	Message string
 }
 
-// legacyLinePattern matches a legacy Block/EndBlock start or end tag with a
-// literal name: the same construct classify (see templates.go) recognizes via
-// codegen.BlockPattern and flags with the rule-6 deprecation warning. Capture
-// groups: 1=leading indent, 2=comment prefix, 3=command (Block or EndBlock),
-// 4=name. The command alternation is restricted to these two literals
-// (instead of codegen.BlockPattern's broader `[a-zA-Z ]+`) so this regex is
-// scoped to exactly what classify treats as a block token; every other
-// command word classify silently ignores, so there is nothing to fix there.
-var legacyLinePattern = regexp.MustCompile(`^(\s*)(///|###|<!---)\s*(Block|EndBlock)\(([a-zA-Z0-9 ]+)\)`)
-
-// legacyToV2Prefix maps each legacy comment prefix to its v2 counterpart.
-// V2BlockPattern allows at most one space between the prefix and "<<", so
-// fixLine always emits exactly one, regardless of the legacy line's spacing.
+// legacyToV2Prefix maps each of codegen.BlockPattern's legacy comment
+// prefixes to its v2 (codegen.V2BlockPattern) counterpart. V2BlockPattern
+// allows at most one space between the prefix and "<<", so fixLine always
+// emits exactly one, regardless of the legacy line's spacing.
+//
+// A prefix codegen.BlockPattern matches but this map doesn't cover (only
+// possible if BlockPattern's prefix alternation is ever extended without
+// updating this map) is left unfixed by matchLegacyTag's caller rather than
+// guessing, so that case fails safe -- no fix applied -- instead of silently
+// emitting a tag with no comment prefix at all.
 var legacyToV2Prefix = map[string]string{
 	"###":   "##",
 	"///":   "//",
 	"<!---": "<!--",
 }
 
+// legacyTag holds the parts of a line matched as a legacy Block or EndBlock
+// tag with a literal name.
+type legacyTag struct {
+	indent, prefix, command, name, suffix string
+}
+
+// matchLegacyTag reports whether line is a legacy Block/EndBlock tag, using
+// codegen.BlockPattern directly -- the same shared regex classify() (see
+// templates.go) and codegen's runtime parser (blocks.go) use -- rather than a
+// second, independently-typed-out copy, so this fixer can never recognize a
+// tag the linter doesn't (or vice versa) if BlockPattern is ever changed. ok
+// is false when line isn't a recognized Block/EndBlock command, including a
+// dynamic-name block (e.g. ###Block({{ $b }})): BlockPattern's name class
+// ([a-zA-Z0-9 ]+) cannot match a template expression at all, so classify
+// never recognizes these as blocks either (no rule-6 warning is ever emitted
+// for them, and in practice this construct exists only in test data).
+func matchLegacyTag(line string) (tag legacyTag, ok bool) {
+	idx := codegen.BlockPattern.FindStringSubmatchIndex(line)
+	if idx == nil {
+		return legacyTag{}, false
+	}
+	command := line[idx[4]:idx[5]]
+	if command != "Block" && command != codegen.EndStatement {
+		// Every other command word is inert to codegen/classify too.
+		return legacyTag{}, false
+	}
+	return legacyTag{
+		indent:  line[idx[0]:idx[2]],
+		prefix:  line[idx[2]:idx[3]],
+		command: command,
+		name:    line[idx[6]:idx[7]],
+		suffix:  line[idx[1]:],
+	}, true
+}
+
 // fixLine rewrites a single legacy Block/EndBlock declaration line (with no
-// trailing line terminator) to v2 syntax. message is empty when the line does
-// not match (fixed then equals line unchanged). Everything before the tag
-// (leading indentation) and after it (e.g. a trailing "-->" closing an HTML
-// comment) is preserved verbatim; only the recognized tag itself is rewritten.
+// trailing line terminator) to v2 syntax. hasOpen/openName describe the block
+// open immediately before this line (as tracked by FixBytes); they are
+// consulted only for an EndBlock tag, to decide whether dropping its name is
+// safe. message is empty when the line is left unchanged.
 //
-// It deliberately does not attempt to migrate:
-//   - a dynamic-name legacy block (e.g. ###Block({{ $b }})): codegen.BlockPattern
-//     cannot match a template expression as a name, so classify never
-//     recognizes these as blocks at all (no rule-6 warning is ever emitted for
-//     them), and in practice this construct exists only in test data.
+// Preserves indentation and everything after the tag (e.g. a trailing "-->"
+// closing an HTML comment) verbatim; only the recognized tag is rewritten.
+//
+// It deliberately does not migrate:
+//   - a dynamic-name legacy block: see matchLegacyTag.
 //   - v2 tag misuse (rule 5, e.g. <<Stencil::EndBlock>>) or anything already
 //     in v2 syntax: only the legacy-to-v2 migration is safe to automate.
+//   - a legacy prefix with no entry in legacyToV2Prefix: fails safe (see
+//     legacyToV2Prefix's doc comment).
+//   - an EndBlock(name) whose name does not match the name of the block open
+//     at this point (hasOpen/openName). codegen's runtime parser
+//     (blocks.go's parseBlocks) rejects exactly this mismatch at render time
+//     ("invalid EndBlock, found EndBlock with name ... while inside of block
+//     with name ...") -- the only place in the system that ever catches this
+//     authoring bug, since neither this linter's own scan() nor v2 syntax
+//     itself (whose close tag carries no name) ever compares names. Migrating
+//     a mismatched EndBlock to the nameless v2 form would permanently erase
+//     that one remaining signal. A bare EndBlock (hasOpen false) has nothing
+//     to compare against and is always safe to migrate: parseBlocks' "not
+//     inside of a block" check depends only on there being no open block,
+//     never on the dropped name.
 //
-// A legacy tag that is part of an already-broken structure (a bare EndBlock,
-// or a Block opened while another is still open) is still rewritten: this is
-// a pure per-line syntax migration keyed only on pattern match, not on
-// block-pairing state. The structural error itself is unaffected by the
-// rewrite and is still reported (in v2 terms) when the fixed bytes are
+// A legacy tag that is part of an otherwise-broken structure (a bare
+// EndBlock, or a Block opened while another is still open) is still
+// rewritten when the above safety checks pass: this is a per-line syntax
+// migration keyed on pattern match and (for EndBlock) name safety, not on
+// full block-pairing correctness. Structural errors are unaffected by the
+// rewrite and are still reported (in v2 terms) when the fixed bytes are
 // re-linted.
-func fixLine(line string) (fixed, message string) {
-	idx := legacyLinePattern.FindStringSubmatchIndex(line)
-	if idx == nil {
+func fixLine(line string, hasOpen bool, openName string) (fixed, message string) {
+	tag, ok := matchLegacyTag(line)
+	if !ok {
 		return line, ""
 	}
-	indent := line[idx[2]:idx[3]]
-	prefix := line[idx[4]:idx[5]]
-	command := line[idx[6]:idx[7]]
-	name := line[idx[8]:idx[9]]
-	suffix := line[idx[1]:]
+	v2Prefix, ok := legacyToV2Prefix[tag.prefix]
+	if !ok {
+		return line, ""
+	}
 
-	v2Prefix := legacyToV2Prefix[prefix]
-
-	switch command {
+	switch tag.command {
 	case "Block":
-		return indent + v2Prefix + " <<Stencil::Block(" + name + ")>>" + suffix,
-			fmt.Sprintf("migrated deprecated block syntax to <<Stencil::Block(%s)>>", name)
-	case "EndBlock":
-		return indent + v2Prefix + " <</Stencil::Block>>" + suffix,
+		return tag.indent + v2Prefix + " <<Stencil::Block(" + tag.name + ")>>" + tag.suffix,
+			fmt.Sprintf("migrated deprecated block syntax to <<Stencil::Block(%s)>>", tag.name)
+	case codegen.EndStatement:
+		if hasOpen && tag.name != openName {
+			return line, ""
+		}
+		return tag.indent + v2Prefix + " <</Stencil::Block>>" + tag.suffix,
 			"migrated deprecated block syntax to <</Stencil::Block>>"
 	default:
-		// Unreachable: legacyLinePattern only matches these two commands.
+		// Unreachable: matchLegacyTag only returns ok for these two commands.
 		return line, ""
 	}
 }
@@ -122,14 +170,37 @@ func splitTerminator(chunk []byte) (content, term []byte) {
 // no-op fix never reformats a file that is already clean or already v2. name
 // identifies the template in the returned Applied entries' Path field.
 //
-// Every other line — and everything on a rewritten line outside the matched
-// tag — is preserved byte for byte, including each line's original line-ending
-// style (LF, CRLF, or no trailing terminator on the final line).
+// Every other line -- and everything on a rewritten line outside the matched
+// tag -- is preserved byte for byte, including each line's original
+// line-ending style (LF, CRLF, or no trailing terminator on the final line).
+//
+// While scanning, FixBytes tracks which block (if any) is open using the same
+// classify() the linter's own scan() uses (see templates.go), so this view of
+// "what's open" -- consulted by fixLine to decide whether an EndBlock's name
+// is safe to drop -- never diverges from the linter's. Unlike scan(), this
+// tracking does not model illegal nesting (a single open name/flag pair is
+// overwritten by a nested start, matching scan()'s "blocks cannot legally
+// nest" simplification but not its nested-credit recovery): that additional
+// fidelity is not needed here, because a file with illegal nesting is already
+// rejected unconditionally by codegen's runtime parser for reasons unrelated
+// to any name match, before it would ever reach a name comparison.
 func FixBytes(name string, raw []byte) (fixed []byte, applied []Applied) {
 	var out bytes.Buffer
+	var hasOpen bool
+	var openName string
 	for i, chunk := range splitKeepEnds(raw) {
 		content, term := splitTerminator(chunk)
-		newContent, message := fixLine(string(content))
+		text := string(content)
+
+		newContent, message := fixLine(text, hasOpen, openName)
+
+		switch tok := classify(text); {
+		case tok.start:
+			hasOpen, openName = true, tok.name
+		case tok.end, tok.misuse != "":
+			hasOpen, openName = false, ""
+		}
+
 		if message == "" {
 			out.Write(chunk)
 			continue

--- a/internal/lint/templates/fix.go
+++ b/internal/lint/templates/fix.go
@@ -24,15 +24,10 @@ type Applied struct {
 }
 
 // legacyToV2Prefix maps each of codegen.BlockPattern's legacy comment
-// prefixes to its v2 (codegen.V2BlockPattern) counterpart. V2BlockPattern
-// allows at most one space between the prefix and "<<", so fixLine always
-// emits exactly one, regardless of the legacy line's spacing.
-//
-// A prefix codegen.BlockPattern matches but this map doesn't cover (only
-// possible if BlockPattern's prefix alternation is ever extended without
-// updating this map) is left unfixed by matchLegacyTag's caller rather than
-// guessing, so that case fails safe -- no fix applied -- instead of silently
-// emitting a tag with no comment prefix at all.
+// prefixes to its v2 (codegen.V2BlockPattern) counterpart. A prefix with no
+// entry here (only reachable if BlockPattern's alternation is ever extended
+// without updating this map) is left unfixed rather than guessed at, so that
+// case fails safe instead of emitting a tag with no comment prefix.
 var legacyToV2Prefix = map[string]string{
 	"###":   "##",
 	"///":   "//",
@@ -45,16 +40,12 @@ type legacyTag struct {
 	indent, prefix, command, name, suffix string
 }
 
-// matchLegacyTag reports whether line is a legacy Block/EndBlock tag, using
-// codegen.BlockPattern directly -- the same shared regex classify() (see
-// templates.go) and codegen's runtime parser (blocks.go) use -- rather than a
-// second, independently-typed-out copy, so this fixer can never recognize a
-// tag the linter doesn't (or vice versa) if BlockPattern is ever changed. ok
-// is false when line isn't a recognized Block/EndBlock command, including a
-// dynamic-name block (e.g. ###Block({{ $b }})): BlockPattern's name class
-// ([a-zA-Z0-9 ]+) cannot match a template expression at all, so classify
-// never recognizes these as blocks either (no rule-6 warning is ever emitted
-// for them, and in practice this construct exists only in test data).
+// matchLegacyTag reports whether line is a legacy Block/EndBlock tag. It uses
+// codegen.BlockPattern directly, the same regex classify() (templates.go) and
+// codegen's runtime parser use, so this fixer can't drift from what the
+// linter recognizes. ok is false for a dynamic-name block (e.g.
+// ###Block({{ $b }})): BlockPattern's name class can't match a template
+// expression, so classify doesn't recognize these as blocks either.
 func matchLegacyTag(line string) (tag legacyTag, ok bool) {
 	idx := codegen.BlockPattern.FindStringSubmatchIndex(line)
 	if idx == nil {
@@ -74,41 +65,22 @@ func matchLegacyTag(line string) (tag legacyTag, ok bool) {
 	}, true
 }
 
-// fixLine rewrites a single legacy Block/EndBlock declaration line (with no
-// trailing line terminator) to v2 syntax. hasOpen/openName describe the block
-// open immediately before this line (as tracked by FixBytes); they are
-// consulted only for an EndBlock tag, to decide whether dropping its name is
-// safe. message is empty when the line is left unchanged.
+// fixLine rewrites a single legacy Block/EndBlock line (no trailing
+// terminator) to v2 syntax, preserving indentation and everything after the
+// tag (e.g. a trailing "-->") verbatim. message is empty when left unchanged:
+// a dynamic-name block, v2 tag misuse, an unmapped legacy prefix (see
+// legacyToV2Prefix), or a legacy EndBlock whose name doesn't match hasOpen/
+// openName (the block FixBytes reports as currently open).
 //
-// Preserves indentation and everything after the tag (e.g. a trailing "-->"
-// closing an HTML comment) verbatim; only the recognized tag is rewritten.
+// The name-mismatch check exists because codegen's runtime parser rejects a
+// mismatched Block/EndBlock pair at render time, and that's the only place in
+// the system that ever catches it -- migrating the EndBlock to v2's nameless
+// close tag would erase that signal for good. A bare EndBlock (hasOpen false)
+// has nothing to compare against, so it's always safe to migrate.
 //
-// It deliberately does not migrate:
-//   - a dynamic-name legacy block: see matchLegacyTag.
-//   - v2 tag misuse (rule 5, e.g. <<Stencil::EndBlock>>) or anything already
-//     in v2 syntax: only the legacy-to-v2 migration is safe to automate.
-//   - a legacy prefix with no entry in legacyToV2Prefix: fails safe (see
-//     legacyToV2Prefix's doc comment).
-//   - an EndBlock(name) whose name does not match the name of the block open
-//     at this point (hasOpen/openName). codegen's runtime parser
-//     (blocks.go's parseBlocks) rejects exactly this mismatch at render time
-//     ("invalid EndBlock, found EndBlock with name ... while inside of block
-//     with name ...") -- the only place in the system that ever catches this
-//     authoring bug, since neither this linter's own scan() nor v2 syntax
-//     itself (whose close tag carries no name) ever compares names. Migrating
-//     a mismatched EndBlock to the nameless v2 form would permanently erase
-//     that one remaining signal. A bare EndBlock (hasOpen false) has nothing
-//     to compare against and is always safe to migrate: parseBlocks' "not
-//     inside of a block" check depends only on there being no open block,
-//     never on the dropped name.
-//
-// A legacy tag that is part of an otherwise-broken structure (a bare
-// EndBlock, or a Block opened while another is still open) is still
-// rewritten when the above safety checks pass: this is a per-line syntax
-// migration keyed on pattern match and (for EndBlock) name safety, not on
-// full block-pairing correctness. Structural errors are unaffected by the
-// rewrite and are still reported (in v2 terms) when the fixed bytes are
-// re-linted.
+// Otherwise a legacy tag is rewritten even inside an already-broken structure
+// (nested/dangling blocks): this is a per-line syntax migration, not a
+// structural fix, and structural errors are still reported after re-linting.
 func fixLine(line string, hasOpen bool, openName string) (fixed, message string) {
 	tag, ok := matchLegacyTag(line)
 	if !ok {
@@ -165,25 +137,19 @@ func splitTerminator(chunk []byte) (content, term []byte) {
 }
 
 // FixBytes mechanically migrates deprecated legacy block syntax in raw to v2
-// syntax (see fixLine) and returns the result along with a log of the changes
-// made. When nothing changed, fixed is raw itself (same underlying bytes) so a
-// no-op fix never reformats a file that is already clean or already v2. name
-// identifies the template in the returned Applied entries' Path field.
+// syntax (see fixLine) and returns the result plus a log of the changes made.
+// When nothing changed, fixed is raw itself, so a no-op fix never reformats an
+// already-clean or already-v2 file. name identifies the template in the
+// returned Applied entries' Path field. Every other line, and everything on a
+// rewritten line outside the matched tag, is preserved byte for byte,
+// including each line's original line-ending style.
 //
-// Every other line -- and everything on a rewritten line outside the matched
-// tag -- is preserved byte for byte, including each line's original
-// line-ending style (LF, CRLF, or no trailing terminator on the final line).
-//
-// While scanning, FixBytes tracks which block (if any) is open using the same
-// classify() the linter's own scan() uses (see templates.go), so this view of
-// "what's open" -- consulted by fixLine to decide whether an EndBlock's name
-// is safe to drop -- never diverges from the linter's. Unlike scan(), this
-// tracking does not model illegal nesting (a single open name/flag pair is
-// overwritten by a nested start, matching scan()'s "blocks cannot legally
-// nest" simplification but not its nested-credit recovery): that additional
-// fidelity is not needed here, because a file with illegal nesting is already
-// rejected unconditionally by codegen's runtime parser for reasons unrelated
-// to any name match, before it would ever reach a name comparison.
+// It tracks which block is open using the same classify() the linter's scan()
+// uses (templates.go), so fixLine's name-mismatch check never diverges from
+// the linter's view of the file. Unlike scan(), it doesn't model illegal
+// nesting (a nested start just overwrites the tracked name): a file with
+// illegal nesting is already rejected by codegen's runtime parser for reasons
+// unrelated to any name match, so that extra fidelity isn't needed here.
 func FixBytes(name string, raw []byte) (fixed []byte, applied []Applied) {
 	var out bytes.Buffer
 	var hasOpen bool

--- a/internal/lint/templates/fix.go
+++ b/internal/lint/templates/fix.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Implements a mechanical, comment-preserving auto-fix that
+// migrates deprecated legacy Stencil block syntax (###Block(name) /
+// ###EndBlock(name), in any of the three legacy comment styles) to the v2
+// <<Stencil::Block(name)>> / <</Stencil::Block>> form, one line at a time.
+
+package templates
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+)
+
+// Applied records one fix the fixer made to a template, for logging. Path is
+// the template name/path (mirroring lint.Finding.Path); Line is the 1-based
+// source line that was rewritten.
+type Applied struct {
+	Path    string
+	Line    int
+	Message string
+}
+
+// legacyLinePattern matches a legacy Block/EndBlock start or end tag with a
+// literal name: the same construct classify (see templates.go) recognizes via
+// codegen.BlockPattern and flags with the rule-6 deprecation warning. Capture
+// groups: 1=leading indent, 2=comment prefix, 3=command (Block or EndBlock),
+// 4=name. The command alternation is restricted to these two literals
+// (instead of codegen.BlockPattern's broader `[a-zA-Z ]+`) so this regex is
+// scoped to exactly what classify treats as a block token; every other
+// command word classify silently ignores, so there is nothing to fix there.
+var legacyLinePattern = regexp.MustCompile(`^(\s*)(///|###|<!---)\s*(Block|EndBlock)\(([a-zA-Z0-9 ]+)\)`)
+
+// legacyToV2Prefix maps each legacy comment prefix to its v2 counterpart.
+// V2BlockPattern allows at most one space between the prefix and "<<", so
+// fixLine always emits exactly one, regardless of the legacy line's spacing.
+var legacyToV2Prefix = map[string]string{
+	"###":   "##",
+	"///":   "//",
+	"<!---": "<!--",
+}
+
+// fixLine rewrites a single legacy Block/EndBlock declaration line (with no
+// trailing line terminator) to v2 syntax. message is empty when the line does
+// not match (fixed then equals line unchanged). Everything before the tag
+// (leading indentation) and after it (e.g. a trailing "-->" closing an HTML
+// comment) is preserved verbatim; only the recognized tag itself is rewritten.
+//
+// It deliberately does not attempt to migrate:
+//   - a dynamic-name legacy block (e.g. ###Block({{ $b }})): codegen.BlockPattern
+//     cannot match a template expression as a name, so classify never
+//     recognizes these as blocks at all (no rule-6 warning is ever emitted for
+//     them), and in practice this construct exists only in test data.
+//   - v2 tag misuse (rule 5, e.g. <<Stencil::EndBlock>>) or anything already
+//     in v2 syntax: only the legacy-to-v2 migration is safe to automate.
+//
+// A legacy tag that is part of an already-broken structure (a bare EndBlock,
+// or a Block opened while another is still open) is still rewritten: this is
+// a pure per-line syntax migration keyed only on pattern match, not on
+// block-pairing state. The structural error itself is unaffected by the
+// rewrite and is still reported (in v2 terms) when the fixed bytes are
+// re-linted.
+func fixLine(line string) (fixed, message string) {
+	idx := legacyLinePattern.FindStringSubmatchIndex(line)
+	if idx == nil {
+		return line, ""
+	}
+	indent := line[idx[2]:idx[3]]
+	prefix := line[idx[4]:idx[5]]
+	command := line[idx[6]:idx[7]]
+	name := line[idx[8]:idx[9]]
+	suffix := line[idx[1]:]
+
+	v2Prefix := legacyToV2Prefix[prefix]
+
+	switch command {
+	case "Block":
+		return indent + v2Prefix + " <<Stencil::Block(" + name + ")>>" + suffix,
+			fmt.Sprintf("migrated deprecated block syntax to <<Stencil::Block(%s)>>", name)
+	case "EndBlock":
+		return indent + v2Prefix + " <</Stencil::Block>>" + suffix,
+			"migrated deprecated block syntax to <</Stencil::Block>>"
+	default:
+		// Unreachable: legacyLinePattern only matches these two commands.
+		return line, ""
+	}
+}
+
+// splitKeepEnds splits raw into lines, each retaining its original line
+// terminator (if any). It mirrors bytes.SplitAfter(raw, []byte("\n")), but
+// drops the trailing empty chunk SplitAfter produces when raw ends in a
+// newline, so callers see exactly one chunk per source line regardless of
+// whether the final line is newline-terminated.
+func splitKeepEnds(raw []byte) [][]byte {
+	if len(raw) == 0 {
+		return nil
+	}
+	chunks := bytes.SplitAfter(raw, []byte("\n"))
+	if last := chunks[len(chunks)-1]; len(last) == 0 {
+		chunks = chunks[:len(chunks)-1]
+	}
+	return chunks
+}
+
+// splitTerminator splits a line chunk (as produced by splitKeepEnds) into its
+// content and terminator ("\r\n", "\n", or nil for a final line with no
+// trailing newline).
+func splitTerminator(chunk []byte) (content, term []byte) {
+	if bytes.HasSuffix(chunk, []byte("\r\n")) {
+		return chunk[:len(chunk)-2], chunk[len(chunk)-2:]
+	}
+	if bytes.HasSuffix(chunk, []byte("\n")) {
+		return chunk[:len(chunk)-1], chunk[len(chunk)-1:]
+	}
+	return chunk, nil
+}
+
+// FixBytes mechanically migrates deprecated legacy block syntax in raw to v2
+// syntax (see fixLine) and returns the result along with a log of the changes
+// made. When nothing changed, fixed is raw itself (same underlying bytes) so a
+// no-op fix never reformats a file that is already clean or already v2. name
+// identifies the template in the returned Applied entries' Path field.
+//
+// Every other line — and everything on a rewritten line outside the matched
+// tag — is preserved byte for byte, including each line's original line-ending
+// style (LF, CRLF, or no trailing terminator on the final line).
+func FixBytes(name string, raw []byte) (fixed []byte, applied []Applied) {
+	var out bytes.Buffer
+	for i, chunk := range splitKeepEnds(raw) {
+		content, term := splitTerminator(chunk)
+		newContent, message := fixLine(string(content))
+		if message == "" {
+			out.Write(chunk)
+			continue
+		}
+		applied = append(applied, Applied{Path: name, Line: i + 1, Message: message})
+		out.WriteString(newContent)
+		out.Write(term)
+	}
+	if len(applied) == 0 {
+		return raw, nil
+	}
+	return out.Bytes(), applied
+}

--- a/internal/lint/templates/fix_test.go
+++ b/internal/lint/templates/fix_test.go
@@ -100,22 +100,14 @@ func TestFixBytes(t *testing.T) {
 			in:   "###EndBlock(x)\n",
 		},
 		{
-			// A genuine name mismatch (###Block(a) ... ###EndBlock(b)) is
-			// rejected by codegen's runtime parser at render time -- the only
-			// place in the system that ever catches it, since neither the
-			// static linter nor v2 close-tag syntax itself compares names.
-			// The start is still migrated (its own name is never at risk),
-			// but the mismatched EndBlock is left in legacy form so
-			// parseBlocks keeps catching the mismatch on the next render.
+			// See fixLine's doc comment: codegen's runtime parser rejects this
+			// mismatch at render time; migrating it would erase the only signal
+			// that catches it.
 			name: "mismatched legacy EndBlock name is left unmigrated to preserve the render-time error",
 			in:   "###Block(a)\n{{ file.Block \"a\" }}\n###EndBlock(b)\n",
 		},
 		{
-			// The same protection applies when the open block was started
-			// with v2 syntax (already correct, untouched) and only the
-			// EndBlock is legacy with a mismatched name: migrating it would
-			// still erase the one signal that catches the mismatch at
-			// render time.
+			// Same protection when the open block was already v2 syntax.
 			name: "mismatched legacy EndBlock after a v2 start is left unmigrated",
 			in:   "## <<Stencil::Block(a)>>\n{{ file.Block \"a\" }}\n###EndBlock(b)\n",
 		},
@@ -165,14 +157,9 @@ func TestFixBytesNameMismatchPreservesLegacyEndBlockVerbatim(t *testing.T) {
 	assert.Equal(t, 1, len(applied))
 	assert.Assert(t, strings.Contains(applied[0].Message, "<<Stencil::Block(a)>>"))
 
-	// LintReader itself reports nothing new here either way: scan() (see
-	// templates.go) never compared EndBlock names before this fix and still
-	// doesn't after it -- it only cares whether *some* block is open, not
-	// whether the name matches. The value of leaving this EndBlock unmigrated
-	// is specifically for codegen's runtime parser (blocks.go's parseBlocks),
-	// a render-time code path LintReader never exercises; see
-	// internal/codegen.TestWrongEndBlockAfterV2Start, which pins that
-	// parseBlocks still rejects this exact fixed-output shape.
+	// LintReader reports nothing here either way -- scan() never compared
+	// EndBlock names -- the protection is for codegen's runtime parser, see
+	// internal/codegen.TestWrongEndBlockAfterV2Start.
 	findings, err := linttemplates.LintReader("t.tpl", strings.NewReader(string(fixed)))
 	assert.NilError(t, err)
 	assert.Equal(t, 0, len(findings))

--- a/internal/lint/templates/fix_test.go
+++ b/internal/lint/templates/fix_test.go
@@ -100,6 +100,33 @@ func TestFixBytes(t *testing.T) {
 			in:   "###EndBlock(x)\n",
 		},
 		{
+			// A genuine name mismatch (###Block(a) ... ###EndBlock(b)) is
+			// rejected by codegen's runtime parser at render time -- the only
+			// place in the system that ever catches it, since neither the
+			// static linter nor v2 close-tag syntax itself compares names.
+			// The start is still migrated (its own name is never at risk),
+			// but the mismatched EndBlock is left in legacy form so
+			// parseBlocks keeps catching the mismatch on the next render.
+			name: "mismatched legacy EndBlock name is left unmigrated to preserve the render-time error",
+			in:   "###Block(a)\n{{ file.Block \"a\" }}\n###EndBlock(b)\n",
+		},
+		{
+			// The same protection applies when the open block was started
+			// with v2 syntax (already correct, untouched) and only the
+			// EndBlock is legacy with a mismatched name: migrating it would
+			// still erase the one signal that catches the mismatch at
+			// render time.
+			name: "mismatched legacy EndBlock after a v2 start is left unmigrated",
+			in:   "## <<Stencil::Block(a)>>\n{{ file.Block \"a\" }}\n###EndBlock(b)\n",
+		},
+		{
+			// Confirms the mismatch check is name-sensitive, not a blanket
+			// "never fix an EndBlock after a Block on a different line"
+			// rule: matching names still migrate fully.
+			name: "matching legacy EndBlock name still migrates",
+			in:   "###Block(a)\n{{ file.Block \"a\" }}\n###EndBlock(a)\n",
+		},
+		{
 			name: "no trailing newline on the final line is preserved",
 			in:   "###Block(x)\n{{ file.Block \"x\" }}\n###EndBlock(x)",
 		},
@@ -121,6 +148,34 @@ func TestFixBytes(t *testing.T) {
 			assert.Equal(t, 0, len(applied2))
 		})
 	}
+}
+
+// TestFixBytesNameMismatchPreservesLegacyEndBlockVerbatim pins the exact
+// output for the name-mismatch protection: the Block start migrates (its own
+// name is never at risk), but the mismatched EndBlock is left byte-identical
+// to the input, name and all, so codegen's runtime parser keeps rejecting the
+// mismatch on the next render exactly as it did before --fix ran.
+func TestFixBytesNameMismatchPreservesLegacyEndBlockVerbatim(t *testing.T) {
+	in := "###Block(a)\n{{ file.Block \"a\" }}\n###EndBlock(b)\n"
+	fixed, applied := linttemplates.FixBytes("t.tpl", []byte(in))
+
+	assert.Equal(t,
+		"## <<Stencil::Block(a)>>\n{{ file.Block \"a\" }}\n###EndBlock(b)\n",
+		string(fixed))
+	assert.Equal(t, 1, len(applied))
+	assert.Assert(t, strings.Contains(applied[0].Message, "<<Stencil::Block(a)>>"))
+
+	// LintReader itself reports nothing new here either way: scan() (see
+	// templates.go) never compared EndBlock names before this fix and still
+	// doesn't after it -- it only cares whether *some* block is open, not
+	// whether the name matches. The value of leaving this EndBlock unmigrated
+	// is specifically for codegen's runtime parser (blocks.go's parseBlocks),
+	// a render-time code path LintReader never exercises; see
+	// internal/codegen.TestWrongEndBlockAfterV2Start, which pins that
+	// parseBlocks still rejects this exact fixed-output shape.
+	findings, err := linttemplates.LintReader("t.tpl", strings.NewReader(string(fixed)))
+	assert.NilError(t, err)
+	assert.Equal(t, 0, len(findings))
 }
 
 // TestFixBytesNoOpReturnsSameBytes pins that an input requiring no fix gets

--- a/internal/lint/templates/fix_test.go
+++ b/internal/lint/templates/fix_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Tests for the legacy-to-v2 block syntax auto-fixer.
+
+package templates_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/bradleyjkemp/cupaloy"
+	"gotest.tools/v3/assert"
+
+	linttemplates "github.com/getoutreach/stencil/internal/lint/templates"
+)
+
+// renderFix formats a FixBytes result for snapshotting: the fixed bytes
+// (fenced so leading/trailing whitespace and line endings are visible), then
+// one line per fix in the same "path:line  message" style as renderFindings
+// in templates_test.go.
+func renderFix(fixed []byte, applied []linttemplates.Applied) string {
+	var b strings.Builder
+	b.WriteString("--- fixed ---\n")
+	b.Write(fixed)
+	b.WriteString("--- applied ---\n")
+	if len(applied) == 0 {
+		b.WriteString("(no fixes applied)\n")
+		return b.String()
+	}
+	for _, a := range applied {
+		fmt.Fprintf(&b, "%s:%d  %s\n", a.Path, a.Line, a.Message)
+	}
+	return b.String()
+}
+
+func TestFixBytes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{name: "no blocks at all is unchanged", in: "just some text\nno blocks here\n"},
+		{
+			name: "already-v2 block is a byte-identical no-op",
+			in:   "## <<Stencil::Block(customMise)>>\n{{ file.Block \"customMise\" }}\n## <</Stencil::Block>>\n",
+		},
+		{
+			name: "legacy hash-comment block is migrated",
+			in:   "###Block(x)\n{{ file.Block \"x\" }}\n###EndBlock(x)\n",
+		},
+		{
+			name: "legacy slash-comment block is migrated",
+			in:   "///Block(x)\n{{ file.Block \"x\" }}\n///EndBlock(x)\n",
+		},
+		{
+			// Real usage (docs/content/en/getting-started/quick-start.md): the
+			// legacy HTML-comment prefix is "<!---" and the line is closed by a
+			// trailing "-->", which must survive the rewrite untouched.
+			name: "legacy HTML-comment block preserves the trailing comment closer",
+			in:   "<!--- Block(overview) -->\n\nhello, world!\n\n<!--- EndBlock(overview) -->\n",
+		},
+		{
+			name: "indentation before the prefix is preserved",
+			in:   "    ###Block(x)\n    {{ file.Block \"x\" }}\n    ###EndBlock(x)\n",
+		},
+		{
+			name: "extra whitespace between prefix and command is normalized to one space",
+			in:   "###   Block(x)\n{{ file.Block \"x\" }}\n###   EndBlock(x)\n",
+		},
+		{
+			name: "a block name with spaces is preserved verbatim",
+			in:   "###Block(my name)\n{{ file.Block \"my name\" }}\n###EndBlock(my name)\n",
+		},
+		{
+			// A legacy block still missing file.Block after the rewrite must
+			// still be reportable by the linter (fixing syntax does not fix
+			// the missing-file.Block structural error).
+			name: "legacy block missing file.Block is migrated but stays incomplete",
+			in:   "###Block(x)\n###EndBlock(x)\n",
+		},
+		{
+			name: "mixed legacy and v2 blocks: only the legacy one changes",
+			in: "## <<Stencil::Block(a)>>\n{{ file.Block \"a\" }}\n## <</Stencil::Block>>\n" +
+				"###Block(b)\n{{ file.Block \"b\" }}\n###EndBlock(b)\n",
+		},
+		{
+			// A dynamic-name legacy block is invisible to codegen.BlockPattern
+			// (and so to the linter's rule-6 warning); FixBytes must leave it
+			// untouched rather than guessing at a migration for a construct the
+			// linter never flagged.
+			name: "dynamic-name legacy block is left untouched",
+			in:   "###Block({{ $b }})\n{{ file.Block $b }}\n###EndBlock({{ $b }})\n",
+		},
+		{
+			// A bare legacy EndBlock (rule-3 structural error, no matching
+			// start) is still migrated at the syntax level; the structural
+			// error itself is unaffected and is re-reported (in v2 terms) by
+			// LintReader on the fixed bytes.
+			name: "bare legacy EndBlock is migrated even though unpaired",
+			in:   "###EndBlock(x)\n",
+		},
+		{
+			name: "no trailing newline on the final line is preserved",
+			in:   "###Block(x)\n{{ file.Block \"x\" }}\n###EndBlock(x)",
+		},
+		{
+			name: "CRLF line endings are preserved",
+			in:   "###Block(x)\r\n{{ file.Block \"x\" }}\r\n###EndBlock(x)\r\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixed, applied := linttemplates.FixBytes("t.tpl", []byte(test.in))
+			cupaloy.SnapshotT(t, renderFix(fixed, applied))
+
+			// Idempotency: fixing already-fixed bytes must be a byte-identical
+			// no-op (same underlying bytes, zero further fixes applied).
+			fixed2, applied2 := linttemplates.FixBytes("t.tpl", fixed)
+			assert.Equal(t, string(fixed), string(fixed2))
+			assert.Equal(t, 0, len(applied2))
+		})
+	}
+}
+
+// TestFixBytesNoOpReturnsSameBytes pins that an input requiring no fix gets
+// back the identical byte slice (not a reallocated copy), matching
+// manifest.FixBytes's no-op contract so a CLI caller's writeFixedFile never
+// dirties a file that needed no change.
+func TestFixBytesNoOpReturnsSameBytes(t *testing.T) {
+	in := []byte("## <<Stencil::Block(x)>>\n{{ file.Block \"x\" }}\n## <</Stencil::Block>>\n")
+	fixed, applied := linttemplates.FixBytes("t.tpl", in)
+	assert.Equal(t, 0, len(applied))
+	assert.Equal(t, string(in), string(fixed))
+}
+
+// TestFixBytesMissingFileBlockStillReportedAfterFix is the CLI-scope
+// requirement made explicit at the package level: migrating syntax does not
+// silence the rule-1 "no file.Block" error, since that is a structural
+// problem the fixer intentionally never touches.
+func TestFixBytesMissingFileBlockStillReportedAfterFix(t *testing.T) {
+	fixed, applied := linttemplates.FixBytes("t.tpl", []byte("###Block(x)\n###EndBlock(x)\n"))
+	assert.Equal(t, 2, len(applied))
+
+	findings, err := linttemplates.LintReader("t.tpl", strings.NewReader(string(fixed)))
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(findings))
+	assert.Assert(t, strings.Contains(findings[0].Message, "no file.Block call"))
+}

--- a/internal/lint/templates/templates.go
+++ b/internal/lint/templates/templates.go
@@ -255,7 +255,7 @@ func classify(text string) token {
 	if m := codegen.BlockPattern.FindStringSubmatch(text); len(m) == 4 {
 		// m[2]=command; m[3]=name.
 		switch m[2] {
-		case "Block":
+		case codegen.StartStatement:
 			return token{start: true, name: m[3], legacy: true}
 		case codegen.EndStatement:
 			return token{end: true, legacy: true}


### PR DESCRIPTION
## What this PR does / why we need it

Adds `--fix` to `stencil lint templates`, mechanically migrating deprecated legacy block syntax (`###Block`/`###EndBlock`, in any of its three comment styles) to the v2 `<<Stencil::Block>>` form and re-linting so only genuinely unfixable findings remain. It also unifies the aggregate `stencil lint --fix`, which previously fixed the manifest only and silently skipped templates; it now fixes and re-lints both in one pass.

The fixer only touches syntax it's certain is safe: a dynamic-name legacy block (e.g. `###Block({{ $b }})`) is left alone because the linter can't even recognize it as a block today, and structural problems (missing `file.Block`, dangling or nested blocks) are never auto-fixed, only re-reported after the syntax rewrite.

## Jira ID

[DT-4828]

## Notes for your reviewers

`fixAndRelint` for the manifest subcommand now delegates to a new `fixManifestBytes` helper that returns findings instead of deciding pass/fail itself, so the aggregate path can combine manifest and template findings into one exit-code decision — worth a look if you're touching that code path again.

Verified manually against a built binary and a module using all three legacy comment styles plus a fixable manifest deprecation: stdin fix, in-place file fix, and the unified aggregate fix all produced correct output and were idempotent on a second run.

[DT-4828]: https://outreach-io.atlassian.net/browse/DT-4828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ