### PR TITLE
refactor(lint): extract shared `internal/lint/yamlfix` node primitives

### DIFF
--- a/internal/lint/manifest/fix.go
+++ b/internal/lint/manifest/fix.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"sort"
 
+	"github.com/getoutreach/stencil/internal/lint/yamlfix"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -19,69 +20,6 @@ import (
 type Applied struct {
 	Path    string
 	Message string
-}
-
-// findKey returns the index in m.Content of the key node named key, or -1.
-// m must be a MappingNode (Content is a flat [key, value, key, value, ...]).
-// This is the package's single even-index key walk; mappingChild builds on it.
-func findKey(m *yaml.Node, key string) int {
-	for i := 0; i+1 < len(m.Content); i += 2 {
-		if m.Content[i].Value == key {
-			return i
-		}
-	}
-	return -1
-}
-
-// removeKey deletes the key/value pair named key from mapping m in place and
-// returns the removed value node, or nil if key was absent. Surviving pairs
-// keep their relative order.
-func removeKey(m *yaml.Node, key string) *yaml.Node {
-	i := findKey(m, key)
-	if i < 0 {
-		return nil
-	}
-	val := m.Content[i+1]
-	m.Content = append(m.Content[:i], m.Content[i+2:]...)
-	return val
-}
-
-// ensureMapping returns the existing child mapping stored under key in m, or
-// appends a new empty MappingNode under key and returns it.
-func ensureMapping(m *yaml.Node, key string) *yaml.Node {
-	if i := findKey(m, key); i >= 0 {
-		return m.Content[i+1]
-	}
-	k := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
-	v := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
-	m.Content = append(m.Content, k, v)
-	return v
-}
-
-// setIfAbsent appends key: val to mapping m only when key is absent. It returns
-// true when it added the pair. The val node is used as-is (its Style and
-// comments are preserved).
-func setIfAbsent(m *yaml.Node, key string, val *yaml.Node) bool {
-	if findKey(m, key) >= 0 {
-		return false
-	}
-	k := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
-	m.Content = append(m.Content, k, val)
-	return true
-}
-
-// carryKeyComments copies the head and foot comments from src (the original
-// key node being migrated away) onto the key node named key in mapping m.
-// yaml.v3 stores a mapping entry's head/foot comments on its KEY node, so when
-// a migration synthesizes a new key it must carry these over or they are lost.
-// The line comment is preserved separately via the reused value node.
-func carryKeyComments(m *yaml.Node, key string, src *yaml.Node) {
-	i := findKey(m, key)
-	if i < 0 {
-		return
-	}
-	m.Content[i].HeadComment = src.HeadComment
-	m.Content[i].FootComment = src.FootComment
 }
 
 // scalarsEqual reports whether a and b are both scalar nodes with equal values.
@@ -121,10 +59,10 @@ func consolidateSchemaSiblings(arg, schema *yaml.Node, argName string, applied *
 		}
 	}
 	for _, key := range siblings {
-		srcKey := arg.Content[findKey(arg, key)]
-		val := removeKey(arg, key)
-		if setIfAbsent(schema, key, val) {
-			carryKeyComments(schema, key, srcKey)
+		srcKey := arg.Content[yamlfix.FindKey(arg, key)]
+		val := yamlfix.RemoveKey(arg, key)
+		if yamlfix.SetIfAbsent(schema, key, val) {
+			yamlfix.CarryKeyComments(schema, key, srcKey)
 			*applied = append(*applied, Applied{
 				Path:    "arguments." + argName + "." + key,
 				Message: "migrated schema keyword '" + key + "' into 'schema'",
@@ -138,7 +76,7 @@ func consolidateSchemaSiblings(arg, schema *yaml.Node, argName string, applied *
 // existing differing schema.type, and reuses the original value node (keeping
 // its comment and style).
 func fixArgType(argName string, arg *yaml.Node, applied *[]Applied) {
-	i := findKey(arg, "type")
+	i := yamlfix.FindKey(arg, "type")
 	if i < 0 {
 		return
 	}
@@ -146,14 +84,14 @@ func fixArgType(argName string, arg *yaml.Node, applied *[]Applied) {
 	if typeVal.Kind != yaml.ScalarNode {
 		return // non-scalar: leave for the linter
 	}
-	schema := ensureMapping(arg, "schema")
-	if si := findKey(schema, "type"); si >= 0 {
+	schema := yamlfix.EnsureMapping(arg, "schema")
+	if si := yamlfix.FindKey(schema, "type"); si >= 0 {
 		existing := schema.Content[si+1]
 		if !scalarsEqual(existing, typeVal) {
 			return // ambiguous: differing schema.type wins, change nothing
 		}
 		// Redundant: schema.type already equals the deprecated type.
-		removeKey(arg, "type")
+		yamlfix.RemoveKey(arg, "type")
 		*applied = append(*applied, Applied{
 			Path:    "arguments." + argName + ".type",
 			Message: "removed redundant 'type' (already set in schema.type)",
@@ -161,9 +99,9 @@ func fixArgType(argName string, arg *yaml.Node, applied *[]Applied) {
 		return
 	}
 	srcKey := arg.Content[i] // capture before removeKey (i still valid here)
-	removeKey(arg, "type")
-	setIfAbsent(schema, "type", typeVal)
-	carryKeyComments(schema, "type", srcKey)
+	yamlfix.RemoveKey(arg, "type")
+	yamlfix.SetIfAbsent(schema, "type", typeVal)
+	yamlfix.CarryKeyComments(schema, "type", srcKey)
 	*applied = append(*applied, Applied{
 		Path:    "arguments." + argName + ".type",
 		Message: "migrated 'type' into 'schema.type'",
@@ -177,7 +115,7 @@ func fixArgType(argName string, arg *yaml.Node, applied *[]Applied) {
 // `schema.enum: [...]`. Same conservative rules as fixArgType; the sequence
 // node is reused verbatim so its flow/block style is preserved.
 func fixArgValues(argName string, arg *yaml.Node, applied *[]Applied) {
-	i := findKey(arg, "values")
+	i := yamlfix.FindKey(arg, "values")
 	if i < 0 {
 		return
 	}
@@ -185,10 +123,10 @@ func fixArgValues(argName string, arg *yaml.Node, applied *[]Applied) {
 	if valuesVal.Kind != yaml.SequenceNode {
 		return
 	}
-	schema := ensureMapping(arg, "schema")
-	if findKey(schema, "enum") >= 0 {
+	schema := yamlfix.EnsureMapping(arg, "schema")
+	if yamlfix.FindKey(schema, "enum") >= 0 {
 		// schema.enum already present: drop the deprecated values, keep schema.
-		removeKey(arg, "values")
+		yamlfix.RemoveKey(arg, "values")
 		*applied = append(*applied, Applied{
 			Path:    "arguments." + argName + ".values",
 			Message: "removed redundant 'values' (schema.enum already set)",
@@ -196,9 +134,9 @@ func fixArgValues(argName string, arg *yaml.Node, applied *[]Applied) {
 		return
 	}
 	srcKey := arg.Content[i] // capture before removeKey
-	removeKey(arg, "values")
-	setIfAbsent(schema, "enum", valuesVal)
-	carryKeyComments(schema, "enum", srcKey)
+	yamlfix.RemoveKey(arg, "values")
+	yamlfix.SetIfAbsent(schema, "enum", valuesVal)
+	yamlfix.CarryKeyComments(schema, "enum", srcKey)
 	*applied = append(*applied, Applied{
 		Path:    "arguments." + argName + ".values",
 		Message: "migrated 'values' into 'schema.enum'",
@@ -210,7 +148,7 @@ func fixArgValues(argName string, arg *yaml.Node, applied *[]Applied) {
 // `channel` is preserved and `prerelease` is just dropped; a false value is
 // simply removed as a redundant default.
 func fixModulePrerelease(modPath string, mod *yaml.Node, applied *[]Applied) {
-	i := findKey(mod, "prerelease")
+	i := yamlfix.FindKey(mod, "prerelease")
 	if i < 0 {
 		return
 	}
@@ -221,10 +159,10 @@ func fixModulePrerelease(modPath string, mod *yaml.Node, applied *[]Applied) {
 	switch val.Value {
 	case "true":
 		srcKey := mod.Content[i] // capture before removeKey
-		removeKey(mod, "prerelease")
-		if setIfAbsent(mod, "channel",
+		yamlfix.RemoveKey(mod, "prerelease")
+		if yamlfix.SetIfAbsent(mod, "channel",
 			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "rc"}) {
-			carryKeyComments(mod, "channel", srcKey)
+			yamlfix.CarryKeyComments(mod, "channel", srcKey)
 			*applied = append(*applied, Applied{
 				Path:    modPath + ".prerelease",
 				Message: "migrated 'prerelease: true' to 'channel: rc'",
@@ -236,7 +174,7 @@ func fixModulePrerelease(modPath string, mod *yaml.Node, applied *[]Applied) {
 			})
 		}
 	case "false":
-		removeKey(mod, "prerelease")
+		yamlfix.RemoveKey(mod, "prerelease")
 		*applied = append(*applied, Applied{
 			Path:    modPath + ".prerelease",
 			Message: "removed redundant 'prerelease: false'",
@@ -268,7 +206,7 @@ func Fix(doc *yaml.Node) []Applied {
 // fixArguments applies argument migrations in sorted key order, skipping
 // arguments that set from: (whose other fields are ignored at render time).
 func fixArguments(root *yaml.Node, applied *[]Applied) {
-	ai := findKey(root, "arguments")
+	ai := yamlfix.FindKey(root, "arguments")
 	if ai < 0 {
 		return
 	}
@@ -285,11 +223,11 @@ func fixArguments(root *yaml.Node, applied *[]Applied) {
 	sort.Strings(names)
 
 	for _, name := range names {
-		arg := deref(args.Content[findKey(args, name)+1])
+		arg := yamlfix.Deref(args.Content[yamlfix.FindKey(args, name)+1])
 		if arg.Kind != yaml.MappingNode {
 			continue
 		}
-		if findKey(arg, "from") >= 0 {
+		if yamlfix.FindKey(arg, "from") >= 0 {
 			continue // from: arguments are skipped, matching checkArguments
 		}
 		fixArgType(name, arg, applied)
@@ -299,7 +237,7 @@ func fixArguments(root *yaml.Node, applied *[]Applied) {
 
 // fixModules applies module migrations in slice order.
 func fixModules(root *yaml.Node, applied *[]Applied) {
-	mi := findKey(root, "modules")
+	mi := yamlfix.FindKey(root, "modules")
 	if mi < 0 {
 		return
 	}
@@ -308,7 +246,7 @@ func fixModules(root *yaml.Node, applied *[]Applied) {
 		return
 	}
 	for i, raw := range modules.Content {
-		mod := deref(raw)
+		mod := yamlfix.Deref(raw)
 		if mod.Kind != yaml.MappingNode {
 			continue
 		}
@@ -320,7 +258,7 @@ func fixModules(root *yaml.Node, applied *[]Applied) {
 // delegating to the checker's shared moduleIDPath formatter.
 func moduleFixPath(mod *yaml.Node, i int) string {
 	name := ""
-	if ni := findKey(mod, "name"); ni >= 0 {
+	if ni := yamlfix.FindKey(mod, "name"); ni >= 0 {
 		name = mod.Content[ni+1].Value
 	}
 	return moduleIDPath(name, i)

--- a/internal/lint/manifest/fix_test.go
+++ b/internal/lint/manifest/fix_test.go
@@ -15,6 +15,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/getoutreach/stencil/internal/lint"
+	"github.com/getoutreach/stencil/internal/lint/yamlfix"
 	"github.com/getoutreach/stencil/pkg/configuration"
 )
 
@@ -27,60 +28,12 @@ func mappingFrom(t *testing.T, in string) *yaml.Node {
 	return doc.Content[0]
 }
 
-func TestFindKey(t *testing.T) {
-	m := mappingFrom(t, "a: 1\nb: 2\n")
-	assert.Equal(t, 0, findKey(m, "a"))
-	assert.Equal(t, 2, findKey(m, "b"))
-	assert.Equal(t, -1, findKey(m, "missing"))
-}
-
-func TestRemoveKeyInPlace(t *testing.T) {
-	m := mappingFrom(t, "a: 1\nb: 2\nc: 3\n")
-	val := removeKey(m, "b")
-	assert.Assert(t, val != nil)
-	assert.Equal(t, "2", val.Value)
-	// a and c remain, in order; b is gone.
-	assert.Equal(t, 0, findKey(m, "a"))
-	assert.Equal(t, -1, findKey(m, "b"))
-	assert.Equal(t, 2, findKey(m, "c"))
-}
-
-func TestRemoveKeyMissing(t *testing.T) {
-	m := mappingFrom(t, "a: 1\n")
-	assert.Assert(t, removeKey(m, "nope") == nil)
-	assert.Equal(t, 0, findKey(m, "a"))
-}
-
-func TestEnsureMappingExisting(t *testing.T) {
-	m := mappingFrom(t, "schema:\n  type: string\n")
-	s := ensureMapping(m, "schema")
-	assert.Equal(t, yaml.MappingNode, s.Kind)
-	assert.Equal(t, 0, findKey(s, "type"))
-}
-
-func TestEnsureMappingCreates(t *testing.T) {
-	m := mappingFrom(t, "name: x\n")
-	s := ensureMapping(m, "schema")
-	assert.Equal(t, yaml.MappingNode, s.Kind)
-	// schema appended last.
-	assert.Equal(t, 2, findKey(m, "schema"))
-}
-
-func TestSetIfAbsent(t *testing.T) {
-	m := mappingFrom(t, "a: 1\n")
-	v := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "rc"}
-	assert.Assert(t, setIfAbsent(m, "channel", v))
-	assert.Equal(t, 2, findKey(m, "channel"))
-	// Second call is a no-op.
-	assert.Assert(t, !setIfAbsent(m, "channel", v))
-}
-
 // argNode returns the value mapping for the single argument in
 // "arguments:\n  <name>:\n    ...". Helper for the per-argument fix tests.
 func argNode(t *testing.T, name, body string) *yaml.Node {
 	t.Helper()
 	m := mappingFrom(t, "arguments:\n  "+name+":\n"+body)
-	args := m.Content[findKey(m, "arguments")+1]
+	args := m.Content[yamlfix.FindKey(m, "arguments")+1]
 	return args.Content[1] // value of the first (only) argument
 }
 
@@ -89,9 +42,9 @@ func TestFixArgTypeMovesIntoSchema(t *testing.T) {
 	var applied []Applied
 	fixArgType("x", arg, &applied)
 
-	assert.Assert(t, findKey(arg, "type") == -1) // removed
-	schema := arg.Content[findKey(arg, "schema")+1]
-	ti := findKey(schema, "type")
+	assert.Assert(t, yamlfix.FindKey(arg, "type") == -1) // removed
+	schema := arg.Content[yamlfix.FindKey(arg, "schema")+1]
+	ti := yamlfix.FindKey(schema, "type")
 	assert.Assert(t, ti >= 0)
 	assert.Equal(t, "string", schema.Content[ti+1].Value)
 	assert.Equal(t, 1, len(applied))
@@ -104,9 +57,9 @@ func TestFixArgTypeRedundantWhenSchemaTypeEqual(t *testing.T) {
 	fixArgType("x", arg, &applied)
 
 	// Deprecated type dropped; existing schema.type kept.
-	assert.Assert(t, findKey(arg, "type") == -1)
-	schema := arg.Content[findKey(arg, "schema")+1]
-	assert.Equal(t, "string", schema.Content[findKey(schema, "type")+1].Value)
+	assert.Assert(t, yamlfix.FindKey(arg, "type") == -1)
+	schema := arg.Content[yamlfix.FindKey(arg, "schema")+1]
+	assert.Equal(t, "string", schema.Content[yamlfix.FindKey(schema, "type")+1].Value)
 	assert.Equal(t, 1, len(applied)) // still logged as a change (removed redundant)
 }
 
@@ -116,9 +69,9 @@ func TestFixArgTypeNoChangeWhenSchemaTypeDiffers(t *testing.T) {
 	fixArgType("x", arg, &applied)
 
 	// Ambiguous: leave both, change nothing.
-	assert.Assert(t, findKey(arg, "type") >= 0)
-	schema := arg.Content[findKey(arg, "schema")+1]
-	assert.Equal(t, "integer", schema.Content[findKey(schema, "type")+1].Value)
+	assert.Assert(t, yamlfix.FindKey(arg, "type") >= 0)
+	schema := arg.Content[yamlfix.FindKey(arg, "schema")+1]
+	assert.Equal(t, "integer", schema.Content[yamlfix.FindKey(schema, "type")+1].Value)
 	assert.Equal(t, 0, len(applied))
 }
 
@@ -127,9 +80,9 @@ func TestFixArgValuesMovesIntoSchemaEnum(t *testing.T) {
 	var applied []Applied
 	fixArgValues("x", arg, &applied)
 
-	assert.Assert(t, findKey(arg, "values") == -1)
-	schema := arg.Content[findKey(arg, "schema")+1]
-	enum := schema.Content[findKey(schema, "enum")+1]
+	assert.Assert(t, yamlfix.FindKey(arg, "values") == -1)
+	schema := arg.Content[yamlfix.FindKey(arg, "schema")+1]
+	enum := schema.Content[yamlfix.FindKey(schema, "enum")+1]
 	assert.Equal(t, yaml.SequenceNode, enum.Kind)
 	assert.Equal(t, 2, len(enum.Content))
 	assert.Equal(t, 1, len(applied))
@@ -140,8 +93,8 @@ func TestFixModulePrereleaseTrueAddsChannel(t *testing.T) {
 	var applied []Applied
 	fixModulePrerelease("modules.m", mod, &applied)
 
-	assert.Assert(t, findKey(mod, "prerelease") == -1)
-	assert.Equal(t, "rc", mod.Content[findKey(mod, "channel")+1].Value)
+	assert.Assert(t, yamlfix.FindKey(mod, "prerelease") == -1)
+	assert.Equal(t, "rc", mod.Content[yamlfix.FindKey(mod, "channel")+1].Value)
 	assert.Equal(t, 1, len(applied))
 }
 
@@ -150,8 +103,8 @@ func TestFixModulePrereleaseKeepsExistingChannel(t *testing.T) {
 	var applied []Applied
 	fixModulePrerelease("modules.m", mod, &applied)
 
-	assert.Assert(t, findKey(mod, "prerelease") == -1)
-	assert.Equal(t, "stable", mod.Content[findKey(mod, "channel")+1].Value) // not overwritten
+	assert.Assert(t, yamlfix.FindKey(mod, "prerelease") == -1)
+	assert.Equal(t, "stable", mod.Content[yamlfix.FindKey(mod, "channel")+1].Value) // not overwritten
 	assert.Equal(t, 1, len(applied))
 }
 
@@ -160,8 +113,8 @@ func TestFixModulePrereleaseFalseDropped(t *testing.T) {
 	var applied []Applied
 	fixModulePrerelease("modules.m", mod, &applied)
 
-	assert.Assert(t, findKey(mod, "prerelease") == -1)
-	assert.Assert(t, findKey(mod, "channel") == -1) // false is just removed
+	assert.Assert(t, yamlfix.FindKey(mod, "prerelease") == -1)
+	assert.Assert(t, yamlfix.FindKey(mod, "channel") == -1) // false is just removed
 	assert.Equal(t, 1, len(applied))
 }
 
@@ -287,9 +240,9 @@ func TestFixArgValuesRedundantEnumDropped(t *testing.T) {
 	var applied []Applied
 	fixArgValues("x", arg, &applied)
 
-	assert.Assert(t, findKey(arg, "values") == -1) // deprecated values removed
-	schema := arg.Content[findKey(arg, "schema")+1]
-	assert.Assert(t, findKey(schema, "enum") >= 0) // schema.enum kept
+	assert.Assert(t, yamlfix.FindKey(arg, "values") == -1) // deprecated values removed
+	schema := arg.Content[yamlfix.FindKey(arg, "schema")+1]
+	assert.Assert(t, yamlfix.FindKey(schema, "enum") >= 0) // schema.enum kept
 	assert.Equal(t, 1, len(applied))
 }
 
@@ -301,7 +254,7 @@ func TestFixConservativeSkips(t *testing.T) {
 		var applied []Applied
 		fixArgType("x", arg, &applied)
 
-		assert.Assert(t, findKey(arg, "type") >= 0) // left in place
+		assert.Assert(t, yamlfix.FindKey(arg, "type") >= 0) // left in place
 		assert.Equal(t, 0, len(applied))
 	})
 
@@ -310,7 +263,7 @@ func TestFixConservativeSkips(t *testing.T) {
 		var applied []Applied
 		fixModulePrerelease("modules.m", mod, &applied)
 
-		assert.Assert(t, findKey(mod, "prerelease") >= 0) // left in place
+		assert.Assert(t, yamlfix.FindKey(mod, "prerelease") >= 0) // left in place
 		assert.Equal(t, 0, len(applied))
 	})
 
@@ -319,7 +272,7 @@ func TestFixConservativeSkips(t *testing.T) {
 		var applied []Applied
 		fixModulePrerelease("modules.m", mod, &applied)
 
-		assert.Assert(t, findKey(mod, "prerelease") >= 0) // left in place
+		assert.Assert(t, yamlfix.FindKey(mod, "prerelease") >= 0) // left in place
 		assert.Equal(t, 0, len(applied))
 	})
 }
@@ -428,13 +381,13 @@ func TestFixConsolidatesUnknownSiblingIntoSchema(t *testing.T) {
 	// type and properties both live under schema now; description stays an arg field.
 	assert.Assert(t, strings.Contains(out, "schema:"), "got:\n%s", out)
 	doc := mappingFrom(t, out)
-	arg := doc.Content[findKey(doc, "arguments")+1].Content[1]
-	assert.Assert(t, findKey(arg, "type") == -1, "deprecated type must leave the arg, got:\n%s", out)
-	assert.Assert(t, findKey(arg, "properties") == -1, "stranded properties must leave the arg, got:\n%s", out)
-	assert.Assert(t, findKey(arg, "description") >= 0, "description must remain an arg field, got:\n%s", out)
-	schema := arg.Content[findKey(arg, "schema")+1]
-	assert.Assert(t, findKey(schema, "type") >= 0, "schema.type expected, got:\n%s", out)
-	assert.Assert(t, findKey(schema, "properties") >= 0, "schema.properties expected, got:\n%s", out)
+	arg := doc.Content[yamlfix.FindKey(doc, "arguments")+1].Content[1]
+	assert.Assert(t, yamlfix.FindKey(arg, "type") == -1, "deprecated type must leave the arg, got:\n%s", out)
+	assert.Assert(t, yamlfix.FindKey(arg, "properties") == -1, "stranded properties must leave the arg, got:\n%s", out)
+	assert.Assert(t, yamlfix.FindKey(arg, "description") >= 0, "description must remain an arg field, got:\n%s", out)
+	schema := arg.Content[yamlfix.FindKey(arg, "schema")+1]
+	assert.Assert(t, yamlfix.FindKey(schema, "type") >= 0, "schema.type expected, got:\n%s", out)
+	assert.Assert(t, yamlfix.FindKey(schema, "properties") >= 0, "schema.properties expected, got:\n%s", out)
 	assert.Assert(t, len(applied) >= 1)
 
 	// The whole point: the fixed manifest must strictly decode (no unknown-field error).
@@ -451,10 +404,10 @@ func TestFixConsolidatesArraySibling(t *testing.T) {
 		"      type: string\n"
 	out, _ := fixString(t, in)
 	doc := mappingFrom(t, out)
-	arg := doc.Content[findKey(doc, "arguments")+1].Content[1]
-	schema := arg.Content[findKey(arg, "schema")+1]
-	assert.Assert(t, findKey(schema, "items") >= 0, "items must move into schema, got:\n%s", out)
-	assert.Assert(t, findKey(arg, "items") == -1, "items must leave the arg, got:\n%s", out)
+	arg := doc.Content[yamlfix.FindKey(doc, "arguments")+1].Content[1]
+	schema := arg.Content[yamlfix.FindKey(arg, "schema")+1]
+	assert.Assert(t, yamlfix.FindKey(schema, "items") >= 0, "items must move into schema, got:\n%s", out)
+	assert.Assert(t, yamlfix.FindKey(arg, "items") == -1, "items must leave the arg, got:\n%s", out)
 	assert.Equal(t, 0, len(fixRelintErrors(t, in)))
 }
 
@@ -472,13 +425,13 @@ func TestFixSiblingConsolidationKeepsKnownArgFields(t *testing.T) {
 		"    description: keep me\n"
 	out, _ := fixString(t, in)
 	doc := mappingFrom(t, out)
-	arg := doc.Content[findKey(doc, "arguments")+1].Content[1]
+	arg := doc.Content[yamlfix.FindKey(doc, "arguments")+1].Content[1]
 	for _, k := range []string{"required", "default", "description"} {
-		assert.Assert(t, findKey(arg, k) >= 0, "%s must remain an arg field, got:\n%s", k, out)
+		assert.Assert(t, yamlfix.FindKey(arg, k) >= 0, "%s must remain an arg field, got:\n%s", k, out)
 	}
-	schema := arg.Content[findKey(arg, "schema")+1]
+	schema := arg.Content[yamlfix.FindKey(arg, "schema")+1]
 	for _, k := range []string{"required", "default", "description"} {
-		assert.Assert(t, findKey(schema, k) == -1, "%s must NOT be in schema, got:\n%s", k, out)
+		assert.Assert(t, yamlfix.FindKey(schema, k) == -1, "%s must NOT be in schema, got:\n%s", k, out)
 	}
 	assert.Equal(t, 0, len(fixRelintErrors(t, in)))
 }
@@ -495,8 +448,8 @@ func TestFixDoesNotConsolidateSiblingsWithoutDeprecatedType(t *testing.T) {
 		"        type: string\n"
 	out, applied := fixString(t, in)
 	doc := mappingFrom(t, out)
-	arg := doc.Content[findKey(doc, "arguments")+1].Content[1]
-	assert.Assert(t, findKey(arg, "properties") >= 0,
+	arg := doc.Content[yamlfix.FindKey(doc, "arguments")+1].Content[1]
+	assert.Assert(t, yamlfix.FindKey(arg, "properties") >= 0,
 		"properties must be left untouched when there is no deprecated type, got:\n%s", out)
 	assert.Equal(t, 0, len(applied))
 }
@@ -517,15 +470,15 @@ func TestFixDoesNotConsolidateSiblingsOnRedundantTypePath(t *testing.T) {
 		"        type: string\n"
 	out, applied := fixString(t, in)
 	doc := mappingFrom(t, out)
-	arg := doc.Content[findKey(doc, "arguments")+1].Content[1]
+	arg := doc.Content[yamlfix.FindKey(doc, "arguments")+1].Content[1]
 
 	// The redundant deprecated `type` is removed...
-	assert.Assert(t, findKey(arg, "type") == -1, "redundant deprecated type should be removed, got:\n%s", out)
+	assert.Assert(t, yamlfix.FindKey(arg, "type") == -1, "redundant deprecated type should be removed, got:\n%s", out)
 	// ...but `properties` is intentionally left orphaned (not swept into schema).
-	assert.Assert(t, findKey(arg, "properties") >= 0,
+	assert.Assert(t, yamlfix.FindKey(arg, "properties") >= 0,
 		"properties must stay orphaned on the redundant path, got:\n%s", out)
-	schema := arg.Content[findKey(arg, "schema")+1]
-	assert.Assert(t, findKey(schema, "properties") == -1,
+	schema := arg.Content[yamlfix.FindKey(arg, "schema")+1]
+	assert.Assert(t, yamlfix.FindKey(schema, "properties") == -1,
 		"properties must NOT be moved into schema on the redundant path, got:\n%s", out)
 	// Exactly one change: the redundant-type removal. No sibling migration entries.
 	assert.Equal(t, 1, len(applied))
@@ -551,14 +504,14 @@ func TestFixDoesNotConsolidateSiblingsOnDiffersTypePath(t *testing.T) {
 		"        type: string\n"
 	out, applied := fixString(t, in)
 	doc := mappingFrom(t, out)
-	arg := doc.Content[findKey(doc, "arguments")+1].Content[1]
+	arg := doc.Content[yamlfix.FindKey(doc, "arguments")+1].Content[1]
 
 	// Nothing moved: deprecated type, schema.type, and properties all stay put.
-	assert.Assert(t, findKey(arg, "type") >= 0, "deprecated type must stay on the differs path, got:\n%s", out)
-	assert.Assert(t, findKey(arg, "properties") >= 0, "properties must stay orphaned on the differs path, got:\n%s", out)
-	schema := arg.Content[findKey(arg, "schema")+1]
-	assert.Equal(t, "string", schema.Content[findKey(schema, "type")+1].Value)
-	assert.Assert(t, findKey(schema, "properties") == -1)
+	assert.Assert(t, yamlfix.FindKey(arg, "type") >= 0, "deprecated type must stay on the differs path, got:\n%s", out)
+	assert.Assert(t, yamlfix.FindKey(arg, "properties") >= 0, "properties must stay orphaned on the differs path, got:\n%s", out)
+	schema := arg.Content[yamlfix.FindKey(arg, "schema")+1]
+	assert.Equal(t, "string", schema.Content[yamlfix.FindKey(schema, "type")+1].Value)
+	assert.Assert(t, yamlfix.FindKey(schema, "properties") == -1)
 	assert.Equal(t, 0, len(applied))
 }
 

--- a/internal/lint/manifest/resolve.go
+++ b/internal/lint/manifest/resolve.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/getoutreach/stencil/internal/lint/yamlfix"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -27,12 +28,12 @@ func resolvePath(root *yaml.Node, path string) int {
 	if root == nil || path == "" {
 		return 0
 	}
-	top := deref(root)
+	top := yamlfix.Deref(root)
 	if top != nil && top.Kind == yaml.DocumentNode {
 		if len(top.Content) == 0 {
 			return 0
 		}
-		top = deref(top.Content[0])
+		top = yamlfix.Deref(top.Content[0])
 	}
 	if top == nil || top.Kind != yaml.MappingNode {
 		return 0
@@ -58,7 +59,7 @@ func resolvePath(root *yaml.Node, path string) int {
 			return 0
 		}
 		lastKeyLine = keyNode.Line
-		cur = deref(valNode)
+		cur = yamlfix.Deref(valNode)
 	}
 	return lastKeyLine
 }
@@ -76,7 +77,7 @@ var argumentFields = []string{"type", "values", "schema"}
 func resolveArgumentPath(top *yaml.Node, path string) int {
 	rest := strings.TrimPrefix(path, "arguments.")
 	_, argsVal := mappingChild(top, "arguments")
-	args := deref(argsVal)
+	args := yamlfix.Deref(argsVal)
 	if args == nil || args.Kind != yaml.MappingNode {
 		return 0
 	}
@@ -99,7 +100,7 @@ func resolveArgumentPath(top *yaml.Node, path string) int {
 	if field == "" {
 		return keyNode.Line
 	}
-	return fieldLineIn(deref(valNode), field)
+	return fieldLineIn(yamlfix.Deref(valNode), field)
 }
 
 // resolveModulePath resolves "modules[N].field" and "modules.NAME.field" within
@@ -109,7 +110,7 @@ func resolveArgumentPath(top *yaml.Node, path string) int {
 func resolveModulePath(top *yaml.Node, path string) int {
 	rest := strings.TrimPrefix(path, "modules")
 	_, seqVal := mappingChild(top, "modules")
-	seq := deref(seqVal)
+	seq := yamlfix.Deref(seqVal)
 	if seq == nil || seq.Kind != yaml.SequenceNode {
 		return 0
 	}
@@ -125,7 +126,7 @@ func resolveModulePath(top *yaml.Node, path string) int {
 			return 0
 		}
 		field := strings.TrimPrefix(rest[closeIdx+1:], ".")
-		return fieldLineIn(deref(seq.Content[idx]), field)
+		return fieldLineIn(yamlfix.Deref(seq.Content[idx]), field)
 	}
 
 	// Name form: modules.NAME.field — the LAST dot separates the (dotted) NAME
@@ -159,23 +160,14 @@ func fieldLineIn(m *yaml.Node, field string) int {
 	return keyNode.Line
 }
 
-// deref follows an alias node to its anchored target, returning other nodes
-// unchanged. A nil node returns nil.
-func deref(n *yaml.Node) *yaml.Node {
-	if n != nil && n.Kind == yaml.AliasNode && n.Alias != nil {
-		return n.Alias
-	}
-	return n
-}
-
 // mappingChild finds the key/value pair in a mapping node whose key scalar
 // equals key. Returns (nil, nil) if not found or m is not a mapping. Shares the
-// even-index key walk with findKey in fix.go.
+// even-index key walk with yamlfix.FindKey.
 func mappingChild(m *yaml.Node, key string) (keyNode, valNode *yaml.Node) {
 	if m == nil || m.Kind != yaml.MappingNode {
 		return nil, nil
 	}
-	if i := findKey(m, key); i >= 0 {
+	if i := yamlfix.FindKey(m, key); i >= 0 {
 		return m.Content[i], m.Content[i+1]
 	}
 	return nil, nil
@@ -189,7 +181,7 @@ func sequenceItemByName(seq *yaml.Node, name string) (item *yaml.Node, nameLine 
 		return nil, 0
 	}
 	for _, raw := range seq.Content {
-		it := deref(raw)
+		it := yamlfix.Deref(raw)
 		keyNode, valNode := mappingChild(it, "name")
 		if keyNode != nil && valNode != nil && valNode.Value == name {
 			return it, keyNode.Line

--- a/internal/lint/yamlfix/yamlfix.go
+++ b/internal/lint/yamlfix/yamlfix.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Shared, generic yaml.Node DOM primitives used by the Stencil
+// lint fixers and line resolvers. These are domain-agnostic mapping/alias
+// helpers; manifest- or project-specific logic lives in its own package.
+
+// Package yamlfix provides generic yaml.Node DOM primitives shared by the
+// Stencil lint packages (manifest and project-manifest fixers, line resolvers).
+package yamlfix
+
+import "go.yaml.in/yaml/v3"
+
+// FindKey returns the index in m.Content of the key node named key, or -1.
+// m must be a MappingNode (Content is a flat [key, value, key, value, ...]).
+func FindKey(m *yaml.Node, key string) int {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return i
+		}
+	}
+	return -1
+}
+
+// RemoveKey deletes the key/value pair named key from mapping m in place and
+// returns the removed value node, or nil if key was absent. Surviving pairs
+// keep their relative order.
+func RemoveKey(m *yaml.Node, key string) *yaml.Node {
+	i := FindKey(m, key)
+	if i < 0 {
+		return nil
+	}
+	val := m.Content[i+1]
+	m.Content = append(m.Content[:i], m.Content[i+2:]...)
+	return val
+}
+
+// EnsureMapping returns the existing child mapping stored under key in m, or
+// appends a new empty MappingNode under key and returns it.
+func EnsureMapping(m *yaml.Node, key string) *yaml.Node {
+	if i := FindKey(m, key); i >= 0 {
+		return m.Content[i+1]
+	}
+	k := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+	v := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	m.Content = append(m.Content, k, v)
+	return v
+}
+
+// SetIfAbsent appends key: val to mapping m only when key is absent. It returns
+// true when it added the pair. The val node is used as-is (its Style and
+// comments are preserved).
+func SetIfAbsent(m *yaml.Node, key string, val *yaml.Node) bool {
+	if FindKey(m, key) >= 0 {
+		return false
+	}
+	k := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+	m.Content = append(m.Content, k, val)
+	return true
+}
+
+// CarryKeyComments copies the head and foot comments from src (the original
+// key node being migrated away) onto the key node named key in mapping m.
+// yaml.v3 stores a mapping entry's head/foot comments on its KEY node, so when
+// a migration synthesizes a new key it must carry these over or they are lost.
+func CarryKeyComments(m *yaml.Node, key string, src *yaml.Node) {
+	i := FindKey(m, key)
+	if i < 0 {
+		return
+	}
+	m.Content[i].HeadComment = src.HeadComment
+	m.Content[i].FootComment = src.FootComment
+}
+
+// Deref follows an alias node to its anchored target, returning other nodes
+// unchanged. A nil node returns nil.
+func Deref(n *yaml.Node) *yaml.Node {
+	if n != nil && n.Kind == yaml.AliasNode && n.Alias != nil {
+		return n.Alias
+	}
+	return n
+}

--- a/internal/lint/yamlfix/yamlfix.go
+++ b/internal/lint/yamlfix/yamlfix.go
@@ -1,11 +1,12 @@
 // Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
 
 // Description: Shared, generic yaml.Node DOM primitives used by the Stencil
-// lint fixers and line resolvers. These are domain-agnostic mapping/alias
-// helpers; manifest- or project-specific logic lives in its own package.
+// manifest lint fixers and line resolvers. These are domain-agnostic
+// mapping/alias helpers; manifest- or project-specific logic lives in its own
+// package.
 
 // Package yamlfix provides generic yaml.Node DOM primitives shared by the
-// Stencil lint packages (manifest and project-manifest fixers, line resolvers).
+// Stencil manifest lint fixers and line resolvers.
 package yamlfix
 
 import "go.yaml.in/yaml/v3"

--- a/internal/lint/yamlfix/yamlfix_test.go
+++ b/internal/lint/yamlfix/yamlfix_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Tests for the shared yaml.Node primitives.
+
+package yamlfix_test
+
+import (
+	"testing"
+
+	"go.yaml.in/yaml/v3"
+	"gotest.tools/v3/assert"
+
+	"github.com/getoutreach/stencil/internal/lint/yamlfix"
+)
+
+// mappingFrom decodes a YAML mapping document and returns its root mapping node.
+func mappingFrom(t *testing.T, in string) *yaml.Node {
+	t.Helper()
+	var doc yaml.Node
+	assert.NilError(t, yaml.Unmarshal([]byte(in), &doc))
+	assert.Assert(t, len(doc.Content) == 1)
+	return doc.Content[0]
+}
+
+func TestFindKey(t *testing.T) {
+	m := mappingFrom(t, "a: 1\nb: 2\n")
+	assert.Equal(t, 0, yamlfix.FindKey(m, "a"))
+	assert.Equal(t, 2, yamlfix.FindKey(m, "b"))
+	assert.Equal(t, -1, yamlfix.FindKey(m, "missing"))
+}
+
+func TestRemoveKeyInPlace(t *testing.T) {
+	m := mappingFrom(t, "a: 1\nb: 2\nc: 3\n")
+	val := yamlfix.RemoveKey(m, "b")
+	assert.Assert(t, val != nil)
+	assert.Equal(t, "2", val.Value)
+	assert.Equal(t, -1, yamlfix.FindKey(m, "b"))
+	assert.Equal(t, 0, yamlfix.FindKey(m, "a"))
+	assert.Equal(t, 2, yamlfix.FindKey(m, "c"))
+}
+
+func TestRemoveKeyMissing(t *testing.T) {
+	m := mappingFrom(t, "a: 1\n")
+	assert.Assert(t, yamlfix.RemoveKey(m, "nope") == nil)
+}
+
+func TestEnsureMappingExisting(t *testing.T) {
+	m := mappingFrom(t, "schema:\n  type: string\n")
+	got := yamlfix.EnsureMapping(m, "schema")
+	assert.Assert(t, got.Kind == yaml.MappingNode)
+	assert.Assert(t, yamlfix.FindKey(got, "type") >= 0)
+}
+
+func TestEnsureMappingCreates(t *testing.T) {
+	m := mappingFrom(t, "name: x\n")
+	got := yamlfix.EnsureMapping(m, "schema")
+	assert.Assert(t, got.Kind == yaml.MappingNode)
+	assert.Equal(t, 0, len(got.Content))
+	assert.Assert(t, yamlfix.FindKey(m, "schema") >= 0)
+}
+
+func TestSetIfAbsent(t *testing.T) {
+	m := mappingFrom(t, "a: 1\n")
+	added := yamlfix.SetIfAbsent(m, "b",
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "2"})
+	assert.Equal(t, true, added)
+	assert.Assert(t, yamlfix.FindKey(m, "b") >= 0)
+
+	again := yamlfix.SetIfAbsent(m, "b",
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "3"})
+	assert.Equal(t, false, again)
+}
+
+func TestDerefFollowsAlias(t *testing.T) {
+	// An anchored mapping referenced by an alias resolves to its target.
+	doc := mappingFrom(t, "a: &anchor {k: v}\nb: *anchor\n")
+	// b's value is an alias node; deref returns the anchored mapping.
+	bIdx := yamlfix.FindKey(doc, "b")
+	alias := doc.Content[bIdx+1]
+	assert.Equal(t, yaml.AliasNode, alias.Kind)
+	target := yamlfix.Deref(alias)
+	assert.Equal(t, yaml.MappingNode, target.Kind)
+}
+
+func TestDerefNonAliasUnchanged(t *testing.T) {
+	n := &yaml.Node{Kind: yaml.ScalarNode, Value: "x"}
+	assert.Equal(t, n, yamlfix.Deref(n))
+	assert.Assert(t, yamlfix.Deref(nil) == nil)
+}
+
+func TestCarryKeyComments(t *testing.T) {
+	m := mappingFrom(t, "dst: 1\n")
+	src := &yaml.Node{Kind: yaml.ScalarNode, Value: "src",
+		HeadComment: "# head", FootComment: "# foot"}
+	yamlfix.CarryKeyComments(m, "dst", src)
+	i := yamlfix.FindKey(m, "dst")
+	assert.Equal(t, "# head", m.Content[i].HeadComment)
+	assert.Equal(t, "# foot", m.Content[i].FootComment)
+}

--- a/internal/lint/yamlfix/yamlfix_test.go
+++ b/internal/lint/yamlfix/yamlfix_test.go
@@ -42,6 +42,7 @@ func TestRemoveKeyInPlace(t *testing.T) {
 func TestRemoveKeyMissing(t *testing.T) {
 	m := mappingFrom(t, "a: 1\n")
 	assert.Assert(t, yamlfix.RemoveKey(m, "nope") == nil)
+	assert.Equal(t, 0, yamlfix.FindKey(m, "a"))
 }
 
 func TestEnsureMappingExisting(t *testing.T) {


### PR DESCRIPTION
## What this PR does / why we need it

Moves the generic `yaml.Node` DOM helpers that the manifest fixer and line-resolver share into a new `internal/lint/yamlfix` package, and points `internal/lint/manifest` at them.

This is a behavior-preserving refactor with no user-facing change. It exists to prepare for an upcoming project-manifest (`service.yaml`) fixer that needs the same comment-preserving node helpers; keeping one copy avoids maintaining a second DOM editor in parallel. Manifest snapshot goldens are unchanged, which is the evidence that behavior did not move.

## Jira ID

[DT-5396](https://outreach-io.atlassian.net/browse/DT-5396)

## Notes for your reviewers

The package boundary is the main thing to sanity-check: only the domain-agnostic mapping/alias helpers move out. The argument- and path-specific logic (schema-sibling consolidation in the fixer, dotted-name resolution in the resolver) intentionally stays in `manifest`, since it is not reusable by a different manifest type.
[
`deepreview`](https://github.com/mechanai/deepreview) (quick) was run on this PR and only found very minor items (already fixed).

[DT-5396]: https://outreach-io.atlassian.net/browse/DT-5396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ