### PR TITLE
feat(lint): add suggestions to fix warnings/errors

### DIFF
--- a/internal/lint/manifest/.snapshots/TestValidate-deprecated_argument_fields
+++ b/internal/lint/manifest/.snapshots/TestValidate-deprecated_argument_fields
@@ -1,3 +1,3 @@
-warning  arguments.x.type:4    argument field 'type' is deprecated; use 'schema'
-warning  arguments.x.values:5  argument field 'values' is deprecated; use 'schema'
+warning  arguments.x.type:4    argument field 'type' is deprecated; use 'schema.type' instead (run 'stencil lint --fix' to migrate it automatically)
+warning  arguments.x.values:5  argument field 'values' is deprecated; use 'schema.enum' instead (run 'stencil lint --fix' to migrate it automatically)
 

--- a/internal/lint/manifest/.snapshots/TestValidate-deprecated_bool_form_is_a_strict-decode_error
+++ b/internal/lint/manifest/.snapshots/TestValidate-deprecated_bool_form_is_a_strict-decode_error
@@ -1,2 +1,2 @@
-error  manifest.yaml:0  invalid manifest: deprecation message must be a string, got !!bool ("true"); the bool form is not supported — supply a migration message
+error  manifest.yaml:0  invalid manifest: deprecation message must be a string, got !!bool ("true"); the bool form is not supported — supply a migration message; check the YAML syntax and field types near this location
 

--- a/internal/lint/manifest/.snapshots/TestValidate-deprecated_module_fields
+++ b/internal/lint/manifest/.snapshots/TestValidate-deprecated_module_fields
@@ -1,3 +1,3 @@
-warning  modules.github.com/getoutreach/stencil-base.url:4         module field 'url' is deprecated; use 'name'
-warning  modules.github.com/getoutreach/stencil-base.prerelease:5  module field 'prerelease' is deprecated; use 'channel: rc'
+warning  modules.github.com/getoutreach/stencil-base.url:4         module field 'url' is deprecated; replace it with 'name' set to the module's import path, then remove 'url' (not migrated automatically by --fix)
+warning  modules.github.com/getoutreach/stencil-base.prerelease:5  module field 'prerelease' is deprecated; use 'channel: rc' instead (run 'stencil lint --fix' to migrate it automatically)
 

--- a/internal/lint/manifest/.snapshots/TestValidate-empty_input
+++ b/internal/lint/manifest/.snapshots/TestValidate-empty_input
@@ -1,2 +1,2 @@
-error  manifest.yaml:0  manifest is empty
+error  manifest.yaml:0  manifest is empty; add at least a 'name' field (e.g. 'name: github.com/getoutreach/stencil-base')
 

--- a/internal/lint/manifest/.snapshots/TestValidate-errors_and_warnings_combined
+++ b/internal/lint/manifest/.snapshots/TestValidate-errors_and_warnings_combined
@@ -1,3 +1,3 @@
 error    type:2              unknown type "bogus" (valid: extension, templates)
-warning  arguments.x.type:5  argument field 'type' is deprecated; use 'schema'
+warning  arguments.x.type:5  argument field 'type' is deprecated; use 'schema.type' instead (run 'stencil lint --fix' to migrate it automatically)
 

--- a/internal/lint/manifest/.snapshots/TestValidate-invalid_stencilVersion
+++ b/internal/lint/manifest/.snapshots/TestValidate-invalid_stencilVersion
@@ -1,2 +1,2 @@
-error  stencilVersion:2  invalid stencilVersion constraint: improper constraint: "not-a-constraint"
+error  stencilVersion:2  invalid stencilVersion constraint: improper constraint: "not-a-constraint"; use a valid semver constraint (e.g. '>=1.0.0')
 

--- a/internal/lint/manifest/.snapshots/TestValidate-missing_name
+++ b/internal/lint/manifest/.snapshots/TestValidate-missing_name
@@ -1,2 +1,2 @@
-error  name:0  name is required
+error  name:0  name is required; add a 'name' field set to the module's import path (e.g. 'name: github.com/getoutreach/stencil-base')
 

--- a/internal/lint/manifest/.snapshots/TestValidate-required_with_default
+++ b/internal/lint/manifest/.snapshots/TestValidate-required_with_default
@@ -1,2 +1,2 @@
-error  arguments.x:3  required argument must not set a default
+error  arguments.x:3  required argument must not set a default; remove 'required: true' or remove 'default'
 

--- a/internal/lint/manifest/manifest.go
+++ b/internal/lint/manifest/manifest.go
@@ -100,9 +100,11 @@ func Validate(res *LoadResult) []lint.Finding {
 	// Check 1: strict decode succeeded.
 	if strictErr != nil {
 		if errors.Is(strictErr, io.EOF) {
-			f.Errorf("manifest.yaml", "manifest is empty")
+			f.Errorf("manifest.yaml", "manifest is empty; add at least a 'name' field "+
+				"(e.g. 'name: github.com/getoutreach/stencil-base')")
 		} else {
-			f.Errorf("manifest.yaml", "invalid manifest: %v", strictErr)
+			f.Errorf("manifest.yaml", "invalid manifest: %v; check the YAML syntax and "+
+				"field types near this location", strictErr)
 		}
 	}
 
@@ -138,7 +140,8 @@ func checkName(f *lint.Findings, mf *configuration.TemplateRepositoryManifest, s
 		if strictErr != nil && strings.Contains(strictErr.Error(), "name") {
 			return
 		}
-		f.Errorf("name", "name is required")
+		f.Errorf("name", "name is required; add a 'name' field set to the module's "+
+			"import path (e.g. 'name: github.com/getoutreach/stencil-base')")
 	}
 }
 
@@ -157,7 +160,8 @@ func checkStencilVersion(f *lint.Findings, mf *configuration.TemplateRepositoryM
 		return
 	}
 	if _, err := semver.NewConstraint(mf.StencilVersion); err != nil {
-		f.Errorf("stencilVersion", "invalid stencilVersion constraint: %v", err)
+		f.Errorf("stencilVersion", "invalid stencilVersion constraint: %v; "+
+			"use a valid semver constraint (e.g. '>=1.0.0')", err)
 	}
 }
 
@@ -185,15 +189,18 @@ func checkArguments(f *lint.Findings, mf *configuration.TemplateRepositoryManife
 			}
 		}
 		if arg.Required && arg.Default != nil {
-			f.Errorf("arguments."+name, "required argument must not set a default")
+			f.Errorf("arguments."+name, "required argument must not set a default; "+
+				"remove 'required: true' or remove 'default'")
 		}
 		//nolint:staticcheck // Why: the linter intentionally reads deprecated fields to warn about their use.
 		if arg.Type != "" {
-			f.Warnf("arguments."+name+".type", "argument field 'type' is deprecated; use 'schema'")
+			f.Warnf("arguments."+name+".type", "argument field 'type' is deprecated; use 'schema.type' "+
+				"instead (run 'stencil lint --fix' to migrate it automatically)")
 		}
 		//nolint:staticcheck // Why: the linter intentionally reads deprecated fields to warn about their use.
 		if len(arg.Values) > 0 {
-			f.Warnf("arguments."+name+".values", "argument field 'values' is deprecated; use 'schema'")
+			f.Warnf("arguments."+name+".values", "argument field 'values' is deprecated; use 'schema.enum' "+
+				"instead (run 'stencil lint --fix' to migrate it automatically)")
 		}
 		if arg.Deprecated != "" {
 			f.Infof("arguments."+name, "argument %q is deprecated: %s", name, arg.Deprecated)
@@ -207,11 +214,13 @@ func checkModules(f *lint.Findings, mf *configuration.TemplateRepositoryManifest
 		path := modulePath(m, i)
 		//nolint:staticcheck // Why: the linter intentionally reads deprecated fields to warn about their use.
 		if m.URL != "" {
-			f.Warnf(path+".url", "module field 'url' is deprecated; use 'name'")
+			f.Warnf(path+".url", "module field 'url' is deprecated; replace it with 'name' set to the "+
+				"module's import path, then remove 'url' (not migrated automatically by --fix)")
 		}
 		//nolint:staticcheck // Why: the linter intentionally reads deprecated fields to warn about their use.
 		if m.Prerelease {
-			f.Warnf(path+".prerelease", "module field 'prerelease' is deprecated; use 'channel: rc'")
+			f.Warnf(path+".prerelease", "module field 'prerelease' is deprecated; use 'channel: rc' "+
+				"instead (run 'stencil lint --fix' to migrate it automatically)")
 		}
 	}
 }

--- a/internal/lint/templates/.snapshots/TestLint-legacy_block_missing_file.Block
+++ b/internal/lint/templates/.snapshots/TestLint-legacy_block_missing_file.Block
@@ -1,3 +1,3 @@
-warning  t.tpl:1  block "x" uses deprecated block syntax; please migrate to <<Stencil::Block(x)>> ... <</Stencil::Block>>.
+warning  t.tpl:1  block "x" uses deprecated block syntax; please migrate to <<Stencil::Block(x)>> ... <</Stencil::Block>> (run 'stencil lint templates --fix' to migrate it automatically).
 error    t.tpl:1  block "x" has no file.Block call; user edits inside this block are silently discarded on the next render. Add {{ file.Block "x" }} inside the block.
 

--- a/internal/lint/templates/.snapshots/TestLint-legacy_block_with_file.Block
+++ b/internal/lint/templates/.snapshots/TestLint-legacy_block_with_file.Block
@@ -1,2 +1,2 @@
-warning  t.tpl:1  block "x" uses deprecated block syntax; please migrate to <<Stencil::Block(x)>> ... <</Stencil::Block>>.
+warning  t.tpl:1  block "x" uses deprecated block syntax; please migrate to <<Stencil::Block(x)>> ... <</Stencil::Block>> (run 'stencil lint templates --fix' to migrate it automatically).
 

--- a/internal/lint/templates/templates.go
+++ b/internal/lint/templates/templates.go
@@ -150,9 +150,15 @@ func scan(name string, r io.Reader, f *lint.Findings) error {
 				// using deprecated-but-valid legacy blocks will now exit non-zero.
 				// This is the deliberate deprecation signal; do not downgrade
 				// severity or gate it.
+				//
+				// This is always mechanically fixable: classify() only sets
+				// tok.legacy for a literal (non-dynamic) name, which is exactly what
+				// fix.go's FixBytes migrates, so the --fix pointer below never
+				// overpromises.
 				addf(f, name, line, lint.SeverityWarning,
 					"block %q uses deprecated block syntax; please migrate to "+
-						"<<Stencil::Block(%s)>> ... <</Stencil::Block>>.", tok.name, tok.name)
+						"<<Stencil::Block(%s)>> ... <</Stencil::Block>> "+
+						"(run 'stencil lint templates --fix' to migrate it automatically).", tok.name, tok.name)
 			}
 		case tok.end:
 			switch {


### PR DESCRIPTION
## What this PR does / why we need it

`stencil lint` reported problems without saying what to do about them. Findings now end with a concrete next step: ones `--fix` already resolves (argument `type`/`values`, module `prerelease`, and — since #499 — legacy `###Block` template syntax) point to `--fix`; ones it can't (missing `name`, invalid `stencilVersion`, `required`+`default` conflicts, deprecated module `url`, empty/malformed manifests) get the manual fix spelled out instead. Module `url` is called out as not auto-fixable, since there's no mechanical way to derive an import-path `name` from an arbitrary URL.

Third-party message text (the JSON-schema compiler's errors) and the block-misuse messages shared verbatim with the codegen runtime are left untouched, to avoid coupling stencil's tests to a dependency's wording or diverging from runtime error output.

## Jira ID

[DT-4828]

[DT-4828]: https://outreach-io.atlassian.net/browse/DT-4828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ