### PR TITLE
feat(lint): add offline `stencil lint project-manifest`

### DIFF
--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/getoutreach/stencil/internal/lint"
 	lintmanifest "github.com/getoutreach/stencil/internal/lint/manifest"
+	lintprojectmanifest "github.com/getoutreach/stencil/internal/lint/projectmanifest"
 	linttemplates "github.com/getoutreach/stencil/internal/lint/templates"
 )
 
@@ -48,7 +49,7 @@ func NewLintCommand() *cli.Command {
 		ArgsUsage:   "[dir]",
 		Description: "Validate a Stencil module's manifest and templates without resolving dependencies",
 		Flags:       []cli.Flag{warningsAsErrorsFlag(), fixFlag()},
-		Commands:    []*cli.Command{newLintModuleManifestCommand(), newLintTemplatesCommand()},
+		Commands:    []*cli.Command{newLintModuleManifestCommand(), newLintTemplatesCommand(), newLintProjectManifestCommand()},
 		Action:      runLintAggregate,
 	}
 }
@@ -412,6 +413,7 @@ func runLintAggregate(_ context.Context, c *cli.Command) error {
 	runners := []runner{
 		manifestRunner(filepath.Join(dir, "manifest.yaml")),
 		templateRunner(filepath.Join(dir, templatesDir)),
+		projectManifestRunner(filepath.Join(dir, "service.yaml")),
 	}
 
 	var all []lint.Finding
@@ -622,6 +624,126 @@ func logFindings(log logrus.FieldLogger, findings []lint.Finding) {
 // success line. name is the manifest identifier. Thin wrapper over failLint.
 func failManifest(log logrus.FieldLogger, name string, findings []lint.Finding, warningsAsErrors bool) error {
 	return failLint(log, fmt.Sprintf("manifest %q is", name), findings, warningsAsErrors)
+}
+
+// newLintProjectManifestCommand builds `lint project-manifest [path]` (offline).
+func newLintProjectManifestCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "project-manifest",
+		Usage:       "Validate a project's service.yaml without resolving dependencies",
+		ArgsUsage:   "[path]",
+		Description: "Validate a single project manifest (service.yaml; defaults to ./service.yaml). Use '-' to read from stdin.",
+		Flags:       []cli.Flag{warningsAsErrorsFlag()},
+		Action:      runLintProjectManifest,
+	}
+}
+
+// runLintProjectManifest is the `lint project-manifest [path]` action (offline).
+func runLintProjectManifest(_ context.Context, c *cli.Command) error {
+	if c.Args().Len() > 1 {
+		return errors.New("expected at most one argument, a path to service.yaml")
+	}
+	log := newLintLogger(c)
+
+	if c.Args().First() == "-" {
+		if readerIsTTY(c.Reader) {
+			return errors.New("'-' expects piped input, not an interactive terminal")
+		}
+		findings, err := runProjectManifestReader(log, stdinName, c.Reader)
+		if err != nil {
+			return errors.Wrap(err, "lint failed")
+		}
+		logFindings(log, findings)
+		return failProjectManifest(log, stdinName, findings, c.Bool("warnings-as-errors"))
+	}
+
+	path := "./service.yaml"
+	if c.Args().Len() == 1 {
+		path = c.Args().First()
+	}
+	r, closer, finding, err := resolveProjectManifestReader(path)
+	if err != nil {
+		return errors.Wrap(err, "lint failed")
+	}
+	if finding != nil {
+		logFindings(log, []lint.Finding{*finding})
+		return failProjectManifest(log, path, []lint.Finding{*finding}, c.Bool("warnings-as-errors"))
+	}
+	if closer != nil {
+		defer closer.Close()
+	}
+	findings, err := runProjectManifestReader(log, path, r)
+	if err != nil {
+		return errors.Wrap(err, "lint failed")
+	}
+	logFindings(log, findings)
+	return failProjectManifest(log, path, findings, c.Bool("warnings-as-errors"))
+}
+
+// projectManifestRunner returns a runner that lints the service.yaml at path.
+// A missing file is skipped (nil, nil) so the aggregate treats a module without
+// a service.yaml as "nothing to lint" — mirroring manifestRunner.
+func projectManifestRunner(path string) runner {
+	return func(log logrus.FieldLogger) ([]lint.Finding, error) {
+		r, closer, finding, err := resolveProjectManifestReader(path)
+		if err != nil {
+			return nil, err
+		}
+		if finding != nil {
+			return nil, nil // missing service.yaml: skip in aggregate
+		}
+		if closer != nil {
+			defer closer.Close()
+		}
+		return runProjectManifestReader(log, path, r)
+	}
+}
+
+// resolveProjectManifestReader resolves path to an io.Reader. If path is a
+// directory it appends "service.yaml". A missing file yields a "service manifest
+// file not found" finding (not an error). Mirrors resolveManifestReader.
+func resolveProjectManifestReader(path string) (io.Reader, io.Closer, *lint.Finding, error) {
+	path = filepath.Clean(path)
+	info, err := os.Stat(path)
+	if err == nil && info.IsDir() {
+		path = filepath.Join(path, "service.yaml")
+		_, err = os.Stat(path)
+	}
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil, &lint.Finding{
+				Severity: lint.SeverityError,
+				Path:     path,
+				Message:  fmt.Sprintf("service manifest file not found: %s", path),
+			}, nil
+		}
+		return nil, nil, nil, errors.Wrapf(err, "failed to stat %q", path)
+	}
+	fh, err := os.Open(path)
+	if err != nil {
+		return nil, nil, nil, errors.Wrapf(err, "failed to open %q", path)
+	}
+	return fh, fh, nil, nil
+}
+
+// runProjectManifestReader loads + validates one service.yaml from r. It does
+// not log; the caller logs once. name is used in the multi-doc warning.
+func runProjectManifestReader(log logrus.FieldLogger, name string, r io.Reader) ([]lint.Finding, error) {
+	res, err := lintprojectmanifest.Load(r)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read service manifest %q", name)
+	}
+	findings := lintprojectmanifest.Validate(res)
+	if res.MultiDoc {
+		log.WithField("path", name).Warn("additional YAML documents after the first are ignored")
+	}
+	return findings, nil
+}
+
+// failProjectManifest applies the warnings-as-errors policy and logs the success
+// line. Thin wrapper over failLint.
+func failProjectManifest(log logrus.FieldLogger, name string, findings []lint.Finding, warningsAsErrors bool) error {
+	return failLint(log, fmt.Sprintf("service manifest %q is", name), findings, warningsAsErrors)
 }
 
 // logApplied logs one info line per fix the fixer applied.

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -551,16 +551,16 @@ func resolveManifestPath(path string) (resolved string, finding *lint.Finding, e
 	return path, nil, nil
 }
 
-// resolveManifestReader resolves path to an io.Reader. If path is a directory,
-// it appends "manifest.yaml". A missing file yields a "manifest file not found"
-// finding (not an error). The returned io.Closer (when non-nil) must be closed
-// by the caller. A non-nil error is an unexpected I/O failure.
-func resolveManifestReader(path string) (io.Reader, io.Closer, *lint.Finding, error) {
+// resolveReader resolves path to an io.Reader. If path is a directory, it
+// appends defaultFile. A missing file yields a "<kind> file not found" finding
+// (not an error). The returned io.Closer (when non-nil) must be closed by the
+// caller. A non-nil error is an unexpected I/O failure.
+func resolveReader(path, defaultFile, kind string) (io.Reader, io.Closer, *lint.Finding, error) {
 	path = filepath.Clean(path)
 	info, err := os.Stat(path)
 	if err == nil && info.IsDir() {
-		// A directory: lint its manifest.yaml (mirrors `lint [dir]`).
-		path = filepath.Join(path, "manifest.yaml")
+		// A directory: lint its default file (mirrors `lint [dir]`).
+		path = filepath.Join(path, defaultFile)
 		_, err = os.Stat(path)
 	}
 	if err != nil {
@@ -568,7 +568,7 @@ func resolveManifestReader(path string) (io.Reader, io.Closer, *lint.Finding, er
 			return nil, nil, &lint.Finding{
 				Severity: lint.SeverityError,
 				Path:     path,
-				Message:  fmt.Sprintf("manifest file not found: %s", path),
+				Message:  fmt.Sprintf("%s file not found: %s", kind, path),
 			}, nil
 		}
 		return nil, nil, nil, errors.Wrapf(err, "failed to stat %q", path)
@@ -579,6 +579,12 @@ func resolveManifestReader(path string) (io.Reader, io.Closer, *lint.Finding, er
 		return nil, nil, nil, errors.Wrapf(err, "failed to open %q", path)
 	}
 	return fh, fh, nil, nil
+}
+
+// resolveManifestReader resolves path to a manifest.yaml reader, appending
+// "manifest.yaml" for a directory. See resolveReader.
+func resolveManifestReader(path string) (io.Reader, io.Closer, *lint.Finding, error) {
+	return resolveReader(path, "manifest.yaml", "manifest")
 }
 
 // runManifestReader loads + validates one manifest from r and returns its
@@ -699,31 +705,10 @@ func projectManifestRunner(path string) runner {
 	}
 }
 
-// resolveProjectManifestReader resolves path to an io.Reader. If path is a
-// directory it appends "service.yaml". A missing file yields a "service manifest
-// file not found" finding (not an error). Mirrors resolveManifestReader.
+// resolveProjectManifestReader resolves path to a service.yaml reader, appending
+// "service.yaml" for a directory. See resolveReader.
 func resolveProjectManifestReader(path string) (io.Reader, io.Closer, *lint.Finding, error) {
-	path = filepath.Clean(path)
-	info, err := os.Stat(path)
-	if err == nil && info.IsDir() {
-		path = filepath.Join(path, "service.yaml")
-		_, err = os.Stat(path)
-	}
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil, &lint.Finding{
-				Severity: lint.SeverityError,
-				Path:     path,
-				Message:  fmt.Sprintf("service manifest file not found: %s", path),
-			}, nil
-		}
-		return nil, nil, nil, errors.Wrapf(err, "failed to stat %q", path)
-	}
-	fh, err := os.Open(path)
-	if err != nil {
-		return nil, nil, nil, errors.Wrapf(err, "failed to open %q", path)
-	}
-	return fh, fh, nil, nil
+	return resolveReader(path, "service.yaml", "service manifest")
 }
 
 // runProjectManifestReader loads + validates one service.yaml from r. It does

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -876,3 +876,25 @@ func TestProjectManifestTooManyArgs(t *testing.T) {
 	err := runProjectManifest(t, []string{"a", "b"}, nil, nil)
 	assert.Assert(t, err != nil)
 }
+
+// TestAggregateLintsServiceYaml proves the aggregate `lint <dir>` also lints a
+// present service.yaml: an invalid project manifest surfaces as a run failure.
+func TestAggregateLintsServiceYaml(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "service.yaml"),
+		[]byte("name: Bad Name\n"), 0o600))
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	err := root.Run(context.Background(), []string{"lint", dir})
+	assert.Assert(t, err != nil) // invalid service.yaml surfaces in the aggregate
+}
+
+// TestAggregateMissingServiceYamlIsNoOp proves the aggregate treats a missing
+// service.yaml (with no manifest or templates) as a no-op, not an error.
+func TestAggregateMissingServiceYamlIsNoOp(t *testing.T) {
+	dir := t.TempDir() // no service.yaml, no manifest.yaml, no templates
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	err := root.Run(context.Background(), []string{"lint", dir})
+	assert.NilError(t, err) // nothing to lint → success
+}

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -821,3 +821,58 @@ func TestRunLintAggregateFixTemplatesUnfixableFails(t *testing.T) {
 	assert.Assert(t, err != nil, "the surviving rule-1 error must fail the aggregate --fix run")
 	assert.Assert(t, strings.Contains(err.Error(), "lint failed"))
 }
+
+// runProjectManifest runs `lint project-manifest [args...]`, feeding stdin/stdout
+// on the subcommand. Mirrors runModuleManifest.
+func runProjectManifest(t *testing.T, args []string, stdin io.Reader, stdout io.Writer) error {
+	t.Helper()
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	sub := findSubcommand(root, "project-manifest")
+	assert.Assert(t, sub != nil, "project-manifest subcommand must exist")
+	if stdout != nil {
+		sub.Writer = stdout
+	}
+	if stdin != nil {
+		sub.Reader = stdin
+	}
+	full := append([]string{"lint", "project-manifest"}, args...)
+	return root.Run(context.Background(), full)
+}
+
+func TestNewLintCommandHasProjectManifestSubcommand(t *testing.T) {
+	cmd := NewLintCommand()
+	assert.Assert(t, findSubcommand(cmd, "project-manifest") != nil)
+}
+
+func TestProjectManifestValidFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "service.yaml")
+	assert.NilError(t, os.WriteFile(p, []byte("name: my-service\n"), 0o600))
+	err := runProjectManifest(t, []string{p}, nil, nil)
+	assert.NilError(t, err)
+}
+
+func TestProjectManifestInvalidFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "service.yaml")
+	assert.NilError(t, os.WriteFile(p, []byte("name: Bad Name\n"), 0o600))
+	err := runProjectManifest(t, []string{p}, nil, nil)
+	assert.Assert(t, err != nil) // invalid name → error finding → non-zero
+}
+
+func TestProjectManifestMissingFileIsError(t *testing.T) {
+	dir := t.TempDir()
+	err := runProjectManifest(t, []string{filepath.Join(dir, "service.yaml")}, nil, nil)
+	assert.Assert(t, err != nil) // subcommand: missing file is an error (unlike aggregate)
+}
+
+func TestProjectManifestStdin(t *testing.T) {
+	err := runProjectManifest(t, []string{"-"}, strings.NewReader("name: my-service\n"), io.Discard)
+	assert.NilError(t, err)
+}
+
+func TestProjectManifestTooManyArgs(t *testing.T) {
+	err := runProjectManifest(t, []string{"a", "b"}, nil, nil)
+	assert.Assert(t, err != nil)
+}

--- a/docs/content/en/commands/stencil_lint.md
+++ b/docs/content/en/commands/stencil_lint.md
@@ -21,8 +21,9 @@ DESCRIPTION:
    Validate a Stencil module's manifest and templates without resolving dependencies
 
 COMMANDS:
-   module-manifest  Validate a module's manifest.yaml without resolving dependencies
-   templates        Validate Stencil templates' block correctness without rendering
+   module-manifest   Validate a module's manifest.yaml without resolving dependencies
+   templates         Validate Stencil templates' block correctness without rendering
+   project-manifest  Validate a project's service.yaml without resolving dependencies
 
 OPTIONS:
    --warnings-as-errors  treat warnings as errors (fail on any finding)

--- a/docs/content/en/commands/stencil_lint_project-manifest.md
+++ b/docs/content/en/commands/stencil_lint_project-manifest.md
@@ -1,0 +1,37 @@
+---
+title: stencil lint project-manifest
+linktitle: stencil lint project-manifest
+description: Validate a single project manifest (service.yaml; defaults to ./service.yaml). Use '-' to read from stdin.
+categories: [commands]
+menu:
+  docs:
+    parent: "commands"
+---
+
+## stencil lint project-manifest
+
+```bash
+NAME:
+   stencil lint project-manifest - Validate a project's service.yaml without resolving dependencies
+
+USAGE:
+   stencil lint project-manifest [options] [path]
+
+DESCRIPTION:
+   Validate a single project manifest (service.yaml; defaults to ./service.yaml). Use '-' to read from stdin.
+
+OPTIONS:
+   --warnings-as-errors  treat warnings as errors (fail on any finding)
+   --help, -h            show help
+
+GLOBAL OPTIONS:
+   --concurrent-resolvers string, -c string  Number of concurrent resolvers to use when resolving modules (default: 5)
+   --dry-run, --dryrun                       Don't write files to disk
+   --frozen-lockfile                         Use versions from the lockfile instead of the latest
+   --use-prerelease                          Use prerelease versions of stencil modules
+   --allow-major-version-upgrades            Allow major version upgrades without confirmation
+   --debug, -d                               Enables debug logging for version resolution, template render, and other useful information
+   --skip-update                             Skips the updater check
+   --force-update-check                      Force checking for an update
+
+```

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-deprecated_prerelease
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-deprecated_prerelease
@@ -1,0 +1,2 @@
+warning  modules.github.com/x/y.prerelease:4  module field 'prerelease' is deprecated; use 'channel: rc' instead (run 'stencil lint --fix' to migrate it automatically)
+

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-deprecated_url
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-deprecated_url
@@ -1,0 +1,2 @@
+warning  modules.github.com/x/y.url:4  module field 'url' is deprecated; replace it with 'name' set to the module's import path, then remove 'url' (not migrated automatically by --fix)
+

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-empty
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-empty
@@ -1,0 +1,2 @@
+error  service.yaml:0  service.yaml is empty; add at least a 'name' field (e.g. 'name: my-service')
+

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-empty_versions_value
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-empty_versions_value
@@ -1,0 +1,2 @@
+warning  versions.golang:3  'versions.golang' is empty; set a value for 'golang' or remove the entry
+

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-invalid_name_leading_digit
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-invalid_name_leading_digit
@@ -1,2 +1,2 @@
-error  name:0  'name' "9lives" is invalid; use a value matching `^[_a-z][_a-z0-9-]*$` (e.g. 'my-service')
+error  name:1  'name' "9lives" is invalid; use a value matching `^[_a-z][_a-z0-9-]*$` (e.g. 'my-service')
 

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-invalid_name_leading_digit
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-invalid_name_leading_digit
@@ -1,0 +1,2 @@
+error  name:0  'name' "9lives" is invalid; use a value matching `^[_a-z][_a-z0-9-]*$` (e.g. 'my-service')
+

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-invalid_name_uppercase
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-invalid_name_uppercase
@@ -1,0 +1,2 @@
+error  name:0  'name' "MyService" is invalid; use a value matching `^[_a-z][_a-z0-9-]*$` (e.g. 'my-service')
+

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-invalid_name_uppercase
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-invalid_name_uppercase
@@ -1,2 +1,2 @@
-error  name:0  'name' "MyService" is invalid; use a value matching `^[_a-z][_a-z0-9-]*$` (e.g. 'my-service')
+error  name:1  'name' "MyService" is invalid; use a value matching `^[_a-z][_a-z0-9-]*$` (e.g. 'my-service')
 

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-missing_name
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-missing_name
@@ -1,0 +1,2 @@
+error  name:0  name is required; add a 'name' field matching `^[_a-z][_a-z0-9-]*$` (e.g. 'name: my-service')
+

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-module_invalid_version
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-module_invalid_version
@@ -1,0 +1,2 @@
+error  modules.github.com/x/y.version:4  invalid version constraint: improper constraint: "not-a-constraint"; use a valid semver constraint (e.g. '>=1.0.0')
+

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-module_missing_name
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-module_missing_name
@@ -1,0 +1,2 @@
+error  modules[0]:0  module name is required; set 'name' to the module's import path (e.g. 'github.com/getoutreach/stencil-base')
+

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-valid_minimal
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-valid_minimal
@@ -1,0 +1,2 @@
+(no findings)
+

--- a/internal/lint/projectmanifest/.snapshots/TestValidate-valid_versions_value
+++ b/internal/lint/projectmanifest/.snapshots/TestValidate-valid_versions_value
@@ -1,0 +1,2 @@
+(no findings)
+

--- a/internal/lint/projectmanifest/projectmanifest.go
+++ b/internal/lint/projectmanifest/projectmanifest.go
@@ -14,7 +14,10 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"sort"
+	"strconv"
 
+	semver "github.com/Masterminds/semver/v3"
 	"go.yaml.in/yaml/v3"
 
 	"github.com/getoutreach/stencil/internal/lint"
@@ -126,7 +129,58 @@ func checkName(f *lint.Findings, mf *configuration.ServiceManifest) {
 	}
 }
 
-// checkModules, checkVersions, resolvePath are implemented in Task 3.
-func checkModules(_ *lint.Findings, _ *configuration.ServiceManifest)  {}
-func checkVersions(_ *lint.Findings, _ *configuration.ServiceManifest) {}
-func resolvePath(_ *yaml.Node, _ string) int                           { return 0 }
+// checkModules implements F3 (name required), F4 (version constraint valid),
+// F5 (deprecated url), F6 (deprecated prerelease), in slice order.
+func checkModules(f *lint.Findings, mf *configuration.ServiceManifest) {
+	for i, m := range mf.Modules {
+		path := modulePath(m, i)
+		if m.Name == "" {
+			f.Errorf(path,
+				"module name is required; set 'name' to the module's import path "+
+					"(e.g. 'github.com/getoutreach/stencil-base')")
+		}
+		if m.Version != "" {
+			if _, err := semver.NewConstraint(m.Version); err != nil {
+				f.Errorf(path+".version",
+					"invalid version constraint: %v; use a valid semver constraint "+
+						"(e.g. '>=1.0.0')", err)
+			}
+		}
+		//nolint:staticcheck // Why: the linter intentionally reads deprecated fields to warn about their use.
+		if m.URL != "" {
+			f.Warnf(path+".url",
+				"module field 'url' is deprecated; replace it with 'name' set to the "+
+					"module's import path, then remove 'url' (not migrated automatically by --fix)")
+		}
+		//nolint:staticcheck // Why: the linter intentionally reads deprecated fields to warn about their use.
+		if m.Prerelease {
+			f.Warnf(path+".prerelease",
+				"module field 'prerelease' is deprecated; use 'channel: rc' instead "+
+					"(run 'stencil lint --fix' to migrate it automatically)")
+		}
+	}
+}
+
+// modulePath builds the finding path for module i, preferring its name.
+func modulePath(m *configuration.TemplateRepository, i int) string {
+	if m.Name != "" {
+		return "modules." + m.Name
+	}
+	return "modules[" + strconv.Itoa(i) + "]"
+}
+
+// checkVersions implements F7: a versions entry with an empty-string value.
+func checkVersions(f *lint.Findings, mf *configuration.ServiceManifest) {
+	names := make([]string, 0, len(mf.Versions))
+	for name := range mf.Versions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if mf.Versions[name] == "" {
+			f.Warnf("versions."+name,
+				"'versions.%s' is empty; set a value for '%s' or remove the entry",
+				name, name)
+		}
+	}
+}

--- a/internal/lint/projectmanifest/projectmanifest.go
+++ b/internal/lint/projectmanifest/projectmanifest.go
@@ -14,7 +14,8 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"sort"
+	"maps"
+	"slices"
 	"strconv"
 
 	semver "github.com/Masterminds/semver/v3"
@@ -171,11 +172,7 @@ func modulePath(m *configuration.TemplateRepository, i int) string {
 
 // checkVersions implements F7: a versions entry with an empty-string value.
 func checkVersions(f *lint.Findings, mf *configuration.ServiceManifest) {
-	names := make([]string, 0, len(mf.Versions))
-	for name := range mf.Versions {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+	names := slices.Sorted(maps.Keys(mf.Versions))
 	for _, name := range names {
 		if mf.Versions[name] == "" {
 			f.Warnf("versions."+name,

--- a/internal/lint/projectmanifest/projectmanifest.go
+++ b/internal/lint/projectmanifest/projectmanifest.go
@@ -12,6 +12,7 @@ package projectmanifest
 
 import (
 	"bytes"
+	"errors"
 	"io"
 
 	"go.yaml.in/yaml/v3"
@@ -72,5 +73,60 @@ func Load(r io.Reader) (*LoadResult, error) {
 	return res, nil
 }
 
-// Validate is defined in the next task.
-var _ = lint.SeverityError
+// Validate runs the offline project-manifest checks (F1–F7) and returns every
+// finding, annotated with the source line of the referenced YAML key where
+// resolvable. It never fails fast. res.Manifest may be nil (empty/malformed
+// input), in which case only the F1 finding is returned.
+func Validate(res *LoadResult) []lint.Finding {
+	var f lint.Findings
+
+	// F1: the document decoded into a mapping.
+	if res.Manifest == nil {
+		if errors.Is(res.DecodeErr, io.EOF) {
+			f.Errorf("service.yaml",
+				"service.yaml is empty; add at least a 'name' field (e.g. 'name: my-service')")
+		} else {
+			f.Errorf("service.yaml",
+				"invalid service.yaml: %v; check the YAML syntax near this location",
+				res.DecodeErr)
+		}
+		return f.Items()
+	}
+
+	checkName(&f, res.Manifest)
+	checkModules(&f, res.Manifest)
+	checkVersions(&f, res.Manifest)
+
+	// Annotate each finding with its source line where resolvable.
+	findings := f.Items()
+	if res.Root != nil {
+		for i := range findings {
+			if findings[i].Line == 0 {
+				findings[i].Line = resolvePath(res.Root, findings[i].Path)
+			}
+		}
+	}
+	return findings
+}
+
+// checkName implements F2. A service manifest's name is a service name and must
+// be present and match the service-name regex (unlike a module manifest, whose
+// name is an import path).
+func checkName(f *lint.Findings, mf *configuration.ServiceManifest) {
+	if mf.Name == "" {
+		f.Errorf("name",
+			"name is required; add a 'name' field matching `^[_a-z][_a-z0-9-]*$` "+
+				"(e.g. 'name: my-service')")
+		return
+	}
+	if !configuration.ValidateName(mf.Name) {
+		f.Errorf("name",
+			"'name' %q is invalid; use a value matching `^[_a-z][_a-z0-9-]*$` "+
+				"(e.g. 'my-service')", mf.Name)
+	}
+}
+
+// checkModules, checkVersions, resolvePath are implemented in Task 3.
+func checkModules(_ *lint.Findings, _ *configuration.ServiceManifest)  {}
+func checkVersions(_ *lint.Findings, _ *configuration.ServiceManifest) {}
+func resolvePath(_ *yaml.Node, _ string) int                           { return 0 }

--- a/internal/lint/projectmanifest/projectmanifest.go
+++ b/internal/lint/projectmanifest/projectmanifest.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Implements static offline validation of a Stencil project
+// manifest (service.yaml) without resolving modules or accessing the network.
+
+// Package projectmanifest implements static offline validation of a Stencil
+// project manifest (service.yaml). Unlike the module-manifest linter it does a
+// lenient decode only: a service.yaml's argument keys are defined by the
+// modules it loads, so strict unknown-key rejection would be wrong. Argument
+// value validation is an online concern handled elsewhere.
+package projectmanifest
+
+import (
+	"bytes"
+	"io"
+
+	"go.yaml.in/yaml/v3"
+
+	"github.com/getoutreach/stencil/internal/lint"
+	"github.com/getoutreach/stencil/pkg/configuration"
+)
+
+// LoadResult holds the outcome of decoding a service.yaml for linting.
+type LoadResult struct {
+	// Manifest is the leniently-decoded manifest, or nil if the YAML could not
+	// be decoded into a mapping at all.
+	Manifest *configuration.ServiceManifest
+	// Root is the first document's YAML node tree, used to resolve finding
+	// paths to source lines. Nil if the bytes did not parse as a node.
+	Root *yaml.Node
+	// DecodeErr is the lenient-decode error (empty input, malformed YAML, or a
+	// non-mapping top-level document), or nil. For empty input it is io.EOF.
+	DecodeErr error
+	// MultiDoc is true when the input contains more than one YAML document.
+	MultiDoc bool
+}
+
+// Load reads a service.yaml from r and decodes it leniently (no strict
+// unknown-key check), plus into a yaml.Node tree for source-line annotation.
+// The returned error is non-nil only when reading from r itself fails.
+func Load(r io.Reader) (*LoadResult, error) {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &LoadResult{}
+
+	// Node decode for source positions. A failure here is non-fatal: field
+	// checks still run on the struct path, just without line numbers.
+	var node yaml.Node
+	if err := yaml.Unmarshal(raw, &node); err == nil {
+		res.Root = &node
+	}
+
+	// Lenient decode (retain the decoder to probe for a second document).
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	var mf configuration.ServiceManifest
+	if err := dec.Decode(&mf); err != nil {
+		// Empty, malformed, or non-mapping input: no usable manifest.
+		res.DecodeErr = err
+		return res, nil
+	}
+	res.Manifest = &mf
+
+	// Probe for a second document on the advanced decoder.
+	var discard any
+	if err := dec.Decode(&discard); err == nil {
+		res.MultiDoc = true
+	}
+
+	return res, nil
+}
+
+// Validate is defined in the next task.
+var _ = lint.SeverityError

--- a/internal/lint/projectmanifest/projectmanifest_test.go
+++ b/internal/lint/projectmanifest/projectmanifest_test.go
@@ -56,12 +56,31 @@ func TestValidate(t *testing.T) {
 		{"missing name", "modules:\n  - name: github.com/getoutreach/stencil-base\n"},
 		{"invalid name uppercase", "name: MyService\n"},
 		{"invalid name leading digit", "name: 9lives\n"},
+		{"module missing name", "name: s\nmodules:\n  - version: 1.0.0\n"},
+		{"module invalid version", "name: s\nmodules:\n  - name: github.com/x/y\n    version: not-a-constraint\n"},
+		{"deprecated url", "name: s\nmodules:\n  - name: github.com/x/y\n    url: https://github.com/x/y\n"},
+		{"deprecated prerelease", "name: s\nmodules:\n  - name: github.com/x/y\n    prerelease: true\n"},
+		{"empty versions value", "name: s\nversions:\n  golang: \"\"\n"},
+		{"valid versions value", "name: s\nversions:\n  golang: \"1.21\"\n"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cupaloy.SnapshotT(t, renderFindings(validateString(test.in)))
 		})
 	}
+}
+
+func TestValidateAnnotatesLines(t *testing.T) {
+	in := "name: s\nmodules:\n  - name: github.com/x/y\n    url: https://github.com/x/y\n"
+	findings := validateString(in)
+	var found bool
+	for _, f := range findings {
+		if f.Path == "modules.github.com/x/y.url" {
+			found = true
+			assert.Equal(t, 4, f.Line) // the 'url:' key is on line 4
+		}
+	}
+	assert.Assert(t, found, "expected a url finding")
 }
 
 func TestLoadValid(t *testing.T) {

--- a/internal/lint/projectmanifest/projectmanifest_test.go
+++ b/internal/lint/projectmanifest/projectmanifest_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Tests for project manifest (service.yaml) loading and validation.
+
+package projectmanifest_test
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	projectmanifest "github.com/getoutreach/stencil/internal/lint/projectmanifest"
+)
+
+func TestLoadValid(t *testing.T) {
+	res, err := projectmanifest.Load(strings.NewReader("name: my-service\n"))
+	assert.NilError(t, err)
+	assert.Assert(t, res.Manifest != nil)
+	assert.Equal(t, "my-service", res.Manifest.Name)
+	assert.Assert(t, res.Root != nil)
+	assert.Equal(t, false, res.MultiDoc)
+	assert.NilError(t, res.DecodeErr)
+}
+
+func TestLoadEmptyInput(t *testing.T) {
+	res, err := projectmanifest.Load(strings.NewReader("   \n# just a comment\n"))
+	assert.NilError(t, err)
+	assert.Assert(t, res.Manifest == nil)
+	assert.Assert(t, res.DecodeErr != nil) // io.EOF
+}
+
+func TestLoadMalformed(t *testing.T) {
+	res, err := projectmanifest.Load(strings.NewReader("name: [unterminated\n"))
+	assert.NilError(t, err) // read succeeded; decode failure is in DecodeErr
+	assert.Assert(t, res.Manifest == nil)
+	assert.Assert(t, res.DecodeErr != nil)
+}
+
+func TestLoadNonMapping(t *testing.T) {
+	// A top-level scalar/sequence is not a mapping: Manifest nil, DecodeErr set.
+	res, err := projectmanifest.Load(strings.NewReader("- a\n- b\n"))
+	assert.NilError(t, err)
+	assert.Assert(t, res.Manifest == nil)
+	assert.Assert(t, res.DecodeErr != nil)
+}
+
+func TestLoadMultiDocument(t *testing.T) {
+	res, err := projectmanifest.Load(
+		strings.NewReader("name: my-service\n---\nname: second\n"))
+	assert.NilError(t, err)
+	assert.Assert(t, res.Manifest != nil)
+	assert.Equal(t, "my-service", res.Manifest.Name) // only doc 1
+	assert.Equal(t, true, res.MultiDoc)
+}

--- a/internal/lint/projectmanifest/projectmanifest_test.go
+++ b/internal/lint/projectmanifest/projectmanifest_test.go
@@ -5,13 +5,64 @@
 package projectmanifest_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/bradleyjkemp/cupaloy"
 	"gotest.tools/v3/assert"
 
+	lint "github.com/getoutreach/stencil/internal/lint"
 	projectmanifest "github.com/getoutreach/stencil/internal/lint/projectmanifest"
 )
+
+// renderFindings formats findings deterministically for snapshotting.
+// Mirrors internal/lint/manifest/manifest_test.go's helper.
+func renderFindings(findings []lint.Finding) string {
+	if len(findings) == 0 {
+		return "(no findings)\n"
+	}
+	sevWidth, locWidth := 0, 0
+	locs := make([]string, len(findings))
+	for i := range findings {
+		locs[i] = fmt.Sprintf("%s:%d", findings[i].Path, findings[i].Line)
+		if l := len(string(findings[i].Severity)); l > sevWidth {
+			sevWidth = l
+		}
+		if l := len(locs[i]); l > locWidth {
+			locWidth = l
+		}
+	}
+	var b strings.Builder
+	for i := range findings {
+		fmt.Fprintf(&b, "%-*s  %-*s  %s\n",
+			sevWidth, findings[i].Severity, locWidth, locs[i], findings[i].Message)
+	}
+	return b.String()
+}
+
+func validateString(in string) []lint.Finding {
+	res, _ := projectmanifest.Load(strings.NewReader(in))
+	return projectmanifest.Validate(res)
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"valid minimal", "name: my-service\n"},
+		{"empty", "   \n"},
+		{"missing name", "modules:\n  - name: github.com/getoutreach/stencil-base\n"},
+		{"invalid name uppercase", "name: MyService\n"},
+		{"invalid name leading digit", "name: 9lives\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cupaloy.SnapshotT(t, renderFindings(validateString(test.in)))
+		})
+	}
+}
 
 func TestLoadValid(t *testing.T) {
 	res, err := projectmanifest.Load(strings.NewReader("name: my-service\n"))

--- a/internal/lint/projectmanifest/resolve.go
+++ b/internal/lint/projectmanifest/resolve.go
@@ -14,6 +14,11 @@ import (
 	"github.com/getoutreach/stencil/internal/lint/yamlfix"
 )
 
+// opaqueLeafPrefixes are the top-level keys whose entries are opaque flat leaf
+// keys: their sub-keys may contain dots (e.g. import paths) but their values are
+// scalars, so a matching finding path has no trailing field to walk into.
+var opaqueLeafPrefixes = []string{"arguments.", "versions.", "replacements."}
+
 // resolvePath returns the 1-based line of the key identified by a dotted finding
 // path within root, or 0 if unresolvable. root is a yaml.v3 DocumentNode.
 //
@@ -40,7 +45,7 @@ func resolvePath(root *yaml.Node, path string) int {
 		return resolveModulePath(top, path)
 	}
 	// arguments.<key>, versions.<key>, replacements.<key>: opaque flat leaf key.
-	for _, p := range []string{"arguments.", "versions.", "replacements."} {
+	for _, p := range opaqueLeafPrefixes {
 		if after, ok := strings.CutPrefix(path, p); ok {
 			return resolveLeafKey(top, after, strings.TrimSuffix(p, "."))
 		}

--- a/internal/lint/projectmanifest/resolve.go
+++ b/internal/lint/projectmanifest/resolve.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Resolves dotted project-manifest lint finding paths to 1-based
+// source lines for annotation.
+
+package projectmanifest
+
+import (
+	"strconv"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+
+	"github.com/getoutreach/stencil/internal/lint/yamlfix"
+)
+
+// resolvePath returns the 1-based line of the key identified by a dotted finding
+// path within root, or 0 if unresolvable. root is a yaml.v3 DocumentNode.
+//
+// modules.<name>.<field> and modules[i].<field> get bespoke parsing because
+// module names are Go import paths containing dots. arguments/versions/
+// replacements keys are opaque flat leaf keys (their values are scalars, so
+// there is no trailing field). Everything else is a plain dotted mapping walk.
+func resolvePath(root *yaml.Node, path string) int {
+	if root == nil || path == "" {
+		return 0
+	}
+	top := yamlfix.Deref(root)
+	if top != nil && top.Kind == yaml.DocumentNode {
+		if len(top.Content) == 0 {
+			return 0
+		}
+		top = yamlfix.Deref(top.Content[0])
+	}
+	if top == nil || top.Kind != yaml.MappingNode {
+		return 0
+	}
+
+	if path == "modules" || strings.HasPrefix(path, "modules.") || strings.HasPrefix(path, "modules[") {
+		return resolveModulePath(top, path)
+	}
+	// arguments.<key>, versions.<key>, replacements.<key>: opaque flat leaf key.
+	for _, p := range []string{"arguments.", "versions.", "replacements."} {
+		if strings.HasPrefix(path, p) {
+			return resolveLeafKey(top, strings.TrimPrefix(path, p), strings.TrimSuffix(p, "."))
+		}
+	}
+
+	// General dotted mapping walk (covers "name").
+	cur := top
+	lastKeyLine := 0
+	for _, seg := range strings.Split(path, ".") {
+		if cur == nil || cur.Kind != yaml.MappingNode {
+			return 0
+		}
+		keyNode, valNode := mappingChild(cur, seg)
+		if keyNode == nil {
+			return 0
+		}
+		lastKeyLine = keyNode.Line
+		cur = yamlfix.Deref(valNode)
+	}
+	return lastKeyLine
+}
+
+// resolveLeafKey resolves "<container>.<key>" where key is a single flat map key
+// whose value is opaque (e.g. versions.golang). Returns the key node's line.
+func resolveLeafKey(top *yaml.Node, key, container string) int {
+	_, containerVal := mappingChild(top, container)
+	m := yamlfix.Deref(containerVal)
+	if m == nil || m.Kind != yaml.MappingNode {
+		return 0
+	}
+	keyNode, _ := mappingChild(m, key)
+	if keyNode == nil {
+		return 0
+	}
+	return keyNode.Line
+}
+
+// resolveModulePath resolves modules[i].field and modules.NAME.field (NAME may
+// contain dots; the last dot separates NAME from field).
+func resolveModulePath(top *yaml.Node, path string) int {
+	rest := strings.TrimPrefix(path, "modules")
+	_, seqVal := mappingChild(top, "modules")
+	seq := yamlfix.Deref(seqVal)
+	if seq == nil || seq.Kind != yaml.SequenceNode {
+		return 0
+	}
+	if strings.HasPrefix(rest, "[") {
+		closeIdx := strings.IndexByte(rest, ']')
+		if closeIdx < 0 {
+			return 0
+		}
+		idx, err := strconv.Atoi(rest[1:closeIdx])
+		if err != nil || idx < 0 || idx >= len(seq.Content) {
+			return 0
+		}
+		field := strings.TrimPrefix(rest[closeIdx+1:], ".")
+		return fieldLineIn(yamlfix.Deref(seq.Content[idx]), field)
+	}
+	rest = strings.TrimPrefix(rest, ".")
+	lastDot := strings.LastIndexByte(rest, '.')
+	if lastDot < 0 {
+		return 0
+	}
+	name, field := rest[:lastDot], rest[lastDot+1:]
+	item, nameLine := sequenceItemByName(seq, name)
+	if item == nil {
+		return 0
+	}
+	if field == "" {
+		return nameLine
+	}
+	return fieldLineIn(item, field)
+}
+
+func fieldLineIn(m *yaml.Node, field string) int {
+	if field == "" {
+		return 0
+	}
+	keyNode, _ := mappingChild(m, field)
+	if keyNode == nil {
+		return 0
+	}
+	return keyNode.Line
+}
+
+func mappingChild(m *yaml.Node, key string) (keyNode, valNode *yaml.Node) {
+	if m == nil || m.Kind != yaml.MappingNode {
+		return nil, nil
+	}
+	if i := yamlfix.FindKey(m, key); i >= 0 {
+		return m.Content[i], m.Content[i+1]
+	}
+	return nil, nil
+}
+
+func sequenceItemByName(seq *yaml.Node, name string) (item *yaml.Node, nameLine int) {
+	if seq == nil || seq.Kind != yaml.SequenceNode {
+		return nil, 0
+	}
+	for _, raw := range seq.Content {
+		it := yamlfix.Deref(raw)
+		keyNode, valNode := mappingChild(it, "name")
+		if keyNode != nil && valNode != nil && valNode.Value == name {
+			return it, keyNode.Line
+		}
+	}
+	return nil, 0
+}

--- a/internal/lint/projectmanifest/resolve.go
+++ b/internal/lint/projectmanifest/resolve.go
@@ -115,6 +115,8 @@ func resolveModulePath(top *yaml.Node, path string) int {
 	return fieldLineIn(item, field)
 }
 
+// fieldLineIn returns the 1-based line of key field within mapping m, or 0 if
+// m is not a mapping, field is empty, or the key is absent.
 func fieldLineIn(m *yaml.Node, field string) int {
 	if field == "" {
 		return 0
@@ -136,6 +138,9 @@ func mappingChild(m *yaml.Node, key string) (keyNode, valNode *yaml.Node) {
 	return nil, nil
 }
 
+// sequenceItemByName finds the mapping item in seq whose "name" scalar equals
+// name, returning the item node and its name key's 1-based line, or nil/0 if no
+// item matches.
 func sequenceItemByName(seq *yaml.Node, name string) (item *yaml.Node, nameLine int) {
 	if seq == nil || seq.Kind != yaml.SequenceNode {
 		return nil, 0

--- a/internal/lint/projectmanifest/resolve.go
+++ b/internal/lint/projectmanifest/resolve.go
@@ -41,15 +41,15 @@ func resolvePath(root *yaml.Node, path string) int {
 	}
 	// arguments.<key>, versions.<key>, replacements.<key>: opaque flat leaf key.
 	for _, p := range []string{"arguments.", "versions.", "replacements."} {
-		if strings.HasPrefix(path, p) {
-			return resolveLeafKey(top, strings.TrimPrefix(path, p), strings.TrimSuffix(p, "."))
+		if after, ok := strings.CutPrefix(path, p); ok {
+			return resolveLeafKey(top, after, strings.TrimSuffix(p, "."))
 		}
 	}
 
 	// General dotted mapping walk (covers "name").
 	cur := top
 	lastKeyLine := 0
-	for _, seg := range strings.Split(path, ".") {
+	for seg := range strings.SplitSeq(path, ".") {
 		if cur == nil || cur.Kind != yaml.MappingNode {
 			return 0
 		}

--- a/internal/lint/projectmanifest/resolve_test.go
+++ b/internal/lint/projectmanifest/resolve_test.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Tests resolving dotted project-manifest lint finding paths to
+// 1-based YAML source lines, covering the opaque leaf-key branches
+// (arguments/versions/replacements) and the module bracket-with-field branch.
+
+package projectmanifest
+
+import (
+	"testing"
+
+	"go.yaml.in/yaml/v3"
+	"gotest.tools/v3/assert"
+)
+
+// parseNode is a test helper: decode YAML text into a *yaml.Node document root.
+func parseNode(t *testing.T, in string) *yaml.Node {
+	t.Helper()
+	var n yaml.Node
+	assert.NilError(t, yaml.Unmarshal([]byte(in), &n))
+	return &n
+}
+
+func TestResolvePath(t *testing.T) {
+	// Line-numbered for reference (1-based):
+	// 1 name: my-service
+	// 2 versions:
+	// 3   golang: "1.22"
+	// 4 arguments:
+	// 5   foo: bar
+	// 6 replacements:
+	// 7   github.com/x/y: file://../y
+	// 8 modules:
+	// 9   - name: github.com/getoutreach/stencil-base
+	// 10    version: v1.2.3
+	const doc = `name: my-service
+versions:
+  golang: "1.22"
+arguments:
+  foo: bar
+replacements:
+  github.com/x/y: file://../y
+modules:
+  - name: github.com/getoutreach/stencil-base
+    version: v1.2.3
+`
+	root := parseNode(t, doc)
+
+	tests := []struct {
+		name string
+		path string
+		want int
+	}{
+		{"general dotted walk (name)", "name", 1},
+		{"versions opaque leaf", "versions.golang", 3},
+		{"arguments opaque leaf", "arguments.foo", 5},
+		// The replacement key itself contains dots and slashes; it is matched
+		// whole as a single opaque leaf key (not prefix-split).
+		{"replacements opaque leaf with dots/slashes", "replacements.github.com/x/y", 7},
+		{"module version by name (last-dot split)", "modules.github.com/getoutreach/stencil-base.version", 10},
+		{"module name by bracket index", "modules[0].name", 9},
+		{"unresolvable path misses", "nope.does.not.exist", 0},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, resolvePath(root, test.path))
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does / why we need it

Adds `stencil lint project-manifest`, an offline linter for a project's `service.yaml`, so common misconfigurations are reported up front with actionable messages instead of surfacing as a confusing failure later. It also runs as part of `stencil lint <dir>` when a `service.yaml` is present. The implementation deliberately mirrors the existing module-manifest linter, so finding output, suggestion wording, and line annotation stay consistent between the two.

One design choice worth understanding: the decode is lenient rather than strict. A `service.yaml`'s argument keys are defined by the modules it loads, so rejecting unknown keys would flag valid input. For the same reason, `arguments` and `replacements` are not validated in this PR — they can only be checked against resolved modules, which is online work in a follow-up. This PR is offline-only, with no `--fix` yet.

## Jira ID

[DT-5396](https://outreach-io.atlassian.net/browse/DT-5396)

## Notes for your reviewers

A missing file is treated differently by the subcommand and the aggregate, on purpose: `stencil lint project-manifest` errors when its target `service.yaml` is absent, while `stencil lint <dir>` skips a missing one, since a module may legitimately have none. This matches the existing module-manifest runner.

[DT-5396]: https://outreach-io.atlassian.net/browse/DT-5396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ