### PR TITLE
feat(lint): flag replacement and cross-module argument problems

### DIFF
--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -954,6 +954,28 @@ func TestProjectManifestOnlinePerModuleManifestFailure(t *testing.T) {
 	assert.Assert(t, err != nil) // O1 modules.<name> error → non-zero
 }
 
+// TestProjectManifestO5UnmatchedReplacement drives O5 end-to-end: a resolved
+// module (via a file:// replacement, so the run is network-free) plus an
+// unmatched replacement key that matches no module in the graph. O5 is a
+// warning; with the default --warnings-as-errors the run exits non-zero.
+//
+// O8 (matched-key local path missing) is intentionally NOT tested at the
+// command level: a matched module whose local replacement path is missing
+// fails module resolution (O1) before O8 runs, so O8 is contradictory
+// end-to-end and is covered at the package level by
+// TestCheckReplacementsMatchedLocalMissingO8.
+func TestProjectManifestO5UnmatchedReplacement(t *testing.T) {
+	modDir := writeLocalModule(t, "name: github.com/x/a\n")
+	dir := t.TempDir()
+	sy := "name: s\nmodules:\n  - name: github.com/x/a\n" +
+		"replacements:\n" +
+		"  github.com/x/a: file://" + modDir + "\n" +
+		"  github.com/x/unused: file://" + modDir + "\n" // matches no module → O5 (warning)
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "service.yaml"), []byte(sy), 0o600))
+	err := runProjectManifest(t, []string{filepath.Join(dir, "service.yaml")}, nil, nil)
+	assert.Assert(t, err != nil)
+}
+
 func TestNewLintCommandHasProjectManifestSubcommand(t *testing.T) {
 	cmd := NewLintCommand()
 	assert.Assert(t, findSubcommand(cmd, "project-manifest") != nil)

--- a/internal/lint/projectmanifest/.snapshots/TestValidateOnlineO5O6O7Snapshot
+++ b/internal/lint/projectmanifest/.snapshots/TestValidateOnlineO5O6O7Snapshot
@@ -1,0 +1,4 @@
+warning  arguments.ghost:0                 no resolved module declares argument "ghost"; check for a typo or remove it
+warning  arguments.shared:0                modules "github.com/x/a" and "github.com/x/b" disagree on the schema for argument "shared"; align their manifests
+warning  replacements.github.com/x/nope:0  replacement for "github.com/x/nope" matches no module in the dependency graph and is ignored; remove it, or correct the import path to a resolved module
+

--- a/internal/lint/projectmanifest/online.go
+++ b/internal/lint/projectmanifest/online.go
@@ -9,9 +9,12 @@ package projectmanifest
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
@@ -79,13 +82,7 @@ func checkReplacements(res *LoadResult, mods []ResolvedModule) []lint.Finding {
 		resolved[m.ImportPath] = struct{}{}
 	}
 
-	keys := make([]string, 0, len(res.Manifest.Replacements))
-	for k := range res.Manifest.Replacements {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	for _, key := range keys {
+	for _, key := range slices.Sorted(maps.Keys(res.Manifest.Replacements)) {
 		value := res.Manifest.Replacements[key]
 		if _, matched := resolved[key]; !matched {
 			// O5: inert replacement key.
@@ -97,7 +94,7 @@ func checkReplacements(res *LoadResult, mods []ResolvedModule) []lint.Finding {
 		// Matched key: O8 checks a local path's existence.
 		if uriIsLocal(value) {
 			path := strings.TrimPrefix(value, "file://")
-			if _, err := os.Stat(path); err != nil {
+			if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 				f.Errorf("replacements."+key,
 					"replacement for %q points at a local path that does not exist: %s; "+
 						"create the path, or correct the replacement", key, path)
@@ -137,13 +134,7 @@ func checkUndeclaredArgs(res *LoadResult, idx map[string][]declaration, mods []R
 		declaredTop[top] = struct{}{}
 	}
 
-	keys := make([]string, 0, len(res.Manifest.Arguments))
-	for k := range res.Manifest.Arguments {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	for _, key := range keys {
+	for _, key := range slices.Sorted(maps.Keys(res.Manifest.Arguments)) {
 		if _, ok := declaredTop[key]; ok {
 			continue // this top-level key is (a prefix of) a declared name
 		}
@@ -170,16 +161,17 @@ func hasDynamicArg(mods []ResolvedModule) bool {
 			if t != "object" {
 				continue
 			}
-			ap, present := arg.Schema["additionalProperties"]
-			// Open object: additionalProperties absent (default true) or explicitly true / a schema.
-			if !present {
-				return true
-			}
-			if b, ok := ap.(bool); ok && b {
-				return true
-			}
-			if _, isSchema := ap.(map[string]interface{}); isSchema {
-				return true
+			// Open object: additionalProperties absent (default true), explicitly
+			// true, a sub-schema, or present-but-null (treated as open).
+			switch ap := arg.Schema["additionalProperties"].(type) {
+			case nil:
+				return true // key absent, or present-but-null → open
+			case bool:
+				if ap {
+					return true // additionalProperties: true → open
+				}
+			case map[string]interface{}:
+				return true // additionalProperties is a sub-schema → open
 			}
 		}
 	}
@@ -286,13 +278,7 @@ func resolveFrom(f *lint.Findings, mods []ResolvedModule, owner ResolvedModule,
 // both schemas still drive O2. Arg names processed in sorted order.
 func checkSchemaConflicts(idx map[string][]declaration) []lint.Finding {
 	var f lint.Findings
-	names := make([]string, 0, len(idx))
-	for name := range idx {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
+	for _, name := range slices.Sorted(maps.Keys(idx)) {
 		decls := idx[name]
 		if len(decls) < 2 {
 			continue
@@ -319,30 +305,26 @@ func checkSchemaConflicts(idx map[string][]declaration) []lint.Finding {
 }
 
 // schemaEquivalent reports whether two argument schemas are byte-equal after a
-// deterministic (sorted-key) JSON marshal. A nil schema and an empty schema are
-// both treated as "no schema" and are equivalent to each other. This is a
-// conservative comparison: a cosmetic difference (e.g. an added description)
-// counts as non-equivalent, which is acceptable for a warning.
+// JSON marshal. encoding/json sorts map keys recursively and preserves slice
+// order, so the marshaled bytes are canonical and the comparison is
+// order-insensitive for keys. A nil schema and an empty schema are both treated
+// as "no schema" and are equivalent to each other. This is a conservative
+// comparison: a cosmetic difference (e.g. an added description) counts as
+// non-equivalent, which is acceptable for a warning.
 func schemaEquivalent(a, b map[string]interface{}) bool {
 	aEmpty, bEmpty := len(a) == 0, len(b) == 0
 	if aEmpty || bEmpty {
 		return aEmpty && bEmpty
 	}
-	ab, err := marshalSorted(a)
+	ab, err := json.Marshal(a)
 	if err != nil {
 		return false
 	}
-	bb, err := marshalSorted(b)
+	bb, err := json.Marshal(b)
 	if err != nil {
 		return false
 	}
 	return bytes.Equal(ab, bb)
-}
-
-// marshalSorted JSON-marshals v with map keys sorted (encoding/json already
-// sorts map keys), returning canonical bytes for comparison.
-func marshalSorted(v map[string]interface{}) ([]byte, error) {
-	return json.Marshal(v)
 }
 
 // checkArguments implements O2 (value vs schema) and O3 (required). For each

--- a/internal/lint/projectmanifest/online.go
+++ b/internal/lint/projectmanifest/online.go
@@ -11,7 +11,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sort"
+	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v5"
 
@@ -52,6 +54,57 @@ func sortOnline(findings []lint.Finding) {
 		}
 		return findings[i].Message < findings[j].Message
 	})
+}
+
+// uriIsLocal reports whether a replacement value is a local path (no scheme, or
+// a file:// URL), mirroring internal/modules' unexported uriIsLocal. Reimplemented
+// here to avoid exporting it from the modules package.
+func uriIsLocal(uri string) bool {
+	return !strings.Contains(uri, "://") || strings.HasPrefix(uri, "file://")
+}
+
+// checkReplacements implements O5 (a replacement key matching no resolved module
+// is inert → warning) and O8 (a replacement key that DOES match a resolved
+// module, whose value is a local path that does not exist → error). Remote
+// values on matched keys are not checked (a bad remote surfaces as O1). The two
+// checks share the matched-key computation and are the only replacement checks;
+// offline says nothing about replacements. Keys are processed in sorted order.
+func checkReplacements(res *LoadResult, mods []ResolvedModule) []lint.Finding {
+	var f lint.Findings
+	if res.Manifest == nil || len(res.Manifest.Replacements) == 0 {
+		return f.Items()
+	}
+	resolved := make(map[string]struct{}, len(mods))
+	for _, m := range mods {
+		resolved[m.ImportPath] = struct{}{}
+	}
+
+	keys := make([]string, 0, len(res.Manifest.Replacements))
+	for k := range res.Manifest.Replacements {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		value := res.Manifest.Replacements[key]
+		if _, matched := resolved[key]; !matched {
+			// O5: inert replacement key.
+			f.Warnf("replacements."+key,
+				"replacement for %q matches no module in the dependency graph and is "+
+					"ignored; remove it, or correct the import path to a resolved module", key)
+			continue
+		}
+		// Matched key: O8 checks a local path's existence.
+		if uriIsLocal(value) {
+			path := strings.TrimPrefix(value, "file://")
+			if _, err := os.Stat(path); err != nil {
+				f.Errorf("replacements."+key,
+					"replacement for %q points at a local path that does not exist: %s; "+
+						"create the path, or correct the replacement", key, path)
+			}
+		}
+	}
+	return f.Items()
 }
 
 // declaration is one module's declaration of an argument (post-from:), retained

--- a/internal/lint/projectmanifest/online.go
+++ b/internal/lint/projectmanifest/online.go
@@ -107,6 +107,85 @@ func checkReplacements(res *LoadResult, mods []ResolvedModule) []lint.Finding {
 	return f.Items()
 }
 
+// checkUndeclaredArgs implements O7: a service.yaml argument whose key matches no
+// declared argument (from the index) is flagged as likely a typo/leftover. It is
+// suppressed entirely when any resolved module declares a dynamic/catch-all
+// argument, since then an "undeclared" key may be legitimately consumed. Matching
+// is at top-level-key granularity: a provided top-level key is undeclared iff no
+// declared name has it as its first (dot-separated) segment, so a dotted declared
+// name (e.g. aws.IRSA) matches a correctly-nested value. Provided arg keys are
+// processed in sorted order.
+func checkUndeclaredArgs(res *LoadResult, idx map[string][]declaration, mods []ResolvedModule) []lint.Finding {
+	var f lint.Findings
+	if res.Manifest == nil || len(res.Manifest.Arguments) == 0 {
+		return f.Items()
+	}
+	if hasDynamicArg(mods) {
+		return f.Items() // carve-out: catch-all arg present → suppress O7
+	}
+
+	// Build the set of top-level service.yaml keys and check each against the
+	// declared set. A provided top-level key is undeclared iff NO declared name
+	// resolves into it. Since declared names may be dotted (nested), we check
+	// whether any declared name has this top-level key as its first segment.
+	declaredTop := map[string]struct{}{}
+	for name := range idx {
+		top := name
+		if i := strings.IndexByte(name, '.'); i >= 0 {
+			top = name[:i]
+		}
+		declaredTop[top] = struct{}{}
+	}
+
+	keys := make([]string, 0, len(res.Manifest.Arguments))
+	for k := range res.Manifest.Arguments {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if _, ok := declaredTop[key]; ok {
+			continue // this top-level key is (a prefix of) a declared name
+		}
+		f.Warnf("arguments."+key,
+			"no resolved module declares argument %q; check for a typo or remove it", key)
+	}
+	return f.Items()
+}
+
+// hasDynamicArg reports whether any resolved module declares a catch-all argument
+// — a schema that is an open object (type object with additionalProperties not
+// disabled). Such a module may legitimately consume otherwise-undeclared keys, so
+// O7 is suppressed when one is present.
+func hasDynamicArg(mods []ResolvedModule) bool {
+	for _, m := range mods {
+		if m.Manifest == nil {
+			continue
+		}
+		for _, arg := range m.Manifest.Arguments {
+			if len(arg.Schema) == 0 {
+				continue
+			}
+			t, _ := arg.Schema["type"].(string)
+			if t != "object" {
+				continue
+			}
+			ap, present := arg.Schema["additionalProperties"]
+			// Open object: additionalProperties absent (default true) or explicitly true / a schema.
+			if !present {
+				return true
+			}
+			if b, ok := ap.(bool); ok && b {
+				return true
+			}
+			if _, isSchema := ap.(map[string]interface{}); isSchema {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // declaration is one module's declaration of an argument (post-from:), retained
 // with the declaring module's import path (identity for messages/ordering) and
 // its owning manifest (owner.Modules drives the O4 dependency-listing check).

--- a/internal/lint/projectmanifest/online.go
+++ b/internal/lint/projectmanifest/online.go
@@ -201,6 +201,71 @@ func resolveFrom(f *lint.Findings, mods []ResolvedModule, owner ResolvedModule,
 	return refArg, true
 }
 
+// checkSchemaConflicts implements O6: for each argument name declared by 2+
+// modules with NON-equivalent schemas, emit one warning naming the first two
+// declarations (in sorted import-path order) whose schemas differ. Never fatal;
+// both schemas still drive O2. Arg names processed in sorted order.
+func checkSchemaConflicts(idx map[string][]declaration) []lint.Finding {
+	var f lint.Findings
+	names := make([]string, 0, len(idx))
+	for name := range idx {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		decls := idx[name]
+		if len(decls) < 2 {
+			continue
+		}
+		// Sort declarations by import path for a deterministic "first two disagreeing".
+		sorted := make([]declaration, len(decls))
+		copy(sorted, decls)
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i].importPath < sorted[j].importPath })
+
+		found := false
+		for i := 0; i < len(sorted) && !found; i++ {
+			for j := i + 1; j < len(sorted); j++ {
+				if !schemaEquivalent(sorted[i].arg.Schema, sorted[j].arg.Schema) {
+					f.Warnf("arguments."+name,
+						"modules %q and %q disagree on the schema for argument %q; "+
+							"align their manifests", sorted[i].importPath, sorted[j].importPath, name)
+					found = true
+					break
+				}
+			}
+		}
+	}
+	return f.Items()
+}
+
+// schemaEquivalent reports whether two argument schemas are byte-equal after a
+// deterministic (sorted-key) JSON marshal. A nil schema and an empty schema are
+// both treated as "no schema" and are equivalent to each other. This is a
+// conservative comparison: a cosmetic difference (e.g. an added description)
+// counts as non-equivalent, which is acceptable for a warning.
+func schemaEquivalent(a, b map[string]interface{}) bool {
+	aEmpty, bEmpty := len(a) == 0, len(b) == 0
+	if aEmpty || bEmpty {
+		return aEmpty && bEmpty
+	}
+	ab, err := marshalSorted(a)
+	if err != nil {
+		return false
+	}
+	bb, err := marshalSorted(b)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(ab, bb)
+}
+
+// marshalSorted JSON-marshals v with map keys sorted (encoding/json already
+// sorts map keys), returning canonical bytes for comparison.
+func marshalSorted(v map[string]interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
 // checkArguments implements O2 (value vs schema) and O3 (required). For each
 // argument name in the index (sorted), it locates the provided value in the
 // service.yaml arguments and validates it against EACH declaration's schema,

--- a/internal/lint/projectmanifest/online.go
+++ b/internal/lint/projectmanifest/online.go
@@ -23,21 +23,22 @@ import (
 )
 
 // ValidateOnline runs the offline checks (Validate) then appends the online
-// argument checks (O2–O4) against the already-resolved modules, in a
+// argument checks (O2–O8) against the already-resolved modules, in a
 // deterministic total order (offline findings first; online sorted by Path,
-// then declaring-module import path, then check ID). It executes no templates
-// and performs no module resolution — the command layer resolves each module's
-// Manifest(ctx) and passes it in via ResolvedModule. O1 (resolution / per-module
-// manifest failure) is produced by the command layer, so this is only reached
-// on a fully-resolved module set. PR 3b appends O5–O8.
+// then message). It executes no templates and performs no module resolution —
+// the command layer resolves each module's Manifest(ctx) and passes it in via
+// ResolvedModule. O1 (resolution / per-module manifest failure) is produced by
+// the command layer, so this is only reached on a fully-resolved module set.
 func ValidateOnline(res *LoadResult, mods []ResolvedModule) []lint.Finding {
 	offline := Validate(res)
 
 	idx, o4 := buildArgIndex(mods)
-	o2o3 := checkArguments(res, idx)
-	online := make([]lint.Finding, 0, len(o4)+len(o2o3))
-	online = append(online, o4...)
-	online = append(online, o2o3...)
+	var online []lint.Finding
+	online = append(online, o4...)                                  // O4
+	online = append(online, checkArguments(res, idx)...)            // O2, O3
+	online = append(online, checkReplacements(res, mods)...)        // O5, O8
+	online = append(online, checkSchemaConflicts(idx)...)           // O6
+	online = append(online, checkUndeclaredArgs(res, idx, mods)...) // O7
 	sortOnline(online)
 
 	return append(offline, online...)

--- a/internal/lint/projectmanifest/online.go
+++ b/internal/lint/projectmanifest/online.go
@@ -44,10 +44,9 @@ func ValidateOnline(res *LoadResult, mods []ResolvedModule) []lint.Finding {
 	return append(offline, online...)
 }
 
-// sortOnline sorts online findings by Path, then by the module import path
-// embedded in the message where present (a stable secondary key). Since
-// O2/O3/O4 all key on arguments.<name>, Path ordering plus the message tie-break
-// is deterministic.
+// sortOnline sorts online findings by Path, then Message (a stable secondary
+// key). Since O2/O3/O4 all key on arguments.<name>, Path ordering plus the
+// Message tie-break is deterministic.
 func sortOnline(findings []lint.Finding) {
 	sort.SliceStable(findings, func(i, j int) bool {
 		if findings[i].Path != findings[j].Path {

--- a/internal/lint/projectmanifest/online_test.go
+++ b/internal/lint/projectmanifest/online_test.go
@@ -391,6 +391,23 @@ func TestValidateOnlineIncludesO5throughO8(t *testing.T) {
 	assert.Assert(t, haveO7, "expected O7 undeclared-arg finding")
 }
 
+// TestValidateOnlineO5O6O7Snapshot exercises O5 (unmatched replacement key),
+// O6 (schema conflict between modules a and b on 'shared'), and O7 (undeclared
+// arg 'ghost') together, plus the offline 'name' finding. Every message is
+// stencil-owned (no jsonschema-library text — O2 is intentionally not
+// triggered), so the golden is stable.
+func TestValidateOnlineO5O6O7Snapshot(t *testing.T) {
+	res, _ := Load(strings.NewReader(
+		"name: s\narguments:\n  ghost: x\nreplacements:\n  github.com/x/nope: https://x\n"))
+	mods := []ResolvedModule{
+		mod("github.com/x/a", map[string]configuration.Argument{
+			"shared": {Schema: map[string]interface{}{"type": "string"}}}),
+		mod("github.com/x/b", map[string]configuration.Argument{
+			"shared": {Schema: map[string]interface{}{"type": "integer"}}}),
+	}
+	cupaloy.SnapshotT(t, renderOnlineFindings(ValidateOnline(res, mods)))
+}
+
 func TestCheckUndeclaredArgsFlagsUnknown(t *testing.T) {
 	idx := map[string][]declaration{"known": {{importPath: "github.com/x/a"}}}
 	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{

--- a/internal/lint/projectmanifest/online_test.go
+++ b/internal/lint/projectmanifest/online_test.go
@@ -369,6 +369,47 @@ func TestValidateOnlineO2SeverityPath(t *testing.T) {
 	assert.Equal(t, "arguments.foo", findings[0].Path)
 }
 
+func TestCheckUndeclaredArgsFlagsUnknown(t *testing.T) {
+	idx := map[string][]declaration{"known": {{importPath: "github.com/x/a"}}}
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"known": {},
+	})}
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Arguments: map[string]interface{}{"known": "v", "typo": "v"},
+	}}
+	findings := checkUndeclaredArgs(res, idx, mods)
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, lint.SeverityWarning, findings[0].Severity)
+	assert.Equal(t, "arguments.typo", findings[0].Path)
+}
+
+func TestCheckUndeclaredArgsDottedNameMatches(t *testing.T) {
+	// declared name aws.IRSA; provided as nested aws: {IRSA: ...} → NOT undeclared.
+	idx := map[string][]declaration{"aws.IRSA": {{importPath: "github.com/x/a"}}}
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"aws.IRSA": {},
+	})}
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Arguments: map[string]interface{}{
+			"aws": map[string]interface{}{"IRSA": true},
+		},
+	}}
+	assert.Equal(t, 0, len(checkUndeclaredArgs(res, idx, mods)))
+}
+
+func TestCheckUndeclaredArgsCarveOutSuppressesAll(t *testing.T) {
+	// a module declares a catch-all arg (open object) → O7 suppressed entirely.
+	idx := map[string][]declaration{"catchall": {{importPath: "github.com/x/a"}}}
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"catchall": {Schema: map[string]interface{}{
+			"type": "object", "additionalProperties": true}},
+	})}
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Arguments: map[string]interface{}{"anything": "v"},
+	}}
+	assert.Equal(t, 0, len(checkUndeclaredArgs(res, idx, mods)))
+}
+
 func TestCheckReplacementsUnmatchedKeyO5(t *testing.T) {
 	mods := []ResolvedModule{mod("github.com/x/a", nil)}
 	res := &LoadResult{Manifest: &configuration.ServiceManifest{

--- a/internal/lint/projectmanifest/online_test.go
+++ b/internal/lint/projectmanifest/online_test.go
@@ -449,6 +449,21 @@ func TestCheckUndeclaredArgsCarveOutSuppressesAll(t *testing.T) {
 	assert.Equal(t, 0, len(checkUndeclaredArgs(res, idx, mods)))
 }
 
+// TestCheckUndeclaredArgsCarveOutNullAdditionalProperties pins that an object
+// schema with additionalProperties present-but-null is treated as an open
+// (catch-all) object, so O7 is suppressed — the same as absent/true/sub-schema.
+func TestCheckUndeclaredArgsCarveOutNullAdditionalProperties(t *testing.T) {
+	idx := map[string][]declaration{"catchall": {{importPath: "github.com/x/a"}}}
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"catchall": {Schema: map[string]interface{}{
+			"type": "object", "additionalProperties": nil}},
+	})}
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Arguments: map[string]interface{}{"anything": "v"},
+	}}
+	assert.Equal(t, 0, len(checkUndeclaredArgs(res, idx, mods)))
+}
+
 func TestCheckReplacementsUnmatchedKeyO5(t *testing.T) {
 	mods := []ResolvedModule{mod("github.com/x/a", nil)}
 	res := &LoadResult{Manifest: &configuration.ServiceManifest{

--- a/internal/lint/projectmanifest/online_test.go
+++ b/internal/lint/projectmanifest/online_test.go
@@ -369,6 +369,28 @@ func TestValidateOnlineO2SeverityPath(t *testing.T) {
 	assert.Equal(t, "arguments.foo", findings[0].Path)
 }
 
+func TestValidateOnlineIncludesO5throughO8(t *testing.T) {
+	// One module resolved; service.yaml has an undeclared arg (O7) and an
+	// unmatched replacement key (O5). Both appear alongside offline findings.
+	res, _ := Load(strings.NewReader(
+		"name: s\narguments:\n  typo: x\nreplacements:\n  github.com/x/nope: file:///w\n"))
+	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{
+		"known": {},
+	})}
+	findings := ValidateOnline(res, mods)
+	var haveO5, haveO7 bool
+	for _, f := range findings {
+		if f.Path == "replacements.github.com/x/nope" {
+			haveO5 = true
+		}
+		if f.Path == "arguments.typo" {
+			haveO7 = true
+		}
+	}
+	assert.Assert(t, haveO5, "expected O5 unmatched-replacement finding")
+	assert.Assert(t, haveO7, "expected O7 undeclared-arg finding")
+}
+
 func TestCheckUndeclaredArgsFlagsUnknown(t *testing.T) {
 	idx := map[string][]declaration{"known": {{importPath: "github.com/x/a"}}}
 	mods := []ResolvedModule{mod("github.com/x/a", map[string]configuration.Argument{

--- a/internal/lint/projectmanifest/online_test.go
+++ b/internal/lint/projectmanifest/online_test.go
@@ -249,6 +249,66 @@ func TestCheckArgumentsHermeticExternalRef(t *testing.T) {
 
 func contains(s, sub string) bool { return strings.Contains(s, sub) }
 
+func TestCheckSchemaConflictsNoneWhenEquivalent(t *testing.T) {
+	// Two modules declare foo with the same schema (different key order) → no O6.
+	idx := map[string][]declaration{
+		"foo": {
+			{importPath: "github.com/x/a", arg: configuration.Argument{
+				Schema: map[string]interface{}{"type": "string", "minLength": 1}}},
+			{importPath: "github.com/x/b", arg: configuration.Argument{
+				Schema: map[string]interface{}{"minLength": 1, "type": "string"}}},
+		},
+	}
+	assert.Equal(t, 0, len(checkSchemaConflicts(idx)))
+}
+
+func TestCheckSchemaConflictsWarnsWhenDifferent(t *testing.T) {
+	idx := map[string][]declaration{
+		"foo": {
+			{importPath: "github.com/x/a", arg: configuration.Argument{
+				Schema: map[string]interface{}{"type": "string"}}},
+			{importPath: "github.com/x/b", arg: configuration.Argument{
+				Schema: map[string]interface{}{"type": "integer"}}},
+		},
+	}
+	findings := checkSchemaConflicts(idx)
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, lint.SeverityWarning, findings[0].Severity)
+	assert.Equal(t, "arguments.foo", findings[0].Path)
+	// names the two disagreeing modules (sorted import-path order: a before b)
+	assert.Assert(t, contains(findings[0].Message, "github.com/x/a"))
+	assert.Assert(t, contains(findings[0].Message, "github.com/x/b"))
+}
+
+func TestCheckSchemaConflictsOnePerArgForThreeModules(t *testing.T) {
+	// a≡b, c differs → exactly one O6 naming the first two disagreeing (a, c).
+	idx := map[string][]declaration{
+		"foo": {
+			{importPath: "github.com/x/a", arg: configuration.Argument{
+				Schema: map[string]interface{}{"type": "string"}}},
+			{importPath: "github.com/x/b", arg: configuration.Argument{
+				Schema: map[string]interface{}{"type": "string"}}},
+			{importPath: "github.com/x/c", arg: configuration.Argument{
+				Schema: map[string]interface{}{"type": "integer"}}},
+		},
+	}
+	findings := checkSchemaConflicts(idx)
+	assert.Equal(t, 1, len(findings))
+	assert.Assert(t, contains(findings[0].Message, "github.com/x/a"))
+	assert.Assert(t, contains(findings[0].Message, "github.com/x/c"))
+}
+
+func TestCheckSchemaConflictsNilVsEmptyEquivalent(t *testing.T) {
+	idx := map[string][]declaration{
+		"foo": {
+			{importPath: "github.com/x/a", arg: configuration.Argument{Schema: nil}},
+			{importPath: "github.com/x/b", arg: configuration.Argument{
+				Schema: map[string]interface{}{}}},
+		},
+	}
+	assert.Equal(t, 0, len(checkSchemaConflicts(idx))) // both "no schema" → equivalent
+}
+
 func TestValidateOnlineRunsOfflineFirst(t *testing.T) {
 	// An offline finding (invalid name, F2) AND an online finding (O3) both appear,
 	// offline first.

--- a/internal/lint/projectmanifest/online_test.go
+++ b/internal/lint/projectmanifest/online_test.go
@@ -308,3 +308,54 @@ func TestValidateOnlineO2SeverityPath(t *testing.T) {
 	assert.Equal(t, lint.SeverityError, findings[0].Severity)
 	assert.Equal(t, "arguments.foo", findings[0].Path)
 }
+
+func TestCheckReplacementsUnmatchedKeyO5(t *testing.T) {
+	mods := []ResolvedModule{mod("github.com/x/a", nil)}
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Replacements: map[string]string{"github.com/x/nope": "file:///wherever"},
+	}}
+	findings := checkReplacements(res, mods)
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, lint.SeverityWarning, findings[0].Severity)
+	assert.Equal(t, "replacements.github.com/x/nope", findings[0].Path)
+}
+
+func TestCheckReplacementsMatchedLocalMissingO8(t *testing.T) {
+	mods := []ResolvedModule{mod("github.com/x/a", nil)}
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Replacements: map[string]string{"github.com/x/a": "file:///does/not/exist/xyz"},
+	}}
+	findings := checkReplacements(res, mods)
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, lint.SeverityError, findings[0].Severity) // O8
+	assert.Equal(t, "replacements.github.com/x/a", findings[0].Path)
+}
+
+func TestCheckReplacementsMatchedLocalExistsNoFinding(t *testing.T) {
+	dir := t.TempDir()
+	mods := []ResolvedModule{mod("github.com/x/a", nil)}
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Replacements: map[string]string{"github.com/x/a": "file://" + dir},
+	}}
+	assert.Equal(t, 0, len(checkReplacements(res, mods)))
+}
+
+func TestCheckReplacementsMatchedRemoteNotChecked(t *testing.T) {
+	mods := []ResolvedModule{mod("github.com/x/a", nil)}
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Replacements: map[string]string{"github.com/x/a": "https://github.com/x/a"},
+	}}
+	// matched key + remote value: neither O5 (matched) nor O8 (not local) → nothing.
+	assert.Equal(t, 0, len(checkReplacements(res, mods)))
+}
+
+func TestCheckReplacementsBareLocalPath(t *testing.T) {
+	// a bare path (no scheme) is local; missing → O8.
+	mods := []ResolvedModule{mod("github.com/x/a", nil)}
+	res := &LoadResult{Manifest: &configuration.ServiceManifest{
+		Replacements: map[string]string{"github.com/x/a": "./nope-does-not-exist-xyz"},
+	}}
+	findings := checkReplacements(res, mods)
+	assert.Equal(t, 1, len(findings))
+	assert.Equal(t, lint.SeverityError, findings[0].Severity)
+}


### PR DESCRIPTION
## What this PR does / why we need it

Adds four online checks to `stencil lint project-manifest`. Two cover `replacements`: a key that matches no module in the dependency graph is reported as inert, and a key that does match a module but points at a local path that doesn't exist is reported as an error. The other two cover arguments across modules: an argument provided in `service.yaml` that no resolved module declares is flagged as a likely typo, and two modules declaring the same argument with conflicting schemas are flagged so the mismatch can be reconciled.

All four are warnings except the missing-replacement-path case, which is an error. The undeclared-argument check is suppressed when a module declares a catch-all argument, since such a module can legitimately consume keys it doesn't name.

## Jira ID

[DT-5396](https://outreach-io.atlassian.net/browse/DT-5396)

## Notes for your reviewers

Stacked on the online-core PR ([#504](https://github.com/getoutreach/stencil/pull/504)); review that first. The checks are additive: they append to the existing online findings and leave the previous PR's resolution and argument-value logic unchanged.

The undeclared-argument check matches at the top level. A dotted declared name such as `aws.IRSA`, provided as a nested `aws:` object, is not flagged; a mistyped nested key under a valid top-level key is left to schema validation rather than reported here. That per-leaf case is noted in the code as future work.

The missing-local-replacement-path check has no command-level test because the scenario can't be reached end to end: a matched module whose replacement path is missing fails resolution before this check runs. It is covered by package tests that supply resolved modules directly.

[DT-5396]: https://outreach-io.atlassian.net/browse/DT-5396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ