### PR TITLE
feat(lint): validate project-manifest arguments against resolved modules

### DIFF
--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -441,21 +441,34 @@ func runLintAggregate(ctx context.Context, c *cli.Command) error {
 	// the runner signature can't carry. A missing service.yaml is skipped so a
 	// module without one is "nothing to lint". Kept last to preserve cross-runner
 	// order: manifest, templates, then service.yaml.
-	sp := filepath.Join(dir, "service.yaml")
-	if _, statErr := os.Stat(sp); statErr == nil {
-		raw, readErr := os.ReadFile(sp)
-		if readErr != nil {
-			return errors.Wrapf(readErr, "failed to read %q", sp)
-		}
-		pf, err := runProjectManifestReaderOnline(ctx, log, sp, bytes.NewReader(raw), c.Bool("offline"))
-		if err != nil {
-			return errors.Wrap(err, "lint failed")
-		}
-		all = append(all, pf...)
+	pf, err := lintServiceYaml(ctx, log, filepath.Join(dir, "service.yaml"), c.Bool("offline"))
+	if err != nil {
+		return err
 	}
+	all = append(all, pf...)
 
 	logFindings(log, all)
 	return failIfFindings(all, c.Bool("warnings-as-errors"))
+}
+
+// lintServiceYaml runs the out-of-band online project-manifest phase for the
+// aggregate action. A missing service.yaml is skipped (nil, nil) so a module
+// without one is "nothing to lint". Errors are already wrapped with "lint
+// failed".
+func lintServiceYaml(ctx context.Context, log logrus.FieldLogger,
+	sp string, offline bool) ([]lint.Finding, error) {
+	if _, statErr := os.Stat(sp); statErr != nil {
+		return nil, nil // missing service.yaml is skipped
+	}
+	raw, readErr := os.ReadFile(sp)
+	if readErr != nil {
+		return nil, errors.Wrapf(readErr, "failed to read %q", sp)
+	}
+	pf, err := runProjectManifestReaderOnline(ctx, log, sp, bytes.NewReader(raw), offline)
+	if err != nil {
+		return nil, errors.Wrap(err, "lint failed")
+	}
+	return pf, nil
 }
 
 // runLintModuleManifest is the `stencil lint module-manifest [path]` action.

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/getoutreach/gobox/pkg/cli/github"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v3"
@@ -29,6 +30,7 @@ import (
 	lintmanifest "github.com/getoutreach/stencil/internal/lint/manifest"
 	lintprojectmanifest "github.com/getoutreach/stencil/internal/lint/projectmanifest"
 	linttemplates "github.com/getoutreach/stencil/internal/lint/templates"
+	"github.com/getoutreach/stencil/internal/modules"
 )
 
 // templatesDir is the conventional subdirectory holding a module's *.tpl files.
@@ -48,7 +50,7 @@ func NewLintCommand() *cli.Command {
 		Usage:       "Validate a Stencil module without resolving dependencies",
 		ArgsUsage:   "[dir]",
 		Description: "Validate a Stencil module's manifest and templates without resolving dependencies",
-		Flags:       []cli.Flag{warningsAsErrorsFlag(), fixFlag()},
+		Flags:       []cli.Flag{warningsAsErrorsFlag(), fixFlag(), offlineFlag()},
 		Commands:    []*cli.Command{newLintModuleManifestCommand(), newLintTemplatesCommand(), newLintProjectManifestCommand()},
 		Action:      runLintAggregate,
 	}
@@ -72,6 +74,17 @@ func fixFlag() cli.Flag {
 		Name: "fix",
 		Usage: "automatically fix safe deprecations in place (a manifest is " +
 			"re-encoded at 2-space indent when fixed; re-lints after fixing)",
+		Value: false,
+	}
+}
+
+// offlineFlag is declared on the lint group and the project-manifest
+// subcommand, since urfave/cli/v3 does not inherit parent flags. It skips
+// module resolution so only the offline syntactic checks run.
+func offlineFlag() cli.Flag {
+	return &cli.BoolFlag{
+		Name:  "offline",
+		Usage: "skip module resolution; run only offline syntactic checks",
 		Value: false,
 	}
 }
@@ -344,7 +357,7 @@ func failTemplates(log logrus.FieldLogger, findings []lint.Finding, warningsAsEr
 }
 
 // runLintAggregate is the `stencil lint [dir]` action.
-func runLintAggregate(_ context.Context, c *cli.Command) error {
+func runLintAggregate(ctx context.Context, c *cli.Command) error {
 	if c.Args().Len() > 1 {
 		return errors.New("expected at most one argument, a module directory")
 	}
@@ -413,7 +426,6 @@ func runLintAggregate(_ context.Context, c *cli.Command) error {
 	runners := []runner{
 		manifestRunner(filepath.Join(dir, "manifest.yaml")),
 		templateRunner(filepath.Join(dir, templatesDir)),
-		projectManifestRunner(filepath.Join(dir, "service.yaml")),
 	}
 
 	var all []lint.Finding
@@ -424,6 +436,24 @@ func runLintAggregate(_ context.Context, c *cli.Command) error {
 		}
 		all = append(all, findings...)
 	}
+
+	// Out-of-band project-manifest phase: it needs ctx + the offline flag, which
+	// the runner signature can't carry. A missing service.yaml is skipped so a
+	// module without one is "nothing to lint". Kept last to preserve cross-runner
+	// order: manifest, templates, then service.yaml.
+	sp := filepath.Join(dir, "service.yaml")
+	if _, statErr := os.Stat(sp); statErr == nil {
+		raw, readErr := os.ReadFile(sp)
+		if readErr != nil {
+			return errors.Wrapf(readErr, "failed to read %q", sp)
+		}
+		pf, err := runProjectManifestReaderOnline(ctx, log, sp, bytes.NewReader(raw), c.Bool("offline"))
+		if err != nil {
+			return errors.Wrap(err, "lint failed")
+		}
+		all = append(all, pf...)
+	}
+
 	logFindings(log, all)
 	return failIfFindings(all, c.Bool("warnings-as-errors"))
 }
@@ -639,23 +669,28 @@ func newLintProjectManifestCommand() *cli.Command {
 		Usage:       "Validate a project's service.yaml without resolving dependencies",
 		ArgsUsage:   "[path]",
 		Description: "Validate a single project manifest (service.yaml; defaults to ./service.yaml). Use '-' to read from stdin.",
-		Flags:       []cli.Flag{warningsAsErrorsFlag()},
+		Flags:       []cli.Flag{warningsAsErrorsFlag(), offlineFlag()},
 		Action:      runLintProjectManifest,
 	}
 }
 
-// runLintProjectManifest is the `lint project-manifest [path]` action (offline).
-func runLintProjectManifest(_ context.Context, c *cli.Command) error {
+// runLintProjectManifest is the `lint project-manifest [path]` action. Unless
+// --offline (or stdin) is given, it resolves the manifest's modules and runs
+// the online checks (O1-O8) in addition to the offline syntactic checks.
+func runLintProjectManifest(ctx context.Context, c *cli.Command) error {
 	if c.Args().Len() > 1 {
 		return errors.New("expected at most one argument, a path to service.yaml")
 	}
 	log := newLintLogger(c)
+	offline := c.Bool("offline")
 
 	if c.Args().First() == "-" {
 		if readerIsTTY(c.Reader) {
 			return errors.New("'-' expects piped input, not an interactive terminal")
 		}
-		findings, err := runProjectManifestReader(log, stdinName, c.Reader)
+		// stdin has no on-disk module context to resolve against, so reading
+		// from '-' forces offline.
+		findings, err := runProjectManifestReaderOnline(ctx, log, stdinName, c.Reader, true)
 		if err != nil {
 			return errors.Wrap(err, "lint failed")
 		}
@@ -678,7 +713,7 @@ func runLintProjectManifest(_ context.Context, c *cli.Command) error {
 	if closer != nil {
 		defer closer.Close()
 	}
-	findings, err := runProjectManifestReader(log, path, r)
+	findings, err := runProjectManifestReaderOnline(ctx, log, path, r, offline)
 	if err != nil {
 		return errors.Wrap(err, "lint failed")
 	}
@@ -686,23 +721,54 @@ func runLintProjectManifest(_ context.Context, c *cli.Command) error {
 	return failProjectManifest(log, path, findings, c.Bool("warnings-as-errors"))
 }
 
-// projectManifestRunner returns a runner that lints the service.yaml at path.
-// A missing file is skipped (nil, nil) so the aggregate treats a module without
-// a service.yaml as "nothing to lint" — mirroring manifestRunner.
-func projectManifestRunner(path string) runner {
-	return func(log logrus.FieldLogger) ([]lint.Finding, error) {
-		r, closer, finding, err := resolveProjectManifestReader(path)
-		if err != nil {
-			return nil, err
-		}
-		if finding != nil {
-			return nil, nil // missing service.yaml: skip in aggregate
-		}
-		if closer != nil {
-			defer closer.Close()
-		}
-		return runProjectManifestReader(log, path, r)
+// resolveAndValidateProjectManifest runs the offline checks and, unless offline,
+// resolves the manifest's modules and runs the online checks (O1-O8). O1 is
+// produced here (the resolver error is opaque, so a resolution failure yields a
+// single `modules` finding; a per-module Manifest decode failure is attributable
+// and yields modules.<name>); either skips O2-O8.
+func resolveAndValidateProjectManifest(ctx context.Context, log logrus.FieldLogger,
+	res *lintprojectmanifest.LoadResult, offline bool) []lint.Finding {
+	if offline || res.Manifest == nil {
+		return lintprojectmanifest.Validate(res)
 	}
+
+	token, err := github.GetToken()
+	if err != nil {
+		log.Warn("failed to get github token, using anonymous access")
+	}
+
+	mods, err := modules.GetModulesForService(ctx, &modules.ModuleResolveOptions{
+		ServiceManifest: res.Manifest,
+		Token:           token,
+		Log:             log,
+	})
+	if err != nil {
+		return append(lintprojectmanifest.Validate(res), lint.Finding{
+			Severity: lint.SeverityError,
+			Path:     "modules",
+			Message: fmt.Sprintf("failed to resolve modules: %v; ensure the module "+
+				"names, versions, and access (auth) are correct", err),
+		})
+	}
+
+	resolved := make([]lintprojectmanifest.ResolvedModule, 0, len(mods))
+	for _, m := range mods {
+		mf, err := m.Manifest(ctx)
+		if err != nil {
+			return append(lintprojectmanifest.Validate(res), lint.Finding{
+				Severity: lint.SeverityError,
+				Path:     "modules." + m.Name,
+				Message:  fmt.Sprintf("failed to read module %q manifest: %v", m.Name, err),
+			})
+		}
+		mfCopy := mf // per-iteration allocation: Manifest returns by value; avoid aliasing.
+		resolved = append(resolved, lintprojectmanifest.ResolvedModule{
+			ImportPath: m.Name,
+			Module:     m,
+			Manifest:   &mfCopy,
+		})
+	}
+	return lintprojectmanifest.ValidateOnline(res, resolved)
 }
 
 // resolveProjectManifestReader resolves path to a service.yaml reader, appending
@@ -711,14 +777,17 @@ func resolveProjectManifestReader(path string) (io.Reader, io.Closer, *lint.Find
 	return resolveReader(path, "service.yaml", "service manifest")
 }
 
-// runProjectManifestReader loads + validates one service.yaml from r. It does
-// not log; the caller logs once. name is used in the multi-doc warning.
-func runProjectManifestReader(log logrus.FieldLogger, name string, r io.Reader) ([]lint.Finding, error) {
+// runProjectManifestReaderOnline loads one service.yaml from r and validates
+// it: always the offline checks, plus (unless offline) module resolution and
+// the online checks. It does not log; the caller logs once. name is used in the
+// multi-doc warning.
+func runProjectManifestReaderOnline(ctx context.Context, log logrus.FieldLogger,
+	name string, r io.Reader, offline bool) ([]lint.Finding, error) {
 	res, err := lintprojectmanifest.Load(r)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read service manifest %q", name)
 	}
-	findings := lintprojectmanifest.Validate(res)
+	findings := resolveAndValidateProjectManifest(ctx, log, res, offline)
 	if res.MultiDoc {
 		log.WithField("path", name).Warn("additional YAML documents after the first are ignored")
 	}

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -774,11 +774,10 @@ func resolveAndValidateProjectManifest(ctx context.Context, log logrus.FieldLogg
 				Message:  fmt.Sprintf("failed to read module %q manifest: %v", m.Name, err),
 			})
 		}
-		mfCopy := mf // per-iteration allocation: Manifest returns by value; avoid aliasing.
 		resolved = append(resolved, lintprojectmanifest.ResolvedModule{
 			ImportPath: m.Name,
 			Module:     m,
-			Manifest:   &mfCopy,
+			Manifest:   &mf,
 		})
 	}
 	return lintprojectmanifest.ValidateOnline(res, resolved)

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -840,6 +840,102 @@ func runProjectManifest(t *testing.T, args []string, stdin io.Reader, stdout io.
 	return root.Run(context.Background(), full)
 }
 
+// runProjectManifestOffline mirrors runProjectManifest but passes --offline so
+// module resolution is skipped and only the offline syntactic checks run.
+func runProjectManifestOffline(t *testing.T, args []string) error {
+	t.Helper()
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	sub := findSubcommand(root, "project-manifest")
+	assert.Assert(t, sub != nil, "project-manifest subcommand must exist")
+	full := append([]string{"lint", "project-manifest", "--offline"}, args...)
+	return root.Run(context.Background(), full)
+}
+
+// writeLocalModule writes a minimal module (manifest.yaml with the given
+// contents) to a temp dir and returns its path, for use as a file://
+// replacement so online resolution never hits the network.
+func writeLocalModule(t *testing.T, manifestYAML string) string {
+	t.Helper()
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "manifest.yaml"),
+		[]byte(manifestYAML), 0o600))
+	return dir
+}
+
+func TestProjectManifestOfflineFlagSkipsResolution(t *testing.T) {
+	dir := t.TempDir()
+	// A module that would fail to resolve online, but --offline skips resolution.
+	sy := "name: s\nmodules:\n  - name: github.com/does/not-exist\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "service.yaml"), []byte(sy), 0o600))
+	err := runProjectManifestOffline(t, []string{filepath.Join(dir, "service.yaml")})
+	assert.NilError(t, err) // offline: only F1-F7 run; the module name is valid syntactically
+}
+
+func TestProjectManifestStdinForcesOffline(t *testing.T) {
+	// stdin references an unresolvable module, but '-' forces offline so no
+	// resolution occurs and the syntactically-valid manifest passes.
+	sy := "name: s\nmodules:\n  - name: github.com/does/not-exist\n"
+	err := runProjectManifest(t, []string{"-"}, strings.NewReader(sy), io.Discard)
+	assert.NilError(t, err)
+}
+
+func TestProjectManifestOnlineRequiredArgViaReplacement(t *testing.T) {
+	modDir := writeLocalModule(t,
+		"name: github.com/x/a\narguments:\n  foo:\n    required: true\n")
+	dir := t.TempDir()
+	sy := "name: s\n" +
+		"modules:\n  - name: github.com/x/a\n" +
+		"replacements:\n  github.com/x/a: file://" + modDir + "\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "service.yaml"), []byte(sy), 0o600))
+	// online (default): module resolves via file:// replacement; foo is required
+	// and unset → O3 → error.
+	err := runProjectManifest(t, []string{filepath.Join(dir, "service.yaml")}, nil, nil)
+	assert.Assert(t, err != nil)
+}
+
+func TestProjectManifestOnlineHappyViaReplacement(t *testing.T) {
+	modDir := writeLocalModule(t, "name: github.com/x/a\n")
+	dir := t.TempDir()
+	sy := "name: s\n" +
+		"modules:\n  - name: github.com/x/a\n" +
+		"replacements:\n  github.com/x/a: file://" + modDir + "\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "service.yaml"), []byte(sy), 0o600))
+	// online (default): module resolves via file:// replacement; no required
+	// args, no misuse → no findings.
+	err := runProjectManifest(t, []string{filepath.Join(dir, "service.yaml")}, nil, nil)
+	assert.NilError(t, err)
+}
+
+// TestAggregateOnlineServiceYamlViaReplacement proves the aggregate `lint <dir>`
+// runs the online project-manifest phase out of band: a required-but-unset arg
+// on a file://-replaced module surfaces as a run failure.
+func TestAggregateOnlineServiceYamlViaReplacement(t *testing.T) {
+	modDir := writeLocalModule(t,
+		"name: github.com/x/a\narguments:\n  foo:\n    required: true\n")
+	dir := t.TempDir()
+	sy := "name: s\n" +
+		"modules:\n  - name: github.com/x/a\n" +
+		"replacements:\n  github.com/x/a: file://" + modDir + "\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "service.yaml"), []byte(sy), 0o600))
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	err := root.Run(context.Background(), []string{"lint", dir})
+	assert.Assert(t, err != nil)
+}
+
+// TestAggregateOfflineFlagSkipsResolution proves `lint <dir> --offline` skips
+// the online phase: an unresolvable module does not fail the run.
+func TestAggregateOfflineFlagSkipsResolution(t *testing.T) {
+	dir := t.TempDir()
+	sy := "name: s\nmodules:\n  - name: github.com/does/not-exist\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "service.yaml"), []byte(sy), 0o600))
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	err := root.Run(context.Background(), []string{"lint", "--offline", dir})
+	assert.NilError(t, err)
+}
+
 func TestNewLintCommandHasProjectManifestSubcommand(t *testing.T) {
 	cmd := NewLintCommand()
 	assert.Assert(t, findSubcommand(cmd, "project-manifest") != nil)

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -936,6 +936,24 @@ func TestAggregateOfflineFlagSkipsResolution(t *testing.T) {
 	assert.NilError(t, err)
 }
 
+// TestProjectManifestOnlinePerModuleManifestFailure proves a per-module
+// manifest load failure (name mismatch: Manifest(ctx) rejects it) surfaces as
+// a non-zero run (an O1 modules.<name> error) without panicking or emitting
+// spurious argument findings. The module is a file:// replacement, so the run
+// is network-free.
+func TestProjectManifestOnlinePerModuleManifestFailure(t *testing.T) {
+	modDir := t.TempDir()
+	// name mismatch: Manifest(ctx) errors ("declares its import path as ...").
+	assert.NilError(t, os.WriteFile(filepath.Join(modDir, "manifest.yaml"),
+		[]byte("name: github.com/wrong/name\n"), 0o600))
+	dir := t.TempDir()
+	sy := "name: s\nmodules:\n  - name: github.com/x/a\n" +
+		"replacements:\n  github.com/x/a: file://" + modDir + "\n"
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "service.yaml"), []byte(sy), 0o600))
+	err := runProjectManifest(t, []string{filepath.Join(dir, "service.yaml")}, nil, nil)
+	assert.Assert(t, err != nil) // O1 modules.<name> error → non-zero
+}
+
 func TestNewLintCommandHasProjectManifestSubcommand(t *testing.T) {
 	cmd := NewLintCommand()
 	assert.Assert(t, findSubcommand(cmd, "project-manifest") != nil)

--- a/docs/content/en/commands/stencil_lint.md
+++ b/docs/content/en/commands/stencil_lint.md
@@ -28,6 +28,7 @@ COMMANDS:
 OPTIONS:
    --warnings-as-errors  treat warnings as errors (fail on any finding)
    --fix                 automatically fix safe deprecations in place (a manifest is re-encoded at 2-space indent when fixed; re-lints after fixing)
+   --offline             skip module resolution; run only offline syntactic checks
    --help, -h            show help
 
 ```

--- a/docs/content/en/commands/stencil_lint_project-manifest.md
+++ b/docs/content/en/commands/stencil_lint_project-manifest.md
@@ -22,6 +22,7 @@ DESCRIPTION:
 
 OPTIONS:
    --warnings-as-errors  treat warnings as errors (fail on any finding)
+   --offline             skip module resolution; run only offline syntactic checks
    --help, -h            show help
 
 GLOBAL OPTIONS:

--- a/internal/lint/projectmanifest/.snapshots/TestValidateOnlineSnapshot
+++ b/internal/lint/projectmanifest/.snapshots/TestValidateOnlineSnapshot
@@ -1,0 +1,4 @@
+error  name:1                'name' "Bad Name" is invalid; use a value matching `^[_a-z][_a-z0-9-]*$` (e.g. 'my-service')
+error  arguments.borrowed:0  argument "borrowed" uses 'from: github.com/x/c' but module "github.com/x/b" does not list "github.com/x/c" in its 'modules'; add it as a dependency
+error  arguments.needed:0    argument "needed" is required by module "github.com/x/a" but is not set; set 'arguments.needed' in service.yaml
+

--- a/internal/lint/projectmanifest/online.go
+++ b/internal/lint/projectmanifest/online.go
@@ -32,7 +32,10 @@ func ValidateOnline(res *LoadResult, mods []ResolvedModule) []lint.Finding {
 	offline := Validate(res)
 
 	idx, o4 := buildArgIndex(mods)
-	online := append(o4, checkArguments(res, idx)...)
+	o2o3 := checkArguments(res, idx)
+	online := make([]lint.Finding, 0, len(o4)+len(o2o3))
+	online = append(online, o4...)
+	online = append(online, o2o3...)
 	sortOnline(online)
 
 	return append(offline, online...)

--- a/internal/lint/projectmanifest/online.go
+++ b/internal/lint/projectmanifest/online.go
@@ -7,8 +7,15 @@
 package projectmanifest
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
 	"sort"
 
+	"github.com/santhosh-tekuri/jsonschema/v5"
+
+	"github.com/getoutreach/stencil/internal/dotnotation"
 	"github.com/getoutreach/stencil/internal/lint"
 	"github.com/getoutreach/stencil/pkg/configuration"
 )
@@ -105,4 +112,94 @@ func resolveFrom(f *lint.Findings, mods []ResolvedModule, owner ResolvedModule,
 		return configuration.Argument{}, false
 	}
 	return refArg, true
+}
+
+// checkArguments implements O2 (value vs schema) and O3 (required). For each
+// argument name in the index (sorted), it locates the provided value in the
+// service.yaml arguments and validates it against EACH declaration's schema,
+// attributing failures to the declaring module. A required declaration with no
+// provided value and no default yields O3.
+func checkArguments(res *LoadResult, idx map[string][]declaration) []lint.Finding {
+	var f lint.Findings
+	if res.Manifest == nil {
+		return f.Items()
+	}
+	names := make([]string, 0, len(idx))
+	for name := range idx {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		value, provided := providedValue(res.Manifest.Arguments, name)
+		for _, d := range idx[name] {
+			if provided {
+				// O2: validate the value against this declaration's schema.
+				if len(d.arg.Schema) > 0 {
+					if err := validateValue(name, d.arg.Schema, value); err != nil {
+						f.Errorf("arguments."+name,
+							"argument %q does not satisfy the schema declared by module %q: %v",
+							name, d.importPath, err)
+					}
+				}
+			} else {
+				// O3: required with no default and no value.
+				if d.arg.Required && d.arg.Default == nil {
+					f.Errorf("arguments."+name,
+						"argument %q is required by module %q but is not set; "+
+							"set 'arguments.%s' in service.yaml", name, d.importPath, name)
+				}
+			}
+		}
+	}
+	return f.Items()
+}
+
+// providedValue reports whether name is provided in the service.yaml arguments
+// (key present AND value not nil), returning the value. An explicit null counts
+// as NOT provided. dotnotation.Get is used only to locate the value (supporting
+// dotted argument names); an absent key returns an error (not provided), a
+// present key returns (value, nil) — including (nil, nil) for an explicit null,
+// which we treat as not provided.
+func providedValue(args map[string]interface{}, name string) (interface{}, bool) {
+	if args == nil {
+		return nil, false
+	}
+	mapInf := make(map[interface{}]interface{}, len(args))
+	for k, v := range args {
+		mapInf[k] = v
+	}
+	v, err := dotnotation.Get(mapInf, name)
+	if err != nil {
+		return nil, false // key absent
+	}
+	if v == nil {
+		return nil, false // explicit null: treat as not provided
+	}
+	return v, true
+}
+
+// validateValue compiles a single argument schema (Draft 2020-12) HERMETICALLY
+// (external $ref rejected — no filesystem/network) and validates v against it.
+// Mirrors internal/lint/manifest/compileSchema, extended to also validate a
+// value. It intentionally diverges from render's non-hermetic validateArg.
+func validateValue(name string, schema map[string]interface{}, v interface{}) error {
+	buf := new(bytes.Buffer)
+	if err := json.NewEncoder(buf).Encode(schema); err != nil {
+		return err
+	}
+	jsc := jsonschema.NewCompiler()
+	jsc.Draft = jsonschema.Draft2020
+	jsc.LoadURL = func(ref string) (io.ReadCloser, error) {
+		return nil, fmt.Errorf("external $ref not allowed in lint: %s", ref)
+	}
+	url := "service.yaml/arguments/" + name
+	if err := jsc.AddResource(url, buf); err != nil {
+		return err
+	}
+	compiled, err := jsc.Compile(url)
+	if err != nil {
+		return err
+	}
+	return compiled.Validate(v)
 }

--- a/internal/lint/projectmanifest/online.go
+++ b/internal/lint/projectmanifest/online.go
@@ -20,6 +20,37 @@ import (
 	"github.com/getoutreach/stencil/pkg/configuration"
 )
 
+// ValidateOnline runs the offline checks (Validate) then appends the online
+// argument checks (O2–O4) against the already-resolved modules, in a
+// deterministic total order (offline findings first; online sorted by Path,
+// then declaring-module import path, then check ID). It executes no templates
+// and performs no module resolution — the command layer resolves each module's
+// Manifest(ctx) and passes it in via ResolvedModule. O1 (resolution / per-module
+// manifest failure) is produced by the command layer, so this is only reached
+// on a fully-resolved module set. PR 3b appends O5–O8.
+func ValidateOnline(res *LoadResult, mods []ResolvedModule) []lint.Finding {
+	offline := Validate(res)
+
+	idx, o4 := buildArgIndex(mods)
+	online := append(o4, checkArguments(res, idx)...)
+	sortOnline(online)
+
+	return append(offline, online...)
+}
+
+// sortOnline sorts online findings by Path, then by the module import path
+// embedded in the message where present (a stable secondary key). Since
+// O2/O3/O4 all key on arguments.<name>, Path ordering plus the message tie-break
+// is deterministic.
+func sortOnline(findings []lint.Finding) {
+	sort.SliceStable(findings, func(i, j int) bool {
+		if findings[i].Path != findings[j].Path {
+			return findings[i].Path < findings[j].Path
+		}
+		return findings[i].Message < findings[j].Message
+	})
+}
+
 // declaration is one module's declaration of an argument (post-from:), retained
 // with the declaring module's import path (identity for messages/ordering) and
 // its owning manifest (owner.Modules drives the O4 dependency-listing check).

--- a/internal/lint/projectmanifest/online.go
+++ b/internal/lint/projectmanifest/online.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Online project-manifest validation: builds an argument index
+// from resolved modules and validates provided values against declared schemas
+// (O2), enforces required arguments (O3), and resolves from: indirection (O4).
+
+package projectmanifest
+
+import (
+	"sort"
+
+	"github.com/getoutreach/stencil/internal/lint"
+	"github.com/getoutreach/stencil/pkg/configuration"
+)
+
+// declaration is one module's declaration of an argument (post-from:), retained
+// with the declaring module's import path (identity for messages/ordering) and
+// its owning manifest (owner.Modules drives the O4 dependency-listing check).
+type declaration struct {
+	importPath string
+	owner      *configuration.TemplateRepositoryManifest
+	arg        configuration.Argument
+}
+
+// buildArgIndex walks every resolved module's declared arguments in deterministic
+// order (by import path, then arg name), resolving from: redirects, and returns
+// the index plus any O4 findings. Every declaration for a name is appended (O6
+// equivalence comparison is added in PR 3b); O2/O3 consume all of them.
+func buildArgIndex(mods []ResolvedModule) (map[string][]declaration, []lint.Finding) {
+	sorted := make([]ResolvedModule, len(mods))
+	copy(sorted, mods)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ImportPath < sorted[j].ImportPath })
+
+	idx := map[string][]declaration{}
+	var f lint.Findings
+
+	for _, rm := range sorted {
+		if rm.Manifest == nil {
+			continue
+		}
+		names := make([]string, 0, len(rm.Manifest.Arguments))
+		for name := range rm.Manifest.Arguments {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			arg := rm.Manifest.Arguments[name]
+			if arg.From != "" {
+				resolved, ok := resolveFrom(&f, sorted, rm, name, &arg)
+				if !ok {
+					continue // O4 finding recorded; skip indexing this declaration
+				}
+				arg = resolved
+			}
+			idx[name] = append(idx[name], declaration{
+				importPath: rm.ImportPath,
+				owner:      rm.Manifest,
+				arg:        arg,
+			})
+		}
+	}
+	return idx, f.Items()
+}
+
+// resolveFrom mirrors render's resolveFrom (internal/codegen/tpl_stencil_arg.go):
+// the owning module must list arg.From in its own Modules; the referenced module
+// must be in the resolved set and declare the same arg name. Records an O4
+// finding and returns ok=false on any failure.
+func resolveFrom(f *lint.Findings, mods []ResolvedModule, owner ResolvedModule,
+	name string, arg *configuration.Argument) (configuration.Argument, bool) {
+	// The owning module must declare arg.From as a dependency.
+	listed := false
+	for _, m := range owner.Manifest.Modules {
+		if m.Name == arg.From {
+			listed = true
+			break
+		}
+	}
+	if !listed {
+		f.Errorf("arguments."+name,
+			"argument %q uses 'from: %s' but module %q does not list %q in its 'modules'; "+
+				"add it as a dependency", name, arg.From, owner.ImportPath, arg.From)
+		return configuration.Argument{}, false
+	}
+	// The referenced module must be in the resolved set.
+	var ref *ResolvedModule
+	for i := range mods {
+		if mods[i].ImportPath == arg.From {
+			ref = &mods[i]
+			break
+		}
+	}
+	if ref == nil || ref.Manifest == nil {
+		f.Errorf("arguments."+name,
+			"argument %q references module %q via 'from:', but it is not in the resolved "+
+				"dependency graph", name, arg.From)
+		return configuration.Argument{}, false
+	}
+	// The referenced module must declare the same argument name.
+	refArg, ok := ref.Manifest.Arguments[name]
+	if !ok {
+		f.Errorf("arguments."+name,
+			"argument %q references module %q via 'from:', but %q does not declare "+
+				"argument %q", name, arg.From, arg.From, name)
+		return configuration.Argument{}, false
+	}
+	return refArg, true
+}

--- a/internal/lint/projectmanifest/online_test.go
+++ b/internal/lint/projectmanifest/online_test.go
@@ -6,14 +6,42 @@
 package projectmanifest
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/bradleyjkemp/cupaloy"
 	"gotest.tools/v3/assert"
 
 	lint "github.com/getoutreach/stencil/internal/lint"
 	"github.com/getoutreach/stencil/pkg/configuration"
 )
+
+// renderOnlineFindings formats findings deterministically for snapshotting,
+// mirroring projectmanifest_test.go's renderFindings (duplicated here because
+// online_test.go is the internal package, not the _test package).
+func renderOnlineFindings(findings []lint.Finding) string {
+	if len(findings) == 0 {
+		return "(no findings)\n"
+	}
+	sevWidth, locWidth := 0, 0
+	locs := make([]string, len(findings))
+	for i := range findings {
+		locs[i] = fmt.Sprintf("%s:%d", findings[i].Path, findings[i].Line)
+		if l := len(string(findings[i].Severity)); l > sevWidth {
+			sevWidth = l
+		}
+		if l := len(locs[i]); l > locWidth {
+			locWidth = l
+		}
+	}
+	var b strings.Builder
+	for i := range findings {
+		fmt.Fprintf(&b, "%-*s  %-*s  %s\n",
+			sevWidth, findings[i].Severity, locWidth, locs[i], findings[i].Message)
+	}
+	return b.String()
+}
 
 // mod is a test helper building a ResolvedModule from an import path and a set
 // of argument declarations (no filesystem/network — the manifest is in memory).
@@ -195,3 +223,63 @@ func TestCheckArgumentsHermeticExternalRef(t *testing.T) {
 }
 
 func contains(s, sub string) bool { return strings.Contains(s, sub) }
+
+func TestValidateOnlineRunsOfflineFirst(t *testing.T) {
+	// An offline finding (invalid name, F2) AND an online finding (O3) both appear,
+	// offline first.
+	res, _ := Load(strings.NewReader("name: Bad Name\n"))
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"foo": {Required: true},
+	})}
+	findings := ValidateOnline(res, mods)
+	assert.Assert(t, len(findings) >= 2)
+	assert.Equal(t, "name", findings[0].Path) // offline F2 precedes online O3
+}
+
+func TestValidateOnlineDeterministicOrder(t *testing.T) {
+	// Two modules both require distinct args; output is stable across runs.
+	res, _ := Load(strings.NewReader("name: s\n"))
+	mods := []ResolvedModule{
+		mod("github.com/x/b", map[string]configuration.Argument{"beta": {Required: true}}),
+		mod("github.com/x/a", map[string]configuration.Argument{"alpha": {Required: true}}),
+	}
+	f1 := ValidateOnline(res, mods)
+	f2 := ValidateOnline(res, mods)
+	assert.DeepEqual(t, f1, f2)
+	// sorted by Path: arguments.alpha before arguments.beta
+	assert.Equal(t, "arguments.alpha", f1[0].Path)
+	assert.Equal(t, "arguments.beta", f1[1].Path)
+}
+
+// TestValidateOnlineSnapshot exercises a mix of offline + O3 + O4 findings whose
+// messages are all stencil-owned, so the golden is stable. O2 (jsonschema
+// library-worded) violations are asserted by severity+path in
+// TestValidateOnlineO2SeverityPath, not snapshotted — the manifest package's
+// TestValidateExternalErrors is the precedent.
+func TestValidateOnlineSnapshot(t *testing.T) {
+	// Offline F2 (invalid name) + O3 (required arg missing) + O4 (from: missing dep).
+	res, _ := Load(strings.NewReader("name: Bad Name\n"))
+	mods := []ResolvedModule{
+		mod("github.com/x/a", map[string]configuration.Argument{
+			"needed": {Required: true},
+		}),
+		mod("github.com/x/b", map[string]configuration.Argument{
+			"borrowed": {From: "github.com/x/c"}, // no dep listed → O4
+		}),
+	}
+	cupaloy.SnapshotT(t, renderOnlineFindings(ValidateOnline(res, mods)))
+}
+
+// TestValidateOnlineO2SeverityPath asserts the O2 (schema-violation) finding by
+// severity+path only; its message is jsonschema-library text and must not be
+// snapshotted.
+func TestValidateOnlineO2SeverityPath(t *testing.T) {
+	res, _ := Load(strings.NewReader("name: s\narguments:\n  foo: 123\n"))
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"foo": {Schema: map[string]interface{}{"type": "string"}},
+	})}
+	findings := ValidateOnline(res, mods)
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, lint.SeverityError, findings[0].Severity)
+	assert.Equal(t, "arguments.foo", findings[0].Path)
+}

--- a/internal/lint/projectmanifest/online_test.go
+++ b/internal/lint/projectmanifest/online_test.go
@@ -129,6 +129,31 @@ func TestBuildArgIndexFromUnexposedArgument(t *testing.T) {
 	assert.Equal(t, "arguments.foo", findings[0].Path)
 }
 
+// TestBuildArgIndexOwnerNotAliased guards the pointer-aliasing footgun: each
+// declaration's owner must be its own ResolvedModule, so a from: dependency
+// check reads the correct Modules slice. Module b (arg foo from a, lists a) is
+// fine; module c (arg bar from a, does NOT list a) must produce exactly one O4
+// finding attributed to bar. If owners were aliased to the last module, both
+// would read the same Modules and the O4 result would be wrong.
+func TestBuildArgIndexOwnerNotAliased(t *testing.T) {
+	mods := []ResolvedModule{
+		mod("github.com/x/a", map[string]configuration.Argument{
+			"foo": {Schema: map[string]interface{}{"type": "string"}},
+			"bar": {Schema: map[string]interface{}{"type": "string"}},
+		}),
+		mod("github.com/x/b", map[string]configuration.Argument{
+			"foo": {From: "github.com/x/a"},
+		}, "github.com/x/a"), // lists a
+		mod("github.com/x/c", map[string]configuration.Argument{
+			"bar": {From: "github.com/x/a"},
+		}), // does NOT list a
+	}
+	_, findings := buildArgIndex(mods)
+	// Only c's 'bar' from: should fail (missing dependency listing).
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, "arguments.bar", findings[0].Path)
+}
+
 func TestCheckArgumentsO2Pass(t *testing.T) {
 	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
 		"foo": {Schema: map[string]interface{}{"type": "string"}},

--- a/internal/lint/projectmanifest/online_test.go
+++ b/internal/lint/projectmanifest/online_test.go
@@ -6,10 +6,12 @@
 package projectmanifest
 
 import (
+	"strings"
 	"testing"
 
 	"gotest.tools/v3/assert"
 
+	lint "github.com/getoutreach/stencil/internal/lint"
 	"github.com/getoutreach/stencil/pkg/configuration"
 )
 
@@ -98,3 +100,98 @@ func TestBuildArgIndexFromUnexposedArgument(t *testing.T) {
 	assert.Equal(t, 1, len(findings))
 	assert.Equal(t, "arguments.foo", findings[0].Path)
 }
+
+func TestCheckArgumentsO2Pass(t *testing.T) {
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"foo": {Schema: map[string]interface{}{"type": "string"}},
+	})}
+	idx, _ := buildArgIndex(mods)
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Arguments: map[string]interface{}{"foo": "hello"},
+	}}
+	findings := checkArguments(res, idx)
+	assert.Equal(t, 0, len(findings))
+}
+
+func TestCheckArgumentsO2Violation(t *testing.T) {
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"foo": {Schema: map[string]interface{}{"type": "string"}},
+	})}
+	idx, _ := buildArgIndex(mods)
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Arguments: map[string]interface{}{"foo": 123}, // number, want string
+	}}
+	findings := checkArguments(res, idx)
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, lint.SeverityError, findings[0].Severity)
+	assert.Equal(t, "arguments.foo", findings[0].Path)
+}
+
+func TestCheckArgumentsO3RequiredMissing(t *testing.T) {
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"foo": {Required: true},
+	})}
+	idx, _ := buildArgIndex(mods)
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{Arguments: nil}}
+	findings := checkArguments(res, idx)
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, "arguments.foo", findings[0].Path)
+	assert.Assert(t, contains(findings[0].Message, "required"))
+}
+
+func TestCheckArgumentsO3RequiredSatisfiedByValue(t *testing.T) {
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"foo": {Required: true},
+	})}
+	idx, _ := buildArgIndex(mods)
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Arguments: map[string]interface{}{"foo": "x"},
+	}}
+	assert.Equal(t, 0, len(checkArguments(res, idx)))
+}
+
+func TestCheckArgumentsO3RequiredSatisfiedByDefault(t *testing.T) {
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"foo": {Required: true, Default: "d"},
+	})}
+	idx, _ := buildArgIndex(mods)
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{Arguments: nil}}
+	assert.Equal(t, 0, len(checkArguments(res, idx)))
+}
+
+func TestCheckArgumentsExplicitNullIsNotProvided(t *testing.T) {
+	// foo: null must count as NOT provided → required arg still missing (O3).
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"foo": {Required: true},
+	})}
+	idx, _ := buildArgIndex(mods)
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Arguments: map[string]interface{}{"foo": nil},
+	}}
+	findings := checkArguments(res, idx)
+	assert.Equal(t, 1, len(findings)) // O3 fires
+}
+
+func TestCheckArgumentsOptionalOmittedNoFindings(t *testing.T) {
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"foo": {Schema: map[string]interface{}{"type": "string"}}, // optional
+	})}
+	idx, _ := buildArgIndex(mods)
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{Arguments: nil}}
+	assert.Equal(t, 0, len(checkArguments(res, idx)))
+}
+
+func TestCheckArgumentsHermeticExternalRef(t *testing.T) {
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"foo": {Schema: map[string]interface{}{"$ref": "https://example.com/s.json"}},
+	})}
+	idx, _ := buildArgIndex(mods)
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Arguments: map[string]interface{}{"foo": "x"},
+	}}
+	findings := checkArguments(res, idx)
+	assert.Equal(t, 1, len(findings)) // external $ref rejected → O2 error, no fetch
+	assert.Equal(t, "arguments.foo", findings[0].Path)
+}
+
+func contains(s, sub string) bool { return strings.Contains(s, sub) }

--- a/internal/lint/projectmanifest/online_test.go
+++ b/internal/lint/projectmanifest/online_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Tests for online project-manifest validation (argument index,
+// O2-O4).
+
+package projectmanifest
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/getoutreach/stencil/pkg/configuration"
+)
+
+// mod is a test helper building a ResolvedModule from an import path and a set
+// of argument declarations (no filesystem/network — the manifest is in memory).
+func mod(importPath string, args map[string]configuration.Argument, deps ...string) ResolvedModule {
+	mf := &configuration.TemplateRepositoryManifest{Name: importPath, Arguments: args}
+	for _, d := range deps {
+		mf.Modules = append(mf.Modules, &configuration.TemplateRepository{Name: d})
+	}
+	return ResolvedModule{ImportPath: importPath, Manifest: mf}
+}
+
+func TestBuildArgIndexSimple(t *testing.T) {
+	mods := []ResolvedModule{
+		mod("github.com/x/a", map[string]configuration.Argument{
+			"foo": {Schema: map[string]interface{}{"type": "string"}},
+		}),
+	}
+	idx, findings := buildArgIndex(mods)
+	assert.Equal(t, 0, len(findings))
+	assert.Equal(t, 1, len(idx["foo"]))
+	assert.Equal(t, "github.com/x/a", idx["foo"][0].importPath)
+}
+
+func TestBuildArgIndexFromRedirect(t *testing.T) {
+	// module b's arg 'foo' has from: a; a declares foo; b lists a as a dep.
+	mods := []ResolvedModule{
+		mod("github.com/x/a", map[string]configuration.Argument{
+			"foo": {Schema: map[string]interface{}{"type": "string"}},
+		}),
+		mod("github.com/x/b", map[string]configuration.Argument{
+			"foo": {From: "github.com/x/a"},
+		}, "github.com/x/a"),
+	}
+	idx, findings := buildArgIndex(mods)
+	assert.Equal(t, 0, len(findings))
+	// b's 'foo' resolves to a's declaration (schema present).
+	var bDecl *declaration
+	for i := range idx["foo"] {
+		if idx["foo"][i].importPath == "github.com/x/b" {
+			bDecl = &idx["foo"][i]
+		}
+	}
+	assert.Assert(t, bDecl != nil)
+	assert.Assert(t, len(bDecl.arg.Schema) > 0) // resolved to a's schema
+}
+
+func TestBuildArgIndexFromMissingDependency(t *testing.T) {
+	// b's foo has from: a, but b does NOT list a as a dependency → O4 error.
+	mods := []ResolvedModule{
+		mod("github.com/x/a", map[string]configuration.Argument{
+			"foo": {Schema: map[string]interface{}{"type": "string"}},
+		}),
+		mod("github.com/x/b", map[string]configuration.Argument{
+			"foo": {From: "github.com/x/a"},
+		}), // no deps
+	}
+	_, findings := buildArgIndex(mods)
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, "arguments.foo", findings[0].Path)
+	assert.Assert(t, findings[0].Message != "")
+}
+
+func TestBuildArgIndexFromReferencedModuleAbsent(t *testing.T) {
+	// b's foo has from: c, b lists c as a dep, but c is not in the resolved set.
+	mods := []ResolvedModule{
+		mod("github.com/x/b", map[string]configuration.Argument{
+			"foo": {From: "github.com/x/c"},
+		}, "github.com/x/c"),
+	}
+	_, findings := buildArgIndex(mods)
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, "arguments.foo", findings[0].Path)
+}
+
+func TestBuildArgIndexFromUnexposedArgument(t *testing.T) {
+	// a is present + listed as dep, but a does not declare 'foo'.
+	mods := []ResolvedModule{
+		mod("github.com/x/a", map[string]configuration.Argument{}),
+		mod("github.com/x/b", map[string]configuration.Argument{
+			"foo": {From: "github.com/x/a"},
+		}, "github.com/x/a"),
+	}
+	_, findings := buildArgIndex(mods)
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, "arguments.foo", findings[0].Path)
+}

--- a/internal/lint/projectmanifest/projectmanifest.go
+++ b/internal/lint/projectmanifest/projectmanifest.go
@@ -29,8 +29,7 @@ import (
 // ResolvedModule pairs a resolved module with its already-decoded manifest and
 // its resolved import path. The command layer decodes Manifest(ctx) and passes
 // these in, so the package performs no module resolution itself. Manifest is a
-// per-module pointer: the command layer MUST allocate one manifest per module
-// (Manifest(ctx) returns by value), or every pointer would alias the last one.
+// per-module pointer; each entry must reference its own manifest.
 type ResolvedModule struct {
 	ImportPath string
 	Module     *modules.Module

--- a/internal/lint/projectmanifest/projectmanifest.go
+++ b/internal/lint/projectmanifest/projectmanifest.go
@@ -22,8 +22,20 @@ import (
 	"go.yaml.in/yaml/v3"
 
 	"github.com/getoutreach/stencil/internal/lint"
+	"github.com/getoutreach/stencil/internal/modules"
 	"github.com/getoutreach/stencil/pkg/configuration"
 )
+
+// ResolvedModule pairs a resolved module with its already-decoded manifest and
+// its resolved import path. The command layer decodes Manifest(ctx) and passes
+// these in, so the package performs no module resolution itself. Manifest is a
+// per-module pointer: the command layer MUST allocate one manifest per module
+// (Manifest(ctx) returns by value), or every pointer would alias the last one.
+type ResolvedModule struct {
+	ImportPath string
+	Module     *modules.Module
+	Manifest   *configuration.TemplateRepositoryManifest
+}
 
 // LoadResult holds the outcome of decoding a service.yaml for linting.
 type LoadResult struct {


### PR DESCRIPTION
## What this PR does / why we need it

Extends `stencil lint project-manifest` from offline-only checks to validating a `service.yaml`'s arguments against the modules it uses: schema conformance, required-but-unset arguments, and `from:` references across modules. Problems that previously appeared only as a render-time failure now surface at lint time, attributed to the module that imposed the constraint.

Resolution is online by default; a new `--offline` flag restricts the command to the syntactic checks from the previous PR, and piped stdin input is always treated as offline. When a module set fails to resolve, or a module's manifest can't be read, the command reports an error and skips the argument checks for that run instead of validating against an incomplete set of modules.

## Jira ID

[DT-5396](https://outreach-io.atlassian.net/browse/DT-5396)

## Notes for your reviewers

Stacked on the offline PR (#503), review that first. The online paths are exercised with local module replacements, so the suite never touches the network.

The argument validation reimplements the render-time logic rather than calling into it, because the render path is coupled to template execution and can fetch external schema references over the network, which a linter must not do. One further divergence from render, noted in the code: an explicit `null` argument value is treated as unset.

The aggregate `stencil lint <dir>` runs this phase alongside its existing runners rather than through the shared runner interface, since resolution needs a request context and the offline flag and that interface can't carry either.

[DT-5396]: https://outreach-io.atlassian.net/browse/DT-5396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ