### PR TITLE
feat(lint): add `--fix` to `stencil lint project-manifest`

### DIFF
--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -356,6 +356,52 @@ func failTemplates(log logrus.FieldLogger, findings []lint.Finding, warningsAsEr
 	return failLint(log, "templates are", findings, warningsAsErrors)
 }
 
+// runLintAggregateFix fixes a module's manifest.yaml, template files, and
+// service.yaml in place (each skipped when absent), then logs and applies the
+// warnings-as-errors policy to whatever findings survive. It mirrors the
+// non-fix aggregate runner order: manifest, templates, then service.yaml.
+func runLintAggregateFix(ctx context.Context, c *cli.Command, log logrus.FieldLogger, dir string) error {
+	var all []lint.Finding
+
+	fixPath, finding, err := resolveManifestPath(filepath.Join(dir, "manifest.yaml"))
+	if err != nil {
+		return errors.Wrap(err, "lint failed")
+	}
+	if finding == nil {
+		raw, readErr := os.ReadFile(fixPath) // path was cleaned inside resolveManifestPath.
+		if readErr != nil {
+			return errors.Wrapf(readErr, "failed to read %q", fixPath)
+		}
+		findings, fixErr := fixManifestBytes(log, fixPath, raw, writeFixedFile(fixPath, raw))
+		if fixErr != nil {
+			return errors.Wrap(fixErr, "lint failed")
+		}
+		all = append(all, findings...)
+	}
+	// A missing manifest is skipped, not fixed: aggregate lint treats it as
+	// "nothing to lint" (a module may be templates-only), matching the
+	// non-fix aggregate path and manifestRunner.
+
+	files, err := collectTemplateFiles(log, filepath.Join(dir, templatesDir))
+	if err != nil {
+		return errors.Wrap(err, "lint failed")
+	}
+	findings, err := fixTemplateFiles(log, files)
+	if err != nil {
+		return errors.Wrap(err, "lint failed")
+	}
+	all = append(all, findings...)
+
+	pf, err := fixServiceYaml(ctx, log, filepath.Join(dir, "service.yaml"), c.Bool("offline"))
+	if err != nil {
+		return err
+	}
+	all = append(all, pf...)
+
+	logFindings(log, all)
+	return failLint(log, fmt.Sprintf("module %q is", dir), all, c.Bool("warnings-as-errors"))
+}
+
 // runLintAggregate is the `stencil lint [dir]` action.
 func runLintAggregate(ctx context.Context, c *cli.Command) error {
 	if c.Args().Len() > 1 {
@@ -388,45 +434,7 @@ func runLintAggregate(ctx context.Context, c *cli.Command) error {
 	}
 
 	if c.Bool("fix") {
-		var all []lint.Finding
-
-		fixPath, finding, err := resolveManifestPath(filepath.Join(dir, "manifest.yaml"))
-		if err != nil {
-			return errors.Wrap(err, "lint failed")
-		}
-		if finding == nil {
-			raw, readErr := os.ReadFile(fixPath) // path was cleaned inside resolveManifestPath.
-			if readErr != nil {
-				return errors.Wrapf(readErr, "failed to read %q", fixPath)
-			}
-			findings, fixErr := fixManifestBytes(log, fixPath, raw, writeFixedFile(fixPath, raw))
-			if fixErr != nil {
-				return errors.Wrap(fixErr, "lint failed")
-			}
-			all = append(all, findings...)
-		}
-		// A missing manifest is skipped, not fixed: aggregate lint treats it as
-		// "nothing to lint" (a module may be templates-only), matching the
-		// non-fix aggregate path and manifestRunner.
-
-		files, err := collectTemplateFiles(log, filepath.Join(dir, templatesDir))
-		if err != nil {
-			return errors.Wrap(err, "lint failed")
-		}
-		findings, err := fixTemplateFiles(log, files)
-		if err != nil {
-			return errors.Wrap(err, "lint failed")
-		}
-		all = append(all, findings...)
-
-		pf, err := fixServiceYaml(ctx, log, filepath.Join(dir, "service.yaml"), c.Bool("offline"))
-		if err != nil {
-			return err
-		}
-		all = append(all, pf...)
-
-		logFindings(log, all)
-		return failLint(log, fmt.Sprintf("module %q is", dir), all, c.Bool("warnings-as-errors"))
+		return runLintAggregateFix(ctx, c, log, dir)
 	}
 
 	runners := []runner{

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/getoutreach/stencil/internal/lint"
 	lintmanifest "github.com/getoutreach/stencil/internal/lint/manifest"
+	"github.com/getoutreach/stencil/internal/lint/modulefix"
 	lintprojectmanifest "github.com/getoutreach/stencil/internal/lint/projectmanifest"
 	linttemplates "github.com/getoutreach/stencil/internal/lint/templates"
 	"github.com/getoutreach/stencil/internal/modules"
@@ -465,18 +466,36 @@ func runLintAggregate(ctx context.Context, c *cli.Command) error {
 	return failIfFindings(all, c.Bool("warnings-as-errors"))
 }
 
-// lintServiceYaml runs the out-of-band online project-manifest phase for the
-// aggregate action. A missing service.yaml is skipped (nil, nil) so a module
-// without one is "nothing to lint". Errors are already wrapped with "lint
-// failed".
-func lintServiceYaml(ctx context.Context, log logrus.FieldLogger,
-	sp string, offline bool) ([]lint.Finding, error) {
+// readServiceYamlOrSkip reads service.yaml at sp for the aggregate action. It
+// reports skip=true when the file is absent, so a module without one is
+// "nothing to lint". A stat error other than absence (e.g. a permission
+// failure) is surfaced rather than silently skipped, so it is not mistaken for
+// "nothing to lint". Returned errors are already wrapped.
+func readServiceYamlOrSkip(sp string) (raw []byte, skip bool, err error) {
 	if _, statErr := os.Stat(sp); statErr != nil {
-		return nil, nil // missing service.yaml is skipped
+		if os.IsNotExist(statErr) {
+			return nil, true, nil // missing service.yaml is skipped
+		}
+		return nil, false, errors.Wrapf(statErr, "failed to stat %q", sp)
 	}
 	raw, readErr := os.ReadFile(sp)
 	if readErr != nil {
-		return nil, errors.Wrapf(readErr, "failed to read %q", sp)
+		return nil, false, errors.Wrapf(readErr, "failed to read %q", sp)
+	}
+	return raw, false, nil
+}
+
+// lintServiceYaml runs the out-of-band online project-manifest phase for the
+// aggregate action. A missing service.yaml is skipped (nil, nil) so a module
+// without one is "nothing to lint".
+func lintServiceYaml(ctx context.Context, log logrus.FieldLogger,
+	sp string, offline bool) ([]lint.Finding, error) {
+	raw, skip, err := readServiceYamlOrSkip(sp)
+	if err != nil {
+		return nil, err
+	}
+	if skip {
+		return nil, nil
 	}
 	pf, err := runProjectManifestReaderOnline(ctx, log, sp, bytes.NewReader(raw), offline)
 	if err != nil {
@@ -491,12 +510,12 @@ func lintServiceYaml(ctx context.Context, log logrus.FieldLogger,
 // lintServiceYaml and the non-fix aggregate path.
 func fixServiceYaml(ctx context.Context, log logrus.FieldLogger,
 	sp string, offline bool) ([]lint.Finding, error) {
-	if _, statErr := os.Stat(sp); statErr != nil {
-		return nil, nil // missing service.yaml is skipped
+	raw, skip, err := readServiceYamlOrSkip(sp)
+	if err != nil {
+		return nil, err
 	}
-	raw, readErr := os.ReadFile(sp)
-	if readErr != nil {
-		return nil, errors.Wrapf(readErr, "failed to read %q", sp)
+	if skip {
+		return nil, nil
 	}
 	findings, err := fixProjectManifestBytes(ctx, log, sp, raw, offline, writeFixedFile(sp, raw))
 	if err != nil {
@@ -929,8 +948,9 @@ func failProjectManifest(log logrus.FieldLogger, name string, findings []lint.Fi
 	return failLint(log, fmt.Sprintf("service manifest %q is", name), findings, warningsAsErrors)
 }
 
-// logApplied logs one info line per fix the fixer applied.
-func logApplied(log logrus.FieldLogger, applied []lintmanifest.Applied) {
+// logApplied logs one info line per fix a module fixer applied. It takes the
+// shared modulefix.Applied so it serves every fixer, not just the manifest one.
+func logApplied(log logrus.FieldLogger, applied []modulefix.Applied) {
 	for _, a := range applied {
 		logFixed(log, a.Path, a.Message, nil)
 	}

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -419,6 +419,12 @@ func runLintAggregate(ctx context.Context, c *cli.Command) error {
 		}
 		all = append(all, findings...)
 
+		pf, err := fixServiceYaml(ctx, log, filepath.Join(dir, "service.yaml"), c.Bool("offline"))
+		if err != nil {
+			return err
+		}
+		all = append(all, pf...)
+
 		logFindings(log, all)
 		return failLint(log, fmt.Sprintf("module %q is", dir), all, c.Bool("warnings-as-errors"))
 	}
@@ -469,6 +475,26 @@ func lintServiceYaml(ctx context.Context, log logrus.FieldLogger,
 		return nil, errors.Wrap(err, "lint failed")
 	}
 	return pf, nil
+}
+
+// fixServiceYaml is the aggregate --fix counterpart to lintServiceYaml: it
+// migrates a module's service.yaml in place (if present) and returns the
+// post-fix findings. A missing service.yaml is skipped (nil, nil), matching
+// lintServiceYaml and the non-fix aggregate path.
+func fixServiceYaml(ctx context.Context, log logrus.FieldLogger,
+	sp string, offline bool) ([]lint.Finding, error) {
+	if _, statErr := os.Stat(sp); statErr != nil {
+		return nil, nil // missing service.yaml is skipped
+	}
+	raw, readErr := os.ReadFile(sp)
+	if readErr != nil {
+		return nil, errors.Wrapf(readErr, "failed to read %q", sp)
+	}
+	findings, err := fixProjectManifestBytes(ctx, log, sp, raw, offline, writeFixedFile(sp, raw))
+	if err != nil {
+		return nil, errors.Wrap(err, "lint failed")
+	}
+	return findings, nil
 }
 
 // runLintModuleManifest is the `stencil lint module-manifest [path]` action.

--- a/cmd/stencil/lint.go
+++ b/cmd/stencil/lint.go
@@ -682,7 +682,7 @@ func newLintProjectManifestCommand() *cli.Command {
 		Usage:       "Validate a project's service.yaml without resolving dependencies",
 		ArgsUsage:   "[path]",
 		Description: "Validate a single project manifest (service.yaml; defaults to ./service.yaml). Use '-' to read from stdin.",
-		Flags:       []cli.Flag{warningsAsErrorsFlag(), offlineFlag()},
+		Flags:       []cli.Flag{warningsAsErrorsFlag(), offlineFlag(), fixFlag()},
 		Action:      runLintProjectManifest,
 	}
 }
@@ -703,6 +703,18 @@ func runLintProjectManifest(ctx context.Context, c *cli.Command) error {
 		}
 		// stdin has no on-disk module context to resolve against, so reading
 		// from '-' forces offline.
+		if c.Bool("fix") {
+			raw, rerr := io.ReadAll(c.Reader)
+			if rerr != nil {
+				return errors.Wrap(rerr, "failed to read stdin")
+			}
+			// stdin forces offline; fixed YAML to stdout, diagnostics to stderr.
+			return fixAndRelintProjectManifest(ctx, c, log, stdinName, raw, true,
+				func(fixed []byte) error {
+					_, werr := c.Writer.Write(fixed)
+					return werr
+				})
+		}
 		findings, err := runProjectManifestReaderOnline(ctx, log, stdinName, c.Reader, true)
 		if err != nil {
 			return errors.Wrap(err, "lint failed")
@@ -714,6 +726,23 @@ func runLintProjectManifest(ctx context.Context, c *cli.Command) error {
 	path := "./service.yaml"
 	if c.Args().Len() == 1 {
 		path = c.Args().First()
+	}
+	if c.Bool("fix") {
+		fixPath, finding, err := resolveProjectManifestPath(path)
+		if err != nil {
+			return errors.Wrap(err, "lint failed")
+		}
+		if finding != nil {
+			logFindings(log, []lint.Finding{*finding})
+			return failProjectManifest(log, fixPath, []lint.Finding{*finding},
+				c.Bool("warnings-as-errors"))
+		}
+		raw, readErr := os.ReadFile(fixPath)
+		if readErr != nil {
+			return errors.Wrapf(readErr, "failed to read %q", fixPath)
+		}
+		return fixAndRelintProjectManifest(ctx, c, log, fixPath, raw, offline,
+			writeFixedFile(fixPath, raw))
 	}
 	r, closer, finding, err := resolveProjectManifestReader(path)
 	if err != nil {
@@ -781,6 +810,60 @@ func resolveAndValidateProjectManifest(ctx context.Context, log logrus.FieldLogg
 		})
 	}
 	return lintprojectmanifest.ValidateOnline(res, resolved)
+}
+
+// resolveProjectManifestPath resolves path to the service.yaml to fix. A
+// directory arg has "service.yaml" appended; a missing file yields a
+// not-found finding (not an error), mirroring resolveManifestPath.
+func resolveProjectManifestPath(path string) (resolved string, finding *lint.Finding, err error) {
+	path = filepath.Clean(path)
+	info, statErr := os.Stat(path)
+	if statErr == nil && info.IsDir() {
+		path = filepath.Join(path, "service.yaml")
+		_, statErr = os.Stat(path)
+	}
+	if statErr != nil {
+		if os.IsNotExist(statErr) {
+			return path, &lint.Finding{
+				Severity: lint.SeverityError,
+				Path:     path,
+				Message:  fmt.Sprintf("service manifest file not found: %s", path),
+			}, nil
+		}
+		return path, nil, errors.Wrapf(statErr, "failed to stat %q", path)
+	}
+	return path, nil, nil
+}
+
+// fixProjectManifestBytes applies the project-manifest fixes to raw, writes the
+// fixed bytes via writeFixed, logs each applied fix, and returns the findings
+// from re-linting the fixed content in the ambient mode (online unless offline).
+// If raw cannot be parsed as YAML, fixing is skipped and the original bytes are
+// linted instead, so the decode error surfaces as a normal finding. Mirrors
+// fixManifestBytes but threads ctx + offline for the online re-lint.
+func fixProjectManifestBytes(ctx context.Context, log logrus.FieldLogger, name string,
+	raw []byte, offline bool, writeFixed func([]byte) error) ([]lint.Finding, error) {
+	fixed, applied, ok := lintprojectmanifest.FixBytes(raw)
+	if !ok {
+		return runProjectManifestReaderOnline(ctx, log, name, bytes.NewReader(raw), offline)
+	}
+	if err := writeFixed(fixed); err != nil {
+		return nil, errors.Wrap(err, "failed to write fixed service manifest")
+	}
+	logApplied(log, applied)
+	return runProjectManifestReaderOnline(ctx, log, name, bytes.NewReader(fixed), offline)
+}
+
+// fixAndRelintProjectManifest wraps fixProjectManifestBytes with logging and the
+// warnings-as-errors policy, mirroring fixAndRelint.
+func fixAndRelintProjectManifest(ctx context.Context, c *cli.Command, log logrus.FieldLogger,
+	name string, raw []byte, offline bool, writeFixed func([]byte) error) error {
+	findings, err := fixProjectManifestBytes(ctx, log, name, raw, offline, writeFixed)
+	if err != nil {
+		return errors.Wrap(err, "lint failed")
+	}
+	logFindings(log, findings)
+	return failProjectManifest(log, name, findings, c.Bool("warnings-as-errors"))
 }
 
 // resolveProjectManifestReader resolves path to a service.yaml reader, appending

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -822,6 +822,33 @@ func TestRunLintAggregateFixTemplatesUnfixableFails(t *testing.T) {
 	assert.Assert(t, strings.Contains(err.Error(), "lint failed"))
 }
 
+// TestRunLintAggregateFixMigratesServiceYaml proves aggregate --fix also
+// migrates a module's service.yaml, keeping runner order (manifest, templates,
+// then service.yaml). The module is a file:// replacement so the post-fix
+// online re-lint stays network-free.
+func TestRunLintAggregateFixMigratesServiceYaml(t *testing.T) {
+	modDir := writeLocalModule(t, "name: github.com/x/a\n")
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "manifest.yaml"),
+		[]byte("name: m\n"), 0o600))
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "templates"), 0o750))
+	sy := "name: s\n" +
+		"modules:\n  - name: github.com/x/a\n    prerelease: true\n" +
+		"replacements:\n  github.com/x/a: file://" + modDir + "\n"
+	sp := filepath.Join(dir, "service.yaml")
+	assert.NilError(t, os.WriteFile(sp, []byte(sy), 0o600))
+
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	err := root.Run(context.Background(), []string{"lint", "--fix", dir})
+	assert.NilError(t, err) // only finding was a fixable warning → exit 0 after fix
+
+	out, _ := os.ReadFile(sp)
+	assert.Assert(t, strings.Contains(string(out), "channel: rc"),
+		"aggregate --fix should migrate service.yaml, got:\n%s", string(out))
+	assert.Assert(t, !strings.Contains(string(out), "prerelease"))
+}
+
 // runProjectManifest runs `lint project-manifest [args...]`, feeding stdin/stdout
 // on the subcommand. Mirrors runModuleManifest.
 func runProjectManifest(t *testing.T, args []string, stdin io.Reader, stdout io.Writer) error {

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -1034,3 +1034,56 @@ func TestAggregateMissingServiceYamlIsNoOp(t *testing.T) {
 	err := root.Run(context.Background(), []string{"lint", dir})
 	assert.NilError(t, err) // nothing to lint → success
 }
+
+// runProjectManifestFix runs `lint project-manifest --fix [args...]`, wiring
+// optional stdin/stdout onto the subcommand like runProjectManifest does.
+func runProjectManifestFix(t *testing.T, args []string, stdin io.Reader, stdout io.Writer) error {
+	t.Helper()
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	sub := findSubcommand(root, "project-manifest")
+	assert.Assert(t, sub != nil, "project-manifest subcommand must exist")
+	if stdout != nil {
+		sub.Writer = stdout
+	}
+	if stdin != nil {
+		sub.Reader = stdin
+	}
+	full := append([]string{"lint", "project-manifest", "--fix"}, args...)
+	return root.Run(context.Background(), full)
+}
+
+func TestProjectManifestFixInPlace(t *testing.T) {
+	modDir := writeLocalModule(t, "name: github.com/x/a\n")
+	dir := t.TempDir()
+	sy := "name: s\n" +
+		"modules:\n  - name: github.com/x/a\n    prerelease: true\n" +
+		"replacements:\n  github.com/x/a: file://" + modDir + "\n"
+	p := filepath.Join(dir, "service.yaml")
+	assert.NilError(t, os.WriteFile(p, []byte(sy), 0o600))
+	err := runProjectManifestFix(t, []string{p}, nil, nil)
+	assert.NilError(t, err) // only finding was a fixable warning -> exit 0 after fix
+	out, _ := os.ReadFile(p)
+	assert.Assert(t, strings.Contains(string(out), "channel: rc"))
+	assert.Assert(t, !strings.Contains(string(out), "prerelease"))
+}
+
+func TestProjectManifestFixStdinFilter(t *testing.T) {
+	var stdout bytes.Buffer
+	in := "name: s\nmodules:\n  - name: github.com/x/a\n    prerelease: true\n"
+	// stdin forces offline; fixed YAML goes to stdout.
+	err := runProjectManifestFix(t, []string{"-"}, strings.NewReader(in), &stdout)
+	assert.NilError(t, err)
+	assert.Assert(t, strings.Contains(stdout.String(), "channel: rc"))
+}
+
+func TestProjectManifestFixNoOpDoesNotRewrite(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "service.yaml")
+	assert.NilError(t, os.WriteFile(p, []byte("name: s\n"), 0o600))
+	info1, _ := os.Stat(p)
+	err := runProjectManifestFix(t, []string{"--offline", p}, nil, nil)
+	assert.NilError(t, err)
+	info2, _ := os.Stat(p)
+	assert.Equal(t, info1.ModTime(), info2.ModTime()) // no change -> not rewritten
+}

--- a/cmd/stencil/lint_test.go
+++ b/cmd/stencil/lint_test.go
@@ -1114,3 +1114,39 @@ func TestProjectManifestFixNoOpDoesNotRewrite(t *testing.T) {
 	info2, _ := os.Stat(p)
 	assert.Equal(t, info1.ModTime(), info2.ModTime()) // no change -> not rewritten
 }
+
+// TestProjectManifestFixNotFound proves --fix on a missing service.yaml emits
+// the not-found finding and fails, rather than erroring on a raw stat failure.
+func TestProjectManifestFixNotFound(t *testing.T) {
+	dir := t.TempDir()
+	err := runProjectManifestFix(t, []string{"--offline", filepath.Join(dir, "service.yaml")}, nil, nil)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, strings.Contains(err.Error(), "lint failed"))
+}
+
+// TestProjectManifestFixMalformedFallsBack proves --fix on unparseable YAML
+// skips fixing and re-lints the original bytes, so the decode error surfaces as
+// a finding (and fails the run) instead of a fix-time crash.
+func TestProjectManifestFixMalformedFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "service.yaml")
+	assert.NilError(t, os.WriteFile(p, []byte("name: [unterminated\n"), 0o600))
+	err := runProjectManifestFix(t, []string{"--offline", p}, nil, nil)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, strings.Contains(err.Error(), "lint failed"))
+}
+
+// TestRunLintAggregateFixMissingServiceYaml proves aggregate --fix treats an
+// absent service.yaml as nothing to lint (skipped, not an error), matching the
+// non-fix aggregate path.
+func TestRunLintAggregateFixMissingServiceYaml(t *testing.T) {
+	dir := t.TempDir()
+	assert.NilError(t, os.WriteFile(filepath.Join(dir, "manifest.yaml"),
+		[]byte("name: m\n"), 0o600))
+	assert.NilError(t, os.MkdirAll(filepath.Join(dir, "templates"), 0o750))
+
+	root := NewLintCommand()
+	root.Writer = io.Discard
+	err := root.Run(context.Background(), []string{"lint", "--fix", dir})
+	assert.NilError(t, err) // no service.yaml -> skipped, nothing fails
+}

--- a/docs/content/en/commands/stencil_lint_project-manifest.md
+++ b/docs/content/en/commands/stencil_lint_project-manifest.md
@@ -23,6 +23,7 @@ DESCRIPTION:
 OPTIONS:
    --warnings-as-errors  treat warnings as errors (fail on any finding)
    --offline             skip module resolution; run only offline syntactic checks
+   --fix                 automatically fix safe deprecations in place (a manifest is re-encoded at 2-space indent when fixed; re-lints after fixing)
    --help, -h            show help
 
 GLOBAL OPTIONS:

--- a/internal/lint/manifest/fix.go
+++ b/internal/lint/manifest/fix.go
@@ -11,16 +11,14 @@ import (
 	"bytes"
 	"sort"
 
+	"github.com/getoutreach/stencil/internal/lint/modulefix"
 	"github.com/getoutreach/stencil/internal/lint/yamlfix"
 	"go.yaml.in/yaml/v3"
 )
 
-// Applied records one fix the fixer made, for logging. Path mirrors the
-// corresponding lint.Finding.Path (e.g. "arguments.x.type").
-type Applied struct {
-	Path    string
-	Message string
-}
+// Applied records one fix the fixer made, for logging. Aliased to the shared
+// modulefix.Applied so both linters and the command layer log fixes uniformly.
+type Applied = modulefix.Applied
 
 // scalarsEqual reports whether a and b are both scalar nodes with equal values.
 func scalarsEqual(a, b *yaml.Node) bool {
@@ -143,45 +141,6 @@ func fixArgValues(argName string, arg *yaml.Node, applied *[]Applied) {
 	})
 }
 
-// fixModulePrerelease migrates a deprecated module `prerelease` field. A true
-// value becomes `channel: rc`, unless `channel` is already set, in which case
-// `channel` is preserved and `prerelease` is just dropped; a false value is
-// simply removed as a redundant default.
-func fixModulePrerelease(modPath string, mod *yaml.Node, applied *[]Applied) {
-	i := yamlfix.FindKey(mod, "prerelease")
-	if i < 0 {
-		return
-	}
-	val := mod.Content[i+1]
-	if val.Kind != yaml.ScalarNode {
-		return
-	}
-	switch val.Value {
-	case "true":
-		srcKey := mod.Content[i] // capture before removeKey
-		yamlfix.RemoveKey(mod, "prerelease")
-		if yamlfix.SetIfAbsent(mod, "channel",
-			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "rc"}) {
-			yamlfix.CarryKeyComments(mod, "channel", srcKey)
-			*applied = append(*applied, Applied{
-				Path:    modPath + ".prerelease",
-				Message: "migrated 'prerelease: true' to 'channel: rc'",
-			})
-		} else {
-			*applied = append(*applied, Applied{
-				Path:    modPath + ".prerelease",
-				Message: "removed deprecated 'prerelease' (channel already set)",
-			})
-		}
-	case "false":
-		yamlfix.RemoveKey(mod, "prerelease")
-		*applied = append(*applied, Applied{
-			Path:    modPath + ".prerelease",
-			Message: "removed redundant 'prerelease: false'",
-		})
-	}
-}
-
 // Fix applies the safe deprecation migrations to the manifest document node in
 // place and returns the list of changes made. doc is the *yaml.Node from
 // yaml.Unmarshal (a DocumentNode wrapping a MappingNode). It never returns an
@@ -199,7 +158,7 @@ func Fix(doc *yaml.Node) []Applied {
 
 	var applied []Applied
 	fixArguments(root, &applied)
-	fixModules(root, &applied)
+	applied = append(applied, modulefix.FixModules(root)...)
 	return applied
 }
 
@@ -233,35 +192,6 @@ func fixArguments(root *yaml.Node, applied *[]Applied) {
 		fixArgType(name, arg, applied)
 		fixArgValues(name, arg, applied)
 	}
-}
-
-// fixModules applies module migrations in slice order.
-func fixModules(root *yaml.Node, applied *[]Applied) {
-	mi := yamlfix.FindKey(root, "modules")
-	if mi < 0 {
-		return
-	}
-	modules := root.Content[mi+1]
-	if modules.Kind != yaml.SequenceNode {
-		return
-	}
-	for i, raw := range modules.Content {
-		mod := yamlfix.Deref(raw)
-		if mod.Kind != yaml.MappingNode {
-			continue
-		}
-		fixModulePrerelease(moduleFixPath(mod, i), mod, applied)
-	}
-}
-
-// moduleFixPath builds the finding path for module i, preferring its name, by
-// delegating to the checker's shared moduleIDPath formatter.
-func moduleFixPath(mod *yaml.Node, i int) string {
-	name := ""
-	if ni := yamlfix.FindKey(mod, "name"); ni >= 0 {
-		name = mod.Content[ni+1].Value
-	}
-	return moduleIDPath(name, i)
 }
 
 // FixBytes decodes raw as a YAML node, applies the safe deprecation migrations,

--- a/internal/lint/manifest/fix_test.go
+++ b/internal/lint/manifest/fix_test.go
@@ -99,11 +99,11 @@ func encode(t *testing.T, doc *yaml.Node) string {
 }
 
 // fixString decodes in, runs Fix, and returns the re-encoded YAML plus applied.
-func fixString(t *testing.T, in string) (string, []Applied) {
+func fixString(t *testing.T, in string) (fixed string, applied []Applied) {
 	t.Helper()
 	var doc yaml.Node
 	assert.NilError(t, yaml.Unmarshal([]byte(in), &doc))
-	applied := Fix(&doc)
+	applied = Fix(&doc)
 	return encode(t, &doc), applied
 }
 

--- a/internal/lint/manifest/fix_test.go
+++ b/internal/lint/manifest/fix_test.go
@@ -88,36 +88,6 @@ func TestFixArgValuesMovesIntoSchemaEnum(t *testing.T) {
 	assert.Equal(t, 1, len(applied))
 }
 
-func TestFixModulePrereleaseTrueAddsChannel(t *testing.T) {
-	mod := mappingFrom(t, "name: m\nprerelease: true\n")
-	var applied []Applied
-	fixModulePrerelease("modules.m", mod, &applied)
-
-	assert.Assert(t, yamlfix.FindKey(mod, "prerelease") == -1)
-	assert.Equal(t, "rc", mod.Content[yamlfix.FindKey(mod, "channel")+1].Value)
-	assert.Equal(t, 1, len(applied))
-}
-
-func TestFixModulePrereleaseKeepsExistingChannel(t *testing.T) {
-	mod := mappingFrom(t, "name: m\nchannel: stable\nprerelease: true\n")
-	var applied []Applied
-	fixModulePrerelease("modules.m", mod, &applied)
-
-	assert.Assert(t, yamlfix.FindKey(mod, "prerelease") == -1)
-	assert.Equal(t, "stable", mod.Content[yamlfix.FindKey(mod, "channel")+1].Value) // not overwritten
-	assert.Equal(t, 1, len(applied))
-}
-
-func TestFixModulePrereleaseFalseDropped(t *testing.T) {
-	mod := mappingFrom(t, "name: m\nprerelease: false\n")
-	var applied []Applied
-	fixModulePrerelease("modules.m", mod, &applied)
-
-	assert.Assert(t, yamlfix.FindKey(mod, "prerelease") == -1)
-	assert.Assert(t, yamlfix.FindKey(mod, "channel") == -1) // false is just removed
-	assert.Equal(t, 1, len(applied))
-}
-
 func encode(t *testing.T, doc *yaml.Node) string {
 	t.Helper()
 	var sb strings.Builder
@@ -255,24 +225,6 @@ func TestFixConservativeSkips(t *testing.T) {
 		fixArgType("x", arg, &applied)
 
 		assert.Assert(t, yamlfix.FindKey(arg, "type") >= 0) // left in place
-		assert.Equal(t, 0, len(applied))
-	})
-
-	t.Run("sequence prerelease left alone", func(t *testing.T) {
-		mod := mappingFrom(t, "name: m\nprerelease: [x]\n")
-		var applied []Applied
-		fixModulePrerelease("modules.m", mod, &applied)
-
-		assert.Assert(t, yamlfix.FindKey(mod, "prerelease") >= 0) // left in place
-		assert.Equal(t, 0, len(applied))
-	})
-
-	t.Run("non-bool scalar prerelease left alone", func(t *testing.T) {
-		mod := mappingFrom(t, "name: m\nprerelease: maybe\n")
-		var applied []Applied
-		fixModulePrerelease("modules.m", mod, &applied)
-
-		assert.Assert(t, yamlfix.FindKey(mod, "prerelease") >= 0) // left in place
 		assert.Equal(t, 0, len(applied))
 	})
 }

--- a/internal/lint/manifest/manifest.go
+++ b/internal/lint/manifest/manifest.go
@@ -226,8 +226,8 @@ func checkModules(f *lint.Findings, mf *configuration.TemplateRepositoryManifest
 }
 
 // moduleIDPath builds the finding path for module i, preferring its name over
-// its slice index. Shared by the checker (modulePath) and the fixer
-// (moduleFixPath) so their finding paths stay identical.
+// its slice index. Kept identical to modulefix.ModulePath so the checker's and
+// the fixer's finding paths stay in sync.
 func moduleIDPath(name string, i int) string {
 	if name != "" {
 		return "modules." + name

--- a/internal/lint/manifest/manifest.go
+++ b/internal/lint/manifest/manifest.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"io"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -24,6 +23,7 @@ import (
 	"go.yaml.in/yaml/v3"
 
 	"github.com/getoutreach/stencil/internal/lint"
+	"github.com/getoutreach/stencil/internal/lint/modulefix"
 	"github.com/getoutreach/stencil/pkg/configuration"
 )
 
@@ -226,13 +226,10 @@ func checkModules(f *lint.Findings, mf *configuration.TemplateRepositoryManifest
 }
 
 // moduleIDPath builds the finding path for module i, preferring its name over
-// its slice index. Kept identical to modulefix.ModulePath so the checker's and
-// the fixer's finding paths stay in sync.
+// its slice index. Delegates to modulefix.ModulePath so the checker and the
+// fixer produce identical paths from a single implementation.
 func moduleIDPath(name string, i int) string {
-	if name != "" {
-		return "modules." + name
-	}
-	return "modules[" + strconv.Itoa(i) + "]"
+	return modulefix.ModulePath(name, i)
 }
 
 // modulePath builds the finding path for module i, preferring its name.

--- a/internal/lint/modulefix/modulefix.go
+++ b/internal/lint/modulefix/modulefix.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Shared, comment-preserving auto-fix for deprecated module fields
+// in a Stencil manifest's or project's modules: list. Both service.yaml and
+// manifest.yaml use the same module DOM (name / prerelease / channel), so this
+// migration is shared.
+
+// Package modulefix implements the shared module-deprecation auto-fix used by
+// both the manifest and project-manifest linters.
+package modulefix
+
+import (
+	"strconv"
+
+	"go.yaml.in/yaml/v3"
+
+	"github.com/getoutreach/stencil/internal/lint/yamlfix"
+)
+
+// Applied records one fix the fixer made, for logging. Path mirrors the
+// corresponding lint.Finding.Path (e.g. "modules.<name>.prerelease").
+type Applied struct {
+	Path    string
+	Message string
+}
+
+// FixModules walks the modules: sequence in root (a manifest/service root
+// mapping node) and applies the safe module-field migrations in place, returning
+// what it changed. A missing or non-sequence modules: key is a no-op.
+func FixModules(root *yaml.Node) []Applied {
+	var applied []Applied
+	mi := yamlfix.FindKey(root, "modules")
+	if mi < 0 {
+		return applied
+	}
+	modules := root.Content[mi+1]
+	if modules.Kind != yaml.SequenceNode {
+		return applied
+	}
+	for i, raw := range modules.Content {
+		mod := yamlfix.Deref(raw)
+		if mod.Kind != yaml.MappingNode {
+			continue
+		}
+		fixModulePrerelease(modulePathFor(mod, i), mod, &applied)
+	}
+	return applied
+}
+
+// modulePathFor builds the finding path for module i, preferring its name.
+func modulePathFor(mod *yaml.Node, i int) string {
+	name := ""
+	if ni := yamlfix.FindKey(mod, "name"); ni >= 0 {
+		name = mod.Content[ni+1].Value
+	}
+	return ModulePath(name, i)
+}
+
+// ModulePath builds the finding path for module i, preferring its name over its
+// slice index. Shared so the checker and fixer produce identical paths.
+func ModulePath(name string, i int) string {
+	if name != "" {
+		return "modules." + name
+	}
+	return "modules[" + strconv.Itoa(i) + "]"
+}
+
+// fixModulePrerelease migrates a deprecated module prerelease field. A true
+// value becomes channel: rc, unless channel is already set, in which case
+// channel is preserved and prerelease is just dropped; a false value is simply
+// removed as a redundant default.
+func fixModulePrerelease(modPath string, mod *yaml.Node, applied *[]Applied) {
+	i := yamlfix.FindKey(mod, "prerelease")
+	if i < 0 {
+		return
+	}
+	val := mod.Content[i+1]
+	if val.Kind != yaml.ScalarNode {
+		return
+	}
+	switch val.Value {
+	case "true":
+		srcKey := mod.Content[i] // capture before RemoveKey
+		yamlfix.RemoveKey(mod, "prerelease")
+		if yamlfix.SetIfAbsent(mod, "channel",
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "rc"}) {
+			yamlfix.CarryKeyComments(mod, "channel", srcKey)
+			*applied = append(*applied, Applied{
+				Path:    modPath + ".prerelease",
+				Message: "migrated 'prerelease: true' to 'channel: rc'",
+			})
+		} else {
+			*applied = append(*applied, Applied{
+				Path:    modPath + ".prerelease",
+				Message: "removed deprecated 'prerelease' (channel already set)",
+			})
+		}
+	case "false":
+		yamlfix.RemoveKey(mod, "prerelease")
+		*applied = append(*applied, Applied{
+			Path:    modPath + ".prerelease",
+			Message: "removed redundant 'prerelease: false'",
+		})
+	}
+}

--- a/internal/lint/modulefix/modulefix_test.go
+++ b/internal/lint/modulefix/modulefix_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Tests for the shared module-deprecation fixer.
+
+package modulefix_test
+
+import (
+	"testing"
+
+	"go.yaml.in/yaml/v3"
+	"gotest.tools/v3/assert"
+
+	"github.com/getoutreach/stencil/internal/lint/modulefix"
+	"github.com/getoutreach/stencil/internal/lint/yamlfix"
+)
+
+func mappingFrom(t *testing.T, in string) *yaml.Node {
+	t.Helper()
+	var doc yaml.Node
+	assert.NilError(t, yaml.Unmarshal([]byte(in), &doc))
+	assert.Assert(t, len(doc.Content) == 1)
+	return doc.Content[0]
+}
+
+func TestFixModulesPrereleaseTrueAddsChannel(t *testing.T) {
+	root := mappingFrom(t, "modules:\n  - name: dep\n    prerelease: true\n")
+	applied := modulefix.FixModules(root)
+	assert.Equal(t, 1, len(applied))
+	mods := root.Content[yamlfix.FindKey(root, "modules")+1]
+	mod := mods.Content[0]
+	assert.Equal(t, -1, yamlfix.FindKey(mod, "prerelease"))
+	assert.Equal(t, "rc", mod.Content[yamlfix.FindKey(mod, "channel")+1].Value)
+}
+
+func TestFixModulesPrereleaseKeepsExistingChannel(t *testing.T) {
+	root := mappingFrom(t, "modules:\n  - name: dep\n    channel: stable\n    prerelease: true\n")
+	applied := modulefix.FixModules(root)
+	assert.Equal(t, 1, len(applied))
+	mods := root.Content[yamlfix.FindKey(root, "modules")+1]
+	mod := mods.Content[0]
+	assert.Equal(t, "stable", mod.Content[yamlfix.FindKey(mod, "channel")+1].Value)
+	assert.Equal(t, -1, yamlfix.FindKey(mod, "prerelease"))
+}
+
+func TestFixModulesPrereleaseFalseDropped(t *testing.T) {
+	root := mappingFrom(t, "modules:\n  - name: dep\n    prerelease: false\n")
+	applied := modulefix.FixModules(root)
+	assert.Equal(t, 1, len(applied))
+	mods := root.Content[yamlfix.FindKey(root, "modules")+1]
+	mod := mods.Content[0]
+	assert.Equal(t, -1, yamlfix.FindKey(mod, "prerelease"))
+	assert.Equal(t, -1, yamlfix.FindKey(mod, "channel"))
+}
+
+func TestFixModulesNoModulesNoOp(t *testing.T) {
+	root := mappingFrom(t, "name: x\n")
+	assert.Equal(t, 0, len(modulefix.FixModules(root)))
+}
+
+func TestFixModulesPathByIndexWhenNoName(t *testing.T) {
+	root := mappingFrom(t, "modules:\n  - prerelease: true\n")
+	applied := modulefix.FixModules(root)
+	assert.Equal(t, 1, len(applied))
+	assert.Equal(t, "modules[0].prerelease", applied[0].Path)
+}
+
+func TestModulePath(t *testing.T) {
+	assert.Equal(t, "modules.github.com/x/y", modulefix.ModulePath("github.com/x/y", 0))
+	assert.Equal(t, "modules[2]", modulefix.ModulePath("", 2))
+}
+
+// TestFixModulesConservativeSkips verifies the fixer leaves prerelease untouched
+// when it is not a recognized boolean scalar, so an unexpected shape is reported
+// by the linter rather than silently rewritten.
+func TestFixModulesConservativeSkips(t *testing.T) {
+	t.Run("sequence prerelease left alone", func(t *testing.T) {
+		root := mappingFrom(t, "modules:\n  - name: m\n    prerelease: [x]\n")
+		applied := modulefix.FixModules(root)
+		mods := root.Content[yamlfix.FindKey(root, "modules")+1]
+		mod := mods.Content[0]
+		assert.Assert(t, yamlfix.FindKey(mod, "prerelease") >= 0) // left in place
+		assert.Equal(t, 0, len(applied))
+	})
+
+	t.Run("non-bool scalar prerelease left alone", func(t *testing.T) {
+		root := mappingFrom(t, "modules:\n  - name: m\n    prerelease: maybe\n")
+		applied := modulefix.FixModules(root)
+		mods := root.Content[yamlfix.FindKey(root, "modules")+1]
+		mod := mods.Content[0]
+		assert.Assert(t, yamlfix.FindKey(mod, "prerelease") >= 0) // left in place
+		assert.Equal(t, 0, len(applied))
+	})
+}

--- a/internal/lint/projectmanifest/fix.go
+++ b/internal/lint/projectmanifest/fix.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Implements safe, comment-preserving auto-fixes for a Stencil
+// project manifest (service.yaml). The only migration is the shared module
+// prerelease -> channel fix; service.yaml has no per-argument schema to migrate.
+
+package projectmanifest
+
+import (
+	"bytes"
+
+	"go.yaml.in/yaml/v3"
+
+	"github.com/getoutreach/stencil/internal/lint/modulefix"
+)
+
+// Applied records one fix the fixer made, for logging. Aliased to the shared
+// modulefix.Applied so the command layer can log manifest and project-manifest
+// fixes uniformly.
+type Applied = modulefix.Applied
+
+// FixBytes decodes raw, applies the shared module-prerelease migration, and
+// re-encodes at 2-space indent. ok is false only when raw cannot be decoded as
+// YAML, in which case the caller should skip fixing and run the normal lint
+// (which reports the decode error). A valid document with no modules: sequence
+// (or nothing to fix) is a no-op that returns raw verbatim with ok true, so a
+// no-op --fix never reformats the file. Mirrors manifest.FixBytes.
+func FixBytes(raw []byte) (fixed []byte, applied []Applied, ok bool) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, nil, false
+	}
+	if len(doc.Content) == 0 {
+		return raw, nil, true
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return raw, nil, true
+	}
+	applied = modulefix.FixModules(root)
+	if len(applied) == 0 {
+		return raw, nil, true
+	}
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&doc); err != nil {
+		return nil, nil, false
+	}
+	if err := enc.Close(); err != nil {
+		return nil, nil, false
+	}
+	return buf.Bytes(), applied, true
+}

--- a/internal/lint/projectmanifest/fix_test.go
+++ b/internal/lint/projectmanifest/fix_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Outreach Corporation. Licensed under the Apache License 2.0.
+
+// Description: Tests for the project manifest (service.yaml) auto-fixer.
+
+package projectmanifest_test
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	projectmanifest "github.com/getoutreach/stencil/internal/lint/projectmanifest"
+)
+
+func TestFixBytesPrereleaseTrue(t *testing.T) {
+	in := "name: s\nmodules:\n  - name: github.com/x/a\n    prerelease: true\n"
+	fixed, applied, ok := projectmanifest.FixBytes([]byte(in))
+	assert.Equal(t, true, ok)
+	assert.Equal(t, 1, len(applied))
+	s := string(fixed)
+	assert.Assert(t, strings.Contains(s, "channel: rc"))
+	assert.Assert(t, !strings.Contains(s, "prerelease"))
+}
+
+func TestFixBytesPrereleaseFalseRemoved(t *testing.T) {
+	in := "name: s\nmodules:\n  - name: github.com/x/a\n    prerelease: false\n"
+	fixed, applied, ok := projectmanifest.FixBytes([]byte(in))
+	assert.Equal(t, true, ok)
+	assert.Equal(t, 1, len(applied))
+	assert.Assert(t, !strings.Contains(string(fixed), "prerelease"))
+}
+
+func TestFixBytesKeepsExistingChannel(t *testing.T) {
+	in := "name: s\nmodules:\n  - name: github.com/x/a\n    channel: stable\n    prerelease: true\n"
+	fixed, applied, ok := projectmanifest.FixBytes([]byte(in))
+	assert.Equal(t, true, ok)
+	assert.Equal(t, 1, len(applied))
+	assert.Assert(t, strings.Contains(string(fixed), "channel: stable"))
+	assert.Assert(t, !strings.Contains(string(fixed), "prerelease"))
+}
+
+func TestFixBytesNoModulesNoOp(t *testing.T) {
+	in := "name: s\narguments:\n  foo: bar\n"
+	fixed, applied, ok := projectmanifest.FixBytes([]byte(in))
+	assert.Equal(t, true, ok)
+	assert.Equal(t, 0, len(applied))
+	assert.Equal(t, in, string(fixed)) // no-op returns raw verbatim
+}
+
+func TestFixBytesMalformed(t *testing.T) {
+	_, _, ok := projectmanifest.FixBytes([]byte("name: [unterminated\n"))
+	assert.Equal(t, false, ok)
+}
+
+func TestFixBytesPreservesSurroundingComments(t *testing.T) {
+	// A head comment on the module and an unrelated key survive the migration.
+	in := "name: s\nmodules:\n  # our core dep\n  - name: github.com/x/a\n    channel: rc\n    prerelease: false\n"
+	fixed, _, ok := projectmanifest.FixBytes([]byte(in))
+	assert.Equal(t, true, ok)
+	s := string(fixed)
+	assert.Assert(t, strings.Contains(s, "# our core dep"))
+	assert.Assert(t, strings.Contains(s, "channel: rc"))
+	assert.Assert(t, !strings.Contains(s, "prerelease"))
+}


### PR DESCRIPTION
## What this PR does / why we need it

`stencil lint project-manifest` already warns when a `service.yaml` module uses the deprecated `prerelease` field and points users at `--fix`, but the subcommand didn't yet accept that flag. This wires it up: `--fix` migrates `prerelease: true` to `channel: rc` (preserving an existing `channel`) and drops the redundant `prerelease: false`, editing the YAML node tree in place so comments and key order survive. After fixing, it re-lints in the ambient mode — online by default, offline under `--offline`, and always offline for stdin (`-`), which writes the fixed document to stdout. The aggregate `stencil lint --fix` gains the same `service.yaml` migration.

Because a project manifest and a template repository manifest share the same module shape, the module fixer is extracted into a new shared `internal/lint/modulefix` package that both linters consume; the manifest fixer's behavior is unchanged (its snapshots are byte-identical).

This is the final change in the `project-manifest` lint series and builds on #505.

## Jira ID

[DT-5396]

## Notes for your reviewers

The `Applied` types in the manifest and project-manifest packages are now aliases of `modulefix.Applied`, so the existing fix-logging helper accepts both without a signature change. A no-op fix returns the original bytes verbatim and skips the write, so an already-clean file keeps its mtime.

[DT-5396]: https://outreach-io.atlassian.net/browse/DT-5396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ