### PR TITLE
fix(stenciltest): stop rendering the module under test twice

### DIFF
--- a/pkg/stenciltest/.snapshots/TestModuleHookNotDuplicated-testdata-module-hook-self-consumer.tpl-testdata-module-hook-self-consumer.snapshot
+++ b/pkg/stenciltest/.snapshots/TestModuleHookNotDuplicated-testdata-module-hook-self-consumer.tpl-testdata-module-hook-self-consumer.snapshot
@@ -1,0 +1,3 @@
+(*codegen.File)(
+one-value
+)

--- a/pkg/stenciltest/stenciltest.go
+++ b/pkg/stenciltest/stenciltest.go
@@ -144,7 +144,6 @@ func (t *Template) Run(save bool) {
 		if err != nil {
 			got.Fatalf("could not get modules: %v ", err)
 		}
-		mods = append(mods, m)
 
 		// Reconcile any declared modules with the found module dependencies.
 		for _, m := range mods {

--- a/pkg/stenciltest/stenciltest_test.go
+++ b/pkg/stenciltest/stenciltest_test.go
@@ -62,6 +62,11 @@ func TestArgs(t *testing.T) {
 	st.Run(false)
 }
 
+func TestModuleHookNotDuplicated(t *testing.T) {
+	st := New(t, "testdata/module-hook-self/consumer.tpl", "testdata/module-hook-self/contributor.tpl")
+	st.Run(true)
+}
+
 // Doing this just to bump up coverage numbers, we essentially test this w/ the Template
 // constructors in each test.
 func TestCoverageHack(t *testing.T) {

--- a/pkg/stenciltest/testdata/module-hook-self/consumer.tpl
+++ b/pkg/stenciltest/testdata/module-hook-self/consumer.tpl
@@ -1,0 +1,3 @@
+{{- range stencil.GetModuleHook "selfHook" }}
+{{ . }}
+{{- end }}

--- a/pkg/stenciltest/testdata/module-hook-self/contributor.tpl
+++ b/pkg/stenciltest/testdata/module-hook-self/contributor.tpl
@@ -1,0 +1,2 @@
+{{- file.Skip "test fixture: contributes to a module hook owned by the module under test" }}
+{{ stencil.AddToModuleHook "testing" "selfHook" (list "one-value") }}


### PR DESCRIPTION
## What this PR does / why we need it

`stenciltest.Template.Run()` adds the module under test to the module list two times. This list feeds the template renderer. So `Run()` renders the module twice. Static template outpu
t stays the same on each render. This hid the bug for a long time. `stencil.AddToModuleHook` calls are not idempotent, though. A hook that gets one value shows two copies of that valu
e instead.

This bug blocks work in a downstream repo. That work needs each `AddToModuleHook` call to add its value one time in tests.

## Notes for your reviewers

The fix removes one redundant line in `Run()`. `getModuleDependencies` already adds the module under test to the list — see the self-inclusion comment in `internal/modules/worklist.go
`'s `newWorkList`. A new regression test (`TestModuleHookNotDuplicated`) proves the bug and the fix, with a committed golden snapshot as the reference output.